### PR TITLE
ci: ensure image is published once

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -15,15 +15,6 @@ permissions:
   id-token: write
 
 jobs:
-  release-please:
-    name: Release please
-    runs-on: ubuntu-latest
-    steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_PAT }}
-
   generate-git-short-sha:
     name: Generate git short sha
     uses: ./.github/workflows/workflow-generate-git-short-sha.yml

--- a/.github/workflows/ci-cd-release-please.yml
+++ b/.github/workflows/ci-cd-release-please.yml
@@ -1,0 +1,84 @@
+# This workflow runs on every push to main and:
+# 1. Checks if a new release should be created (via release-please)
+# 2. If a release is created, checks for backend changes since previous release
+# 3. If backend changes exist, builds and publishes Docker images with the new version
+# 4. Triggers staging and yt01 deployment via repository dispatch
+
+name: CI/CD Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+  
+jobs:
+  release-please:
+    name: Release please
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      version: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
+      previous_release_sha: ${{ steps.get-previous-release.outputs.sha }}
+    steps:
+      - name: Get previous release SHA
+        id: get-previous-release
+        run: |
+          sha=$(gh api repos/${{ github.repository }}/releases/latest --jq '.target_commitish')
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
+
+  check-for-changes:
+    name: Check for changes
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/workflow-check-for-changes.yml
+    with:
+      apps_base_sha: ${{ needs.release-please.outputs.previous_release_sha }}
+
+  publish:
+    name: Build and publish docker images
+    needs: [release-please, check-for-changes]
+    if: needs.release-please.outputs.release_created == 'true' && needs.check-for-changes.outputs.hasBackendChanges == 'true'
+    uses: ./.github/workflows/workflow-publish.yml
+    secrets:
+      GCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      dockerImageBaseName: ghcr.io/altinn/dialogporten-
+      version: ${{ needs.release-please.outputs.version }}
+
+  notify-release-created:
+    name: Notify release created
+    needs: [release-please, publish]
+    if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify release created
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
+          event-type: release_created
+
+  send-slack-message-on-failure:
+    name: Send Slack message on failure
+    needs: [release-please, publish, notify-release-created]
+    if: ${{ always() && failure() && !cancelled() }}
+    uses: ./.github/workflows/workflow-send-ci-cd-status-slack-message.yml
+    with:
+      environment: release-please
+      publish_status: ${{ needs.publish.result }}
+      release_please_status: ${{ needs.release-please.result }}
+      notify_release_created_status: ${{ needs.notify-release-created.result }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_CI_CD_STATUS }}
+        

--- a/.github/workflows/ci-cd-release-please.yml
+++ b/.github/workflows/ci-cd-release-please.yml
@@ -1,8 +1,9 @@
 # This workflow runs on every push to main and:
 # 1. Checks if a new release should be created (via release-please)
-# 2. If a release is created, checks for backend changes since previous release
-# 3. If backend changes exist, builds and publishes Docker images with the new version
-# 4. Triggers staging and yt01 deployment via repository dispatch
+# 2. If a release is created:
+# 2.1. Checks for backend changes since previous release
+# 2.2. If backend changes exist, builds and publishes Docker images with the new version
+# 2.3. Triggers staging and yt01 deployment via repository dispatch
 
 name: CI/CD Release Please
 

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -131,7 +131,6 @@ jobs:
       apps_status: ${{ needs.deploy-apps.result }}
       e2e_tests_status: ${{ needs.run-e2e-tests.result }}
       schema_npm_status: ${{ needs.publish-schema-npm.result }}
-      publish_status: ${{ needs.publish.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_CI_CD_STATUS }}

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -2,9 +2,8 @@
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "v*.*.*"
+  repository_dispatch:
+    types: [release_created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -60,21 +59,10 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
 
-  publish:
-    name: Build and publish docker images
-    uses: ./.github/workflows/workflow-publish.yml
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
-    needs: [get-current-version, check-for-changes]
-    secrets:
-      GCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    with:
-      dockerImageBaseName: ghcr.io/altinn/dialogporten-
-      version: ${{ needs.get-current-version.outputs.version }}
-
   deploy-apps:
     name: Deploy apps to staging
     needs:
-      [get-current-version, check-for-changes, deploy-infra, publish]
+      [get-current-version, check-for-changes, deploy-infra]
     if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
     uses: ./.github/workflows/workflow-deploy-apps.yml
     secrets:
@@ -134,7 +122,7 @@ jobs:
 
   send-slack-message-on-failure:
     name: Send Slack message on failure
-    needs: [deploy-infra, deploy-apps, run-e2e-tests, publish-schema-npm, publish]
+    needs: [deploy-infra, deploy-apps, run-e2e-tests, publish-schema-npm]
     if: ${{ always() && failure() && !cancelled() }}
     uses: ./.github/workflows/workflow-send-ci-cd-status-slack-message.yml
     with:

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -2,9 +2,8 @@
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "v*.*.*"
+  repository_dispatch:
+    types: [release_created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -29,17 +28,6 @@ jobs:
   get-current-version:
     name: Get current version
     uses: ./.github/workflows/workflow-get-current-version.yml
-
-  publish:
-    name: Build and publish docker images
-    uses: ./.github/workflows/workflow-publish.yml
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
-    needs: [get-current-version, check-for-changes]
-    secrets:
-      GCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    with:
-      dockerImageBaseName: ghcr.io/altinn/dialogporten-
-      version: ${{ needs.get-current-version.outputs.version }}
 
   deploy-infra:
     name: Deploy infra to yt01
@@ -74,7 +62,7 @@ jobs:
   deploy-apps:
     name: Deploy apps to yt01
     needs:
-      [get-current-version, check-for-changes, deploy-infra, publish]
+      [get-current-version, check-for-changes, deploy-infra]
     # we want deployment of apps to be dependent on deployment of infrastructure, but if infrastructure is skipped, we still want to deploy the apps
     if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
     uses: ./.github/workflows/workflow-deploy-apps.yml
@@ -154,7 +142,7 @@ jobs:
 
   send-slack-message-on-failure:
     name: Send Slack message on failure
-    needs: [deploy-infra, deploy-apps, run-e2e-tests, publish, run-performance-tests]
+    needs: [deploy-infra, deploy-apps, run-e2e-tests, run-performance-tests]
     if: ${{ always() && failure() && !cancelled() }}
     uses: ./.github/workflows/workflow-send-ci-cd-status-slack-message.yml
     with:
@@ -163,7 +151,6 @@ jobs:
       apps_status: ${{ needs.deploy-apps.result }}
       e2e_tests_status: ${{ needs.run-e2e-tests.result }}
       performance_tests_status: ${{ needs.run-performance-tests.result }}
-      publish_status: ${{ needs.publish.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_CI_CD_STATUS }}

--- a/.github/workflows/workflow-send-ci-cd-status-slack-message.yml
+++ b/.github/workflows/workflow-send-ci-cd-status-slack-message.yml
@@ -34,6 +34,14 @@ on:
         type: string
         description: "Status of the build and test job"
         default: "skipped"
+      release_please_status:
+        type: string
+        description: "Status of the release-please job"
+        default: "skipped"
+      notify_release_created_status:
+        type: string
+        description: "Status of the notify-release-created job"
+        default: "skipped"
     secrets:
       SLACK_BOT_TOKEN:
         required: true
@@ -69,6 +77,8 @@ jobs:
             echo "PUBLISH_EMOJI=$(determine_emoji "${{ inputs.publish_status }}")"
             echo "BUILD_AND_TEST_EMOJI=$(determine_emoji "${{ inputs.build_and_test_status }}")"
             echo "PERFORMANCE_TESTS_EMOJI=$(determine_emoji "${{ inputs.performance_tests_status }}")"
+            echo "RELEASE_PLEASE_EMOJI=$(determine_emoji "${{ inputs.release_please_status }}")"
+            echo "NOTIFY_RELEASE_CREATED_EMOJI=$(determine_emoji "${{ inputs.notify_release_created_status }}")"
           } >> "$GITHUB_OUTPUT"
 
       - name: Send GitHub slack message
@@ -85,6 +95,8 @@ jobs:
           PUBLISH_STATUS: "${{ steps.status-emojis.outputs.PUBLISH_EMOJI }}"
           BUILD_AND_TEST_STATUS: "${{ steps.status-emojis.outputs.BUILD_AND_TEST_EMOJI }}"
           PERFORMANCE_TESTS_STATUS: "${{ steps.status-emojis.outputs.PERFORMANCE_TESTS_EMOJI }}"
+          RELEASE_PLEASE_STATUS: "${{ steps.status-emojis.outputs.RELEASE_PLEASE_EMOJI }}"
+          NOTIFY_RELEASE_CREATED_STATUS: "${{ steps.status-emojis.outputs.NOTIFY_RELEASE_CREATED_EMOJI }}"
         uses: slackapi/slack-github-action@v2.0.0
         with:
           errors: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This change streamlines our Docker image management by building and publishing images only once when a release is created, rather than rebuilding for each environment. These published images are then reused across staging, yt01 and production deployments.

## Technical Changes
1. Get the previous release SHA before creating a new release
2. Only trigger Docker image builds when there are backend changes since the previous release
3. Trigger staging/yt01 deployment via repository dispatch after successful release

Next up:
- Trigger a dry-run of deployment to production
- Notify dry-run of production is complete in Slack
- Add deploy-to-production workflow without dry-run and environment gating

## Related Issue(s)

- #1692

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
