### PR TITLE
fix(graphql): Set max execution depth to allow inspection query

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/ServiceCollectionExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/ServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ public static class ServiceCollectionExtensions
             .AddType<SearchDialogValidationError>()
             .AddType<SearchDialogForbidden>()
             .AddType<SetSystemLabelEntityNotFound>()
-            .AddMaxExecutionDepthRule(10)
+            .AddMaxExecutionDepthRule(12)
             .AddInstrumentation()
             .InitializeOnStartup()
             .Services;


### PR DESCRIPTION
Missing some depth to allow the inspection query through 

Issue #1680 