### PR TITLE
ci: ensure that workflow run name of staging and yt01 contains the version number

### DIFF
--- a/.github/workflows/ci-cd-release-please.yml
+++ b/.github/workflows/ci-cd-release-please.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_PLEASE_PAT }}
           event-type: release_created
+          client-payload: '{"version": "${{ needs.release-please.outputs.version }}"}'
 
   send-slack-message-on-failure:
     name: Send Slack message on failure

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -1,5 +1,7 @@
 ﻿name: CI/CD Staging
 
+run-name: CI/CD Staging ${{ github.event.client_payload.version && format('({0})', github.event.client_payload.version) || '' }}
+
 on:
   workflow_dispatch:
   repository_dispatch:

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -1,5 +1,7 @@
 ﻿name: CI/CD YT01
 
+run-name: CI/CD YT01 ${{ github.event.client_payload.version && format('({0})', github.event.client_payload.version) || '' }}
+
 on:
   workflow_dispatch:
   repository_dispatch:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

include the version number in the workflow run name for yt01 and staging. It looks weird that every workflow run should be named the event-name aka "release_created"

![CleanShot 2025-01-29 at 11 09 46](https://github.com/user-attachments/assets/391cb9ed-466b-4607-b3af-f1ca481b1e36)


## Related Issue(s)

- #1692

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
