### PR TITLE
fix(deps): ensure traces are sent to application insights

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/Digdir.Domain.Dialogporten.GraphQL.csproj
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Digdir.Domain.Dialogporten.GraphQL.csproj
@@ -15,10 +15,10 @@
         <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0"/>
         <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
-        <PackageReference Include="OpenTelemetry" Version="1.11.0" />
+        <PackageReference Include="OpenTelemetry" Version="1.10.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
         <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.2" />
         <PackageReference Include="ZiggyCreatures.FusionCache.OpenTelemetry" Version="2.0.0" />

--- a/src/Digdir.Domain.Dialogporten.Janitor/Digdir.Domain.Dialogporten.Janitor.csproj
+++ b/src/Digdir.Domain.Dialogporten.Janitor/Digdir.Domain.Dialogporten.Janitor.csproj
@@ -20,10 +20,10 @@
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
         <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
-        <PackageReference Include="OpenTelemetry" Version="1.11.0" />
+        <PackageReference Include="OpenTelemetry" Version="1.10.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
         <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.2" />
         <PackageReference Include="ZiggyCreatures.FusionCache.OpenTelemetry" Version="2.0.0" />

--- a/src/Digdir.Domain.Dialogporten.Service/Digdir.Domain.Dialogporten.Service.csproj
+++ b/src/Digdir.Domain.Dialogporten.Service/Digdir.Domain.Dialogporten.Service.csproj
@@ -6,10 +6,10 @@
         <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0"/>
         <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
-        <PackageReference Include="OpenTelemetry" Version="1.11.0" />
+        <PackageReference Include="OpenTelemetry" Version="1.10.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
         <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.2" />
     </ItemGroup>

--- a/src/Digdir.Domain.Dialogporten.WebApi/Digdir.Domain.Dialogporten.WebApi.csproj
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Digdir.Domain.Dialogporten.WebApi.csproj
@@ -17,10 +17,10 @@
         <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
-        <PackageReference Include="OpenTelemetry" Version="1.11.0" />
+        <PackageReference Include="OpenTelemetry" Version="1.10.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
         <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.2" />
         <PackageReference Include="ZiggyCreatures.FusionCache.OpenTelemetry" Version="2.0.0" />


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

After some debugging, we found out that the only thing different that is related to opentelemetry are updates of these dependencies. 

1.47.1 seemed to work, but not 1.47.2. https://github.com/Altinn/dialogporten/compare/88a9217846afaa1580f9430c52e2f880bd4906c1...d9281fc697b6ad613c5546b1cd81a115e349bde4

(this is a bit fragile, so we need to consider other options, or adding alerts that notify us if we don't get any traces anymore)

Reverted commit: 75c7a24f3897eb6a64dc63463d3db492f44ebd79.

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
