### PR TITLE
ci: separate between dry-run and real production deploy

### DIFF
--- a/.github/workflows/ci-cd-prod-dry-run.yml
+++ b/.github/workflows/ci-cd-prod-dry-run.yml
@@ -1,8 +1,12 @@
 ﻿name: CI/CD Production
 
+run-name: CI/CD Production Dry Run ${{ github.event.client_payload.version && format('({0})', github.event.client_payload.version) || '' }}
+
 on:
   workflow_dispatch:
-  
+  repository_dispatch:
+    types: [release_created]
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
 
@@ -27,8 +31,8 @@ jobs:
     name: Get current version
     uses: ./.github/workflows/workflow-get-current-version.yml
 
-  deploy-infra:
-    name: Deploy infra to prod
+  dry-run-deploy-infra:
+    name: Dry run deploy infra to prod
     if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasInfraChanges == 'true' }}
     needs: [get-current-version, check-for-changes]
     uses: ./.github/workflows/workflow-deploy-infra.yml
@@ -44,24 +48,14 @@ jobs:
       environment: prod
       region: norwayeast
       version: ${{ needs.get-current-version.outputs.version }}
+      dryRun: true
 
-  store-infra-version:
-    name: Store Latest Deployed Infra Version as GitHub Variable
-    needs: [deploy-infra, get-current-version]
-    if: ${{ needs.deploy-infra.result == 'success' }}
-    uses: ./.github/workflows/workflow-store-github-env-variable.yml
-    with:
-      variable_name: LATEST_DEPLOYED_INFRA_VERSION
-      variable_value: ${{ needs.get-current-version.outputs.version }}
-      environment: prod
-    secrets:
-      GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
-
-  deploy-apps:
-    name: Deploy apps to prod
+  dry-run-deploy-apps:
+    name: Dry run deploy apps to prod
     needs:
-      [get-current-version, check-for-changes]
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
+      [get-current-version, check-for-changes, dry-run-deploy-infra]
+    # we want deployment of apps to be dependent on deployment of infrastructure, but if infrastructure is skipped, we still want to dry-run deploy the apps
+    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
     uses: ./.github/workflows/workflow-deploy-apps.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -78,29 +72,18 @@ jobs:
       environment: prod
       region: norwayeast
       version: ${{ needs.get-current-version.outputs.version }}
+      dryRun: true
       runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
-
-  store-apps-version:
-    name: Store Latest Deployed Apps Version as GitHub Variable
-    needs: [deploy-apps, get-current-version]
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.deploy-apps.outputs.deployment_executed == 'true') }}
-    uses: ./.github/workflows/workflow-store-github-env-variable.yml
-    with:
-      variable_name: LATEST_DEPLOYED_APPS_VERSION
-      variable_value: ${{ needs.get-current-version.outputs.version }}
-      environment: prod
-    secrets:
-      GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
 
   send-slack-message-on-failure:
     name: Send Slack message on failure
-    needs: [deploy-infra, deploy-apps]
+    needs: [dry-run-deploy-infra, dry-run-deploy-apps]
     if: ${{ always() && failure() && !cancelled() }}
     uses: ./.github/workflows/workflow-send-ci-cd-status-slack-message.yml
     with:
       environment: prod
-      infra_status: ${{ needs.deploy-infra.result }}
-      apps_status: ${{ needs.deploy-apps.result }}
+      infra_status: ${{ needs.dry-run-deploy-infra.result }}
+      apps_status: ${{ needs.dry-run-deploy-apps.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_CI_CD_STATUS }}

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -44,6 +44,7 @@ jobs:
       environment: prod
       region: norwayeast
       version: ${{ needs.get-current-version.outputs.version }}
+      ref: ${{ needs.get-current-version.outputs.version_sha }}
 
   store-infra-version:
     name: Store Latest Deployed Infra Version as GitHub Variable
@@ -79,7 +80,7 @@ jobs:
       region: norwayeast
       version: ${{ needs.get-current-version.outputs.version }}
       runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
-
+      ref: ${{ needs.get-current-version.outputs.version_sha }}
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable
     needs: [deploy-apps, get-current-version]

--- a/.github/workflows/workflow-deploy-apps.yml
+++ b/.github/workflows/workflow-deploy-apps.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: boolean
         default: false
+      ref:
+        description: "The branch or tag ref to deploy. Using default checkout ref if not provided."
+        required: false
+        default: ${{ github.ref }}
+        type: string
 concurrency:
   # Existing runs are cancelled if someone repeatedly commits to their own Pull Request (PR). However, it does not stop others' dry runs or actual deployments from the main branch.
   # Also, the cancellation does not occur on merges to the main branch. Therefore, if multiple merges to main are performed simultaneously, they will just be queued up.
@@ -64,6 +69,8 @@ jobs:
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Azure Login
         uses: ./.github/actions/azure-login
@@ -157,6 +164,8 @@ jobs:
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Azure Login
         uses: ./.github/actions/azure-login
@@ -247,6 +256,8 @@ jobs:
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Azure Login
         uses: ./.github/actions/azure-login

--- a/.github/workflows/workflow-get-current-version.yml
+++ b/.github/workflows/workflow-get-current-version.yml
@@ -7,15 +7,27 @@ on:
       version:
         description: "Version"
         value: ${{ jobs.get-current-version.outputs.version }}
+      version_sha:
+        description: "SHA of the version tag"
+        value: ${{ jobs.get-current-version.outputs.version_sha }}
 jobs:
   get-current-version:
     name: Filter
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.set-current-version.outputs.version }}
+      version_sha: ${{ steps.get-version-sha.outputs.sha }}
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set current version
         id: set-current-version
         run: echo "version=$(cat version.txt)" >> $GITHUB_OUTPUT
+      - name: Get version SHA
+        id: get-version-sha
+        run: |
+          VERSION=$(cat version.txt)
+          SHA=$(git rev-list -n 1 v${VERSION})
+          echo "sha=$SHA" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A step towards easier deployment to production. 
- Separated dry-run and actual deployment into two workflows. 
- The dry-run will run at the same time deployment to staging/yt01 takes place
- Actual deploy has to be run manually for now. 
- Environment gating will be removed from production to allow for more seamless production deploy

Other improvements later: 
- Notify on Slack when a dry-run has completed for production deployment with a button to trigger the workflow for deployment

## Related Issue(s)

- #1692

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
