### PR TITLE
fix(webapi): Mask unauthorized attachment URLs in EndUser transmission endpoints

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogTransmissions/Queries/Get/GetTransmissionQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogTransmissions/Queries/Get/GetTransmissionQuery.cs
@@ -83,7 +83,7 @@ internal sealed class GetTransmissionQueryHandler : IRequestHandler<GetTransmiss
 
         if (dto.IsAuthorized) return dto;
 
-        var urls = transmission.Attachments.SelectMany(a => a.Urls).ToList();
+        var urls = dto.Attachments.SelectMany(a => a.Urls).ToList();
         foreach (var url in urls)
         {
             url.Url = Constants.UnauthorizedUri;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

EndUser transmission endpoints gives out original URLs when the user is not authorized to see them

## Related Issue(s)

- #1889 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
