### PR TITLE
chore: Remove old OccuredAt property on DomainEvent

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Domain/Common/DomainEvents/DomainEvent.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Common/DomainEvents/DomainEvent.cs
@@ -9,14 +9,7 @@ public abstract record DomainEvent : IDomainEvent
     public Guid EventId { get; private set; } = Guid.NewGuid();
 
     [JsonInclude]
-    public DateTimeOffset OccuredAt { get; set; }
-
-    [JsonInclude]
-    public DateTimeOffset OccurredAt
-    {
-        get => OccuredAt;
-        set => OccuredAt = value;
-    }
+    public DateTimeOffset OccurredAt { get; set; }
 
     [JsonInclude]
     public Dictionary<string, string> Metadata { get; set; } = [];

--- a/src/Digdir.Domain.Dialogporten.Domain/Common/EventPublisher/IDomainEvent.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Common/EventPublisher/IDomainEvent.cs
@@ -15,20 +15,7 @@ public interface IDomainEvent : INotification
     /// <summary>
     /// The time at which the event, as well as all the actual changes, occurred.
     /// </summary>
-    [Obsolete($"Use {nameof(OccurredAt)} instead")]
-    DateTimeOffset OccuredAt { get; set; }
-
-    /// <summary>
-    /// The time at which the event, as well as all the actual changes, occurred.
-    /// </summary>
-    DateTimeOffset OccurredAt
-    {
-        // Will be removed once all events in the database/on the bus have been consumed
-#pragma warning disable CS0618 // Type or member is obsolete
-        get => OccuredAt;
-        set => OccuredAt = value;
-#pragma warning restore CS0618 // Type or member is obsolete
-    }
+    DateTimeOffset OccurredAt { get; set; }
 
     /// <summary>
     /// Dictionary of metadata.


### PR DESCRIPTION
Previous release pushed to all environments, all outbox messages tables checked 