### PR TITLE
fix: Removed .AsSingleQuery from EndUser Search query

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQuery.cs
@@ -158,7 +158,6 @@ internal sealed class SearchDialogQueryHandler : IRequestHandler<SearchDialogQue
 
         var paginatedList = await _db.Dialogs
             .PrefilterAuthorizedDialogs(authorizedResources)
-            .AsSingleQuery()
             .AsNoTracking()
             .Include(x => x.Content)
             .ThenInclude(x => x.Value.Localizations)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Removed .AsSingleQuery from EndUser Search query.

Tested locally with 50 million dialogs. Results show that the removal of .AsSingleQuery() brings Enduser Search query performance up to par with that of ServiceOwner Search. We should seek further improvements as well, as query scaling seems to be an issue.

## Related Issue(s)

- #1706 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
