### PR TITLE
fix(webapi): Correctly handle deleted filter null value on ServiceOwner search

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQuery.cs
@@ -52,12 +52,17 @@ public sealed class SearchDialogQuery : SortablePaginationParameter<SearchDialog
     /// </summary>
     public List<DialogStatus.Values>? Status { get; init; }
 
+    private DeletedFilter? _deleted = DeletedFilter.Exclude;
     /// <summary>
     /// If set to 'include', the result will include both deleted and non-deleted dialogs
     /// If set to 'exclude', the result will only include non-deleted dialogs
     /// If set to 'only', the result will only include deleted dialogs
     /// </summary>
-    public DeletedFilter? Deleted { get; set; } = DeletedFilter.Exclude;
+    public DeletedFilter? Deleted
+    {
+        get => _deleted;
+        set => _deleted = value ?? DeletedFilter.Exclude;
+    }
 
     /// <summary>
     /// Only return dialogs created after this date


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`?deleted` and `?deleted=` query params on ServiceOwner search is not handled as default (exclude)

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1825 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
