### PR TITLE
ci: ensure deployments to yt01/staging/prod uses the tag as a base rather than main

### DIFF
--- a/.github/workflows/ci-cd-prod-dry-run.yml
+++ b/.github/workflows/ci-cd-prod-dry-run.yml
@@ -44,6 +44,7 @@ jobs:
       region: norwayeast
       version: ${{ github.event.client_payload.version }}
       dryRun: true
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
 
   dry-run-deploy-apps:
     name: Dry run deploy apps to prod
@@ -67,7 +68,8 @@ jobs:
       version: ${{ github.event.client_payload.version }}
       dryRun: true
       runMigration: ${{ needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
-
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
+      
   send-slack-message-on-failure:
     name: Send Slack message on failure
     needs: [dry-run-deploy-infra, dry-run-deploy-apps]

--- a/.github/workflows/ci-cd-prod-dry-run.yml
+++ b/.github/workflows/ci-cd-prod-dry-run.yml
@@ -1,9 +1,8 @@
-﻿name: CI/CD Production
-
+﻿name: CI/CD Production Dry Run
+description: Runs a dry-run deployment of production whenever a new release is created
 run-name: CI/CD Production Dry Run ${{ github.event.client_payload.version && format('({0})', github.event.client_payload.version) || '' }}
 
 on:
-  workflow_dispatch:
   repository_dispatch:
     types: [release_created]
 
@@ -27,14 +26,10 @@ jobs:
       infra_base_sha: ${{ needs.get-versions-from-github.outputs.infra_version_sha }}
       apps_base_sha: ${{ needs.get-versions-from-github.outputs.apps_version_sha }}
 
-  get-current-version:
-    name: Get current version
-    uses: ./.github/workflows/workflow-get-current-version.yml
-
   dry-run-deploy-infra:
     name: Dry run deploy infra to prod
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasInfraChanges == 'true' }}
-    needs: [get-current-version, check-for-changes]
+    if: ${{ needs.check-for-changes.outputs.hasInfraChanges == 'true' }}
+    needs: [check-for-changes]
     uses: ./.github/workflows/workflow-deploy-infra.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -47,15 +42,13 @@ jobs:
     with:
       environment: prod
       region: norwayeast
-      version: ${{ needs.get-current-version.outputs.version }}
+      version: ${{ github.event.client_payload.version }}
       dryRun: true
 
   dry-run-deploy-apps:
     name: Dry run deploy apps to prod
-    needs:
-      [get-current-version, check-for-changes, dry-run-deploy-infra]
-    # we want deployment of apps to be dependent on deployment of infrastructure, but if infrastructure is skipped, we still want to dry-run deploy the apps
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
+    needs: [check-for-changes, dry-run-deploy-infra]
+    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
     uses: ./.github/workflows/workflow-deploy-apps.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -71,9 +64,9 @@ jobs:
     with:
       environment: prod
       region: norwayeast
-      version: ${{ needs.get-current-version.outputs.version }}
+      version: ${{ github.event.client_payload.version }}
       dryRun: true
-      runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
+      runMigration: ${{ needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
 
   send-slack-message-on-failure:
     name: Send Slack message on failure

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -1,14 +1,34 @@
 ﻿name: CI/CD Production
+description: Deploys the specified version to production
+run-name: CI/CD Production ${{ inputs.version && format('({0})', inputs.version) || '' }}
 
 on:
   workflow_dispatch:
-  
+    inputs:
+      version:
+        required: true
+        type: string
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}
 
 jobs:
+  check-if-version-exists:
+    name: Check if version exists
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if tag exists
+        run: |
+          if ! gh api repos/${{ github.repository }}/git/refs/tags/${{ inputs.version }} &>/dev/null; then
+            echo "::error::Version ${{ inputs.version }} does not exist as a tag"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   get-versions-from-github:
     name: Get Latest Deployed Version Info from GitHub
+    needs: [check-if-version-exists]
     uses: ./.github/workflows/workflow-get-latest-deployed-version-info-from-github.yml
     with:
       environment: prod
@@ -23,14 +43,10 @@ jobs:
       infra_base_sha: ${{ needs.get-versions-from-github.outputs.infra_version_sha }}
       apps_base_sha: ${{ needs.get-versions-from-github.outputs.apps_version_sha }}
 
-  get-current-version:
-    name: Get current version
-    uses: ./.github/workflows/workflow-get-current-version.yml
-
   deploy-infra:
     name: Deploy infra to prod
     if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasInfraChanges == 'true' }}
-    needs: [get-current-version, check-for-changes]
+    needs: [check-for-changes]
     uses: ./.github/workflows/workflow-deploy-infra.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -43,16 +59,16 @@ jobs:
     with:
       environment: prod
       region: norwayeast
-      version: ${{ needs.get-current-version.outputs.version }}
+      version: ${{ inputs.version }}
 
   store-infra-version:
     name: Store Latest Deployed Infra Version as GitHub Variable
-    needs: [deploy-infra, get-current-version]
+    needs: [deploy-infra]
     if: ${{ needs.deploy-infra.result == 'success' }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_INFRA_VERSION
-      variable_value: ${{ needs.get-current-version.outputs.version }}
+      variable_value: ${{ inputs.version }}
       environment: prod
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
@@ -60,7 +76,7 @@ jobs:
   deploy-apps:
     name: Deploy apps to prod
     needs:
-      [get-current-version, check-for-changes]
+      [check-for-changes]
     if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
     uses: ./.github/workflows/workflow-deploy-apps.yml
     secrets:
@@ -77,17 +93,17 @@ jobs:
     with:
       environment: prod
       region: norwayeast
-      version: ${{ needs.get-current-version.outputs.version }}
+      version: ${{ inputs.version }}
       runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
 
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable
-    needs: [deploy-apps, get-current-version]
+    needs: [deploy-apps]
     if: ${{ always() && !failure() && (github.event_name == 'workflow_dispatch' || needs.deploy-apps.outputs.deployment_executed == 'true') }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_APPS_VERSION
-      variable_value: ${{ needs.get-current-version.outputs.version }}
+      variable_value: ${{ inputs.version }}
       environment: prod
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -60,6 +60,7 @@ jobs:
       environment: prod
       region: norwayeast
       version: ${{ inputs.version }}
+      ref: "refs/tags/v${{ inputs.version }}"
 
   store-infra-version:
     name: Store Latest Deployed Infra Version as GitHub Variable
@@ -95,6 +96,7 @@ jobs:
       region: norwayeast
       version: ${{ inputs.version }}
       runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
+      ref: "refs/tags/v${{ inputs.version }}"
 
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable

--- a/.github/workflows/ci-cd-pull-request-release-please.yml
+++ b/.github/workflows/ci-cd-pull-request-release-please.yml
@@ -1,5 +1,5 @@
 ﻿name: CI/CD Pull Request Release Please
-
+description: Run dry-runs of staging deployment on release PRs
 on:
   pull_request:
     branches: [main]
@@ -15,10 +15,12 @@ jobs:
 
   get-current-version:
     name: Get current version
+    needs: [verify-release-please-branch]
     uses: ./.github/workflows/workflow-get-current-version.yml
 
   check-for-changes:
     name: Check for changes
+    needs: [verify-release-please-branch]
     uses: ./.github/workflows/workflow-check-for-changes.yml
 
   generate-git-short-sha:

--- a/.github/workflows/ci-cd-pull-request-title.yml
+++ b/.github/workflows/ci-cd-pull-request-title.yml
@@ -1,4 +1,5 @@
 name: "PR Title Checker"
+description: Checks the title of a PR to ensure it follows the correct format
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]

--- a/.github/workflows/ci-cd-release-please.yml
+++ b/.github/workflows/ci-cd-release-please.yml
@@ -6,7 +6,7 @@
 # 2.3. Triggers staging and yt01 deployment via repository dispatch
 
 name: CI/CD Release Please
-
+description: When new releases are created, this workflow builds and publishes docker images and notify other environments about it through dispatch
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -43,6 +43,7 @@ jobs:
       environment: staging
       region: norwayeast
       version: ${{ github.event.client_payload.version }}
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
 
   store-infra-version:
     name: Store Latest Deployed Infra Version as GitHub Variable
@@ -76,6 +77,7 @@ jobs:
       region: norwayeast
       version: ${{ github.event.client_payload.version }}
       runMigration: ${{ needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
 
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable
@@ -96,6 +98,7 @@ jobs:
     uses: ./.github/workflows/workflow-publish-schema.yml
     with:
       version: ${{ github.event.client_payload.version }}
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -112,6 +115,7 @@ jobs:
       environment: staging
       apiVersion: v1
       testSuitePath: tests/k6/suites/all-single-pass.js
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
     permissions:
       checks: write
       pull-requests: write

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -1,9 +1,8 @@
 ﻿name: CI/CD Staging
-
+description: Deploys the created release to staging
 run-name: CI/CD Staging ${{ github.event.client_payload.version && format('({0})', github.event.client_payload.version) || '' }}
 
 on:
-  workflow_dispatch:
   repository_dispatch:
     types: [release_created]
 
@@ -27,14 +26,10 @@ jobs:
       infra_base_sha: ${{ needs.get-versions-from-github.outputs.infra_version_sha }}
       apps_base_sha: ${{ needs.get-versions-from-github.outputs.apps_version_sha }}
 
-  get-current-version:
-    name: Get current version
-    uses: ./.github/workflows/workflow-get-current-version.yml
-
   deploy-infra:
     name: Deploy infra to staging
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasInfraChanges == 'true' }}
-    needs: [get-current-version, check-for-changes]
+    if: ${{ needs.check-for-changes.outputs.hasInfraChanges == 'true' }}
+    needs: [check-for-changes]
     uses: ./.github/workflows/workflow-deploy-infra.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -47,25 +42,24 @@ jobs:
     with:
       environment: staging
       region: norwayeast
-      version: ${{ needs.get-current-version.outputs.version }}
+      version: ${{ github.event.client_payload.version }}
 
   store-infra-version:
     name: Store Latest Deployed Infra Version as GitHub Variable
-    needs: [deploy-infra, get-current-version]
+    needs: [deploy-infra]
     if: ${{ needs.deploy-infra.result == 'success' }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_INFRA_VERSION
-      variable_value: ${{ needs.get-current-version.outputs.version }}
+      variable_value: ${{ github.event.client_payload.version }}
       environment: staging
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
 
   deploy-apps:
     name: Deploy apps to staging
-    needs:
-      [get-current-version, check-for-changes, deploy-infra]
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
+    needs: [check-for-changes, deploy-infra]
+    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
     uses: ./.github/workflows/workflow-deploy-apps.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -80,35 +74,35 @@ jobs:
     with:
       environment: staging
       region: norwayeast
-      version: ${{ needs.get-current-version.outputs.version }}
-      runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
+      version: ${{ github.event.client_payload.version }}
+      runMigration: ${{ needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
 
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable
-    needs: [deploy-apps, get-current-version]
-    if: ${{ always() && !failure() && (github.event_name == 'workflow_dispatch' || needs.deploy-apps.outputs.deployment_executed == 'true') }}
+    needs: [deploy-apps]
+    if: ${{ always() && !failure() && needs.deploy-apps.outputs.deployment_executed == 'true' }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_APPS_VERSION
-      variable_value: ${{ needs.get-current-version.outputs.version }}
+      variable_value: ${{ github.event.client_payload.version }}
       environment: staging
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
 
   publish-schema-npm:
     name: Publish schema npm package
-    needs: [check-for-changes, get-current-version, deploy-apps]
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasSchemaChanges == 'true') }}
+    needs: [check-for-changes, deploy-apps]
+    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasSchemaChanges == 'true' }}
     uses: ./.github/workflows/workflow-publish-schema.yml
     with:
-      version: ${{ needs.get-current-version.outputs.version }}
+      version: ${{ github.event.client_payload.version }}
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   run-e2e-tests:
     name: "Run K6 functional end-to-end tests"
     # we want the end-to-end tests to be dependent on deployment of infrastructure and apps, but if infrastructure is skipped, we still want to run the tests
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
+    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
     needs: [deploy-apps, check-for-changes]
     uses: ./.github/workflows/workflow-run-k6-tests.yml
     secrets:

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -1,9 +1,8 @@
 ﻿name: CI/CD YT01
-
+description: Deploys the created release to yt01
 run-name: CI/CD YT01 ${{ github.event.client_payload.version && format('({0})', github.event.client_payload.version) || '' }}
 
 on:
-  workflow_dispatch:
   repository_dispatch:
     types: [release_created]
 
@@ -27,14 +26,10 @@ jobs:
       infra_base_sha: ${{ needs.get-versions-from-github.outputs.infra_version_sha }}
       apps_base_sha: ${{ needs.get-versions-from-github.outputs.apps_version_sha }}
 
-  get-current-version:
-    name: Get current version
-    uses: ./.github/workflows/workflow-get-current-version.yml
-
   deploy-infra:
     name: Deploy infra to yt01
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasInfraChanges == 'true' }}
-    needs: [get-current-version, check-for-changes]
+    if: ${{ needs.check-for-changes.outputs.hasInfraChanges == 'true' }}
+    needs: [check-for-changes]
     uses: ./.github/workflows/workflow-deploy-infra.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -47,26 +42,24 @@ jobs:
     with:
       environment: yt01
       region: norwayeast
-      version: ${{ needs.get-current-version.outputs.version }}
+      version: ${{ github.event.client_payload.version }}
 
   store-infra-version:
     name: Store Latest Deployed Infra Version as GitHub Variable
-    needs: [deploy-infra, get-current-version]
+    needs: [deploy-infra]
     if: ${{ needs.deploy-infra.result == 'success' }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_INFRA_VERSION
-      variable_value: ${{ needs.get-current-version.outputs.version }}
+      variable_value: ${{ github.event.client_payload.version }}
       environment: yt01
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
 
   deploy-apps:
     name: Deploy apps to yt01
-    needs:
-      [get-current-version, check-for-changes, deploy-infra]
-    # we want deployment of apps to be dependent on deployment of infrastructure, but if infrastructure is skipped, we still want to deploy the apps
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
+    needs: [check-for-changes, deploy-infra]
+    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
     uses: ./.github/workflows/workflow-deploy-apps.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -82,17 +75,17 @@ jobs:
     with:
       environment: yt01
       region: norwayeast
-      version: ${{ needs.get-current-version.outputs.version }}
-      runMigration: ${{ github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
+      version: ${{ github.event.client_payload.version }}
+      runMigration: ${{ needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
 
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable
-    needs: [deploy-apps, get-current-version]
-    if: ${{ always() && !failure() && (github.event_name == 'workflow_dispatch' || needs.deploy-apps.outputs.deployment_executed == 'true') }}
+    needs: [deploy-apps]
+    if: ${{ always() && !failure() && needs.deploy-apps.outputs.deployment_executed == 'true' }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_APPS_VERSION
-      variable_value: ${{ needs.get-current-version.outputs.version }}
+      variable_value: ${{ github.event.client_payload.version }}
       environment: yt01
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
@@ -100,7 +93,7 @@ jobs:
   run-e2e-tests:
     name: "Run K6 functional end-to-end tests"
     # we want the end-to-end tests to be dependent on deployment of infrastructure and apps, but if infrastructure is skipped, we still want to run the tests
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true') }}
+    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
     needs: [deploy-apps, check-for-changes]
     uses: ./.github/workflows/workflow-run-k6-tests.yml
     secrets:
@@ -117,7 +110,7 @@ jobs:
   run-performance-tests:
     name: "Run K6 performance tests"
     # we want the performance tests to be dependent on deployment of infrastructure and apps, but if infrastructure is skipped, we still want to run the tests
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasInfraChanges == 'true') }}
+    if: ${{ always() && !failure() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasInfraChanges == 'true') }}
     needs: [deploy-apps, deploy-infra, check-for-changes]
     #needs: [deploy-apps, check-for-changes]
     uses: ./.github/workflows/workflow-run-k6-ci-cd-yt01.yml

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -43,6 +43,7 @@ jobs:
       environment: yt01
       region: norwayeast
       version: ${{ github.event.client_payload.version }}
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
 
   store-infra-version:
     name: Store Latest Deployed Infra Version as GitHub Variable
@@ -77,7 +78,7 @@ jobs:
       region: norwayeast
       version: ${{ github.event.client_payload.version }}
       runMigration: ${{ needs.check-for-changes.outputs.hasMigrationChanges == 'true' }}
-
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable
     needs: [deploy-apps]
@@ -103,6 +104,7 @@ jobs:
       environment: yt01
       apiVersion: v1
       testSuitePath: tests/k6/suites/all-single-pass.js
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
     permissions:
       checks: write
       pull-requests: write
@@ -131,6 +133,7 @@ jobs:
       vus: 1
       duration: 30s
       testSuitePath: ${{ matrix.files }}
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
     permissions:
       checks: write
       pull-requests: write

--- a/.github/workflows/dispatch-apps.yml
+++ b/.github/workflows/dispatch-apps.yml
@@ -60,3 +60,4 @@ jobs:
       region: norwayeast
       version: ${{ inputs.version }}
       runMigration: ${{ inputs.runMigration }}
+      ref: "refs/tags/v${{ inputs.version }}"

--- a/.github/workflows/workflow-deploy-apps.yml
+++ b/.github/workflows/workflow-deploy-apps.yml
@@ -46,6 +46,12 @@ on:
         required: false
         type: boolean
         default: false
+      ref:
+        description: "The branch or tag ref to deploy. Using default checkout ref if not provided."
+        required: false
+        default: ${{ github.ref }}
+        type: string
+  
 concurrency:
   # Existing runs are cancelled if someone repeatedly commits to their own Pull Request (PR). However, it does not stop others' dry runs or actual deployments from the main branch.
   # Also, the cancellation does not occur on merges to the main branch. Therefore, if multiple merges to main are performed simultaneously, they will just be queued up.
@@ -64,6 +70,8 @@ jobs:
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Azure Login
         uses: ./.github/actions/azure-login
@@ -157,6 +165,8 @@ jobs:
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Azure Login
         uses: ./.github/actions/azure-login
@@ -247,6 +257,8 @@ jobs:
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Azure Login
         uses: ./.github/actions/azure-login

--- a/.github/workflows/workflow-publish-schema.yml
+++ b/.github/workflows/workflow-publish-schema.yml
@@ -6,6 +6,11 @@ on:
       version:
         required: true
         type: string
+      ref:
+        description: "The branch or tag ref to publish. Using default checkout ref if not provided."
+        required: false
+        default: ${{ github.ref }}
+        type: string
     secrets:
       NPM_TOKEN:
         required: true
@@ -23,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -55,6 +62,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/workflow-run-k6-ci-cd-yt01.yml
+++ b/.github/workflows/workflow-run-k6-ci-cd-yt01.yml
@@ -18,6 +18,11 @@ on:
       duration:
         required: true
         type: string
+      ref:
+        description: "The branch or tag ref to run the tests on. Using default checkout ref if not provided."
+        required: false
+        default: ${{ github.ref }}
+        type: string
     secrets:
       TOKEN_GENERATOR_USERNAME:
         required: true
@@ -33,6 +38,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
     - name: Setup k6
       uses: grafana/setup-k6-action@v1
     - name: Run K6 tests (${{ inputs.testSuitePath }})

--- a/.github/workflows/workflow-run-k6-tests.yml
+++ b/.github/workflows/workflow-run-k6-tests.yml
@@ -12,6 +12,11 @@ on:
       testSuitePath:
         required: true
         type: string
+      ref:
+        description: "The branch or tag ref to run the tests on. Using default checkout ref if not provided."
+        required: false
+        default: ${{ github.ref }}
+        type: string
     secrets:
       TOKEN_GENERATOR_USERNAME:
         required: true
@@ -28,6 +33,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
 
     # todo: change to use the new https://github.com/grafana/setup-k6-action and https://github.com/grafana/run-k6-action
     # grafana/k6-action is deprecated


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Ensures that deployments to yt01/staging/production does not check out `main` branch for bicep configuration of an application or infra when a release is made. There was an issue where a release was created, and when deploying to yt01, it checked out the `main` branch, causing it to use bicep config from the `main` branch instead of from the tag. 
- Added a required version on the `ci-cd-prod.yml` workflow to avoid that we check out the `main` branch on deployment
- Removed manual dispatch of the `ci-cd-`-workflows. Keeping these automatic. We should rather use the `dispatch-apps` and `dispatch-infrastructure` workflows instead if we want to do a manual deployment. 
- Added some descriptions on the workflows
- For deployments to staging/yt01/prod-dry-run, using the version that was sent in the repository dispatch instead of reading the current version from file. 

## Related Issue(s)

- #1692
