### PR TITLE
chore: updated push sdk to NuGet workflow on WebApiClient changes

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -101,7 +101,7 @@ jobs:
   publish-sdk-to-nuget:
     uses: ./.github/workflows/workflow-publish-nuget.yml
     needs: [ deploy-apps, get-current-version, generate-git-short-sha, check-for-changes ]
-    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiClientChanges ) }}
+    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiClientChanges == 'true' ) }}
     with:
       version: ${{ needs.get-current-version.outputs.version }}-rc.${{ needs.generate-git-short-sha.outputs.gitShortSha }}
       path: 'src/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj'

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -101,7 +101,7 @@ jobs:
   publish-sdk-to-nuget:
     uses: ./.github/workflows/workflow-publish-nuget.yml
     needs: [ deploy-apps, get-current-version, generate-git-short-sha, check-for-changes ]
-    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' }}
+    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiClientChanges ) }}
     with:
       version: ${{ needs.get-current-version.outputs.version }}-rc.${{ needs.generate-git-short-sha.outputs.gitShortSha }}
       path: 'src/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj'

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -102,7 +102,7 @@ jobs:
   publish-sdk-to-nuget:
     uses: ./.github/workflows/workflow-publish-nuget.yml
     needs: [ deploy-apps, check-for-changes ]
-    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiClientChanges ) }}
+    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiClientChanges == 'true' ) }}
     with:
       version: ${{ inputs.version }}
       path: 'src/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj'

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -102,7 +102,7 @@ jobs:
   publish-sdk-to-nuget:
     uses: ./.github/workflows/workflow-publish-nuget.yml
     needs: [ deploy-apps, check-for-changes ]
-    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' }}
+    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiClientChanges ) }}
     with:
       version: ${{ inputs.version }}
       path: 'src/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj'

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -82,7 +82,7 @@ jobs:
   publish-sdk-to-nuget:
     uses: ./.github/workflows/workflow-publish-nuget.yml
     needs: [ deploy-apps, check-for-changes ]
-    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiClientChanges )}}
+    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiClientChanges == 'true' )}}
     with:
       version: ${{ github.event.client_payload.version }}-rc
       path: 'src/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj'

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -82,7 +82,7 @@ jobs:
   publish-sdk-to-nuget:
     uses: ./.github/workflows/workflow-publish-nuget.yml
     needs: [ deploy-apps, check-for-changes ]
-    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' }}
+    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiClientChanges )}}
     with:
       version: ${{ github.event.client_payload.version }}-rc
       path: 'src/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj'

--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -20,6 +20,9 @@ on:
       hasBackendChanges:
         description: "Backend related files changed"
         value: ${{ jobs.check-for-changes.outputs.hasBackendChanges }}
+      hasWebApiClientChanges:
+        description: "WebApiClient related files changed"
+        value: ${{ jobs.check-for-changes.outputs.hasWebApiClientChanges }}
       hasTestChanges:
         description: "Test related files changed"
         value: ${{ jobs.check-for-changes.outputs.hasTestChanges }}
@@ -48,6 +51,7 @@ jobs:
       hasSwaggerSchemaChanges: ${{ steps.filter-backend.outputs.swagger_schema_any_modified == 'true'}}
       hasGqlSchemaChanges: ${{ steps.filter-backend.outputs.gql_schema_any_modified == 'true'}}
       hasMigrationChanges: ${{ steps.filter-backend.outputs.migration_any_modified == 'true'}}
+      hasWebApiClientChanges: ${{ steps.filter-backend.outputs.web_api_client_modified == 'true'}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,6 +83,8 @@ jobs:
               - '.azure/modules/containerApp/**/*'
             tests:
               - 'tests/**/*'
+            web_api_client:
+              - 'src/Digdir.Library.Dialogporten.WebApiClient/**/*
             swagger_schema:
               - 'docs/schema/V1/swagger.verified.json'
             gql_schema:

--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -84,7 +84,7 @@ jobs:
             tests:
               - 'tests/**/*'
             web_api_client:
-              - 'src/Digdir.Library.Dialogporten.WebApiClient/**/*
+              - 'src/Digdir.Library.Dialogporten.WebApiClient/**/*'
             swagger_schema:
               - 'docs/schema/V1/swagger.verified.json'
             gql_schema:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

WebApiClient NuGet is now also pushed on changes in the WebApiClient not only on schema changes

## Related Issue(s)

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
