### PR TITLE
fix(infra): ensure we set az for primary in postgresql

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -64,6 +64,7 @@ param postgresConfiguration {
   enableQueryPerformanceInsight: bool
   enableHighAvailability: bool
   backupRetentionDays: int
+  availabilityZone: string
 }
 
 import { Sku as ServiceBusSku } from '../modules/serviceBus/main.bicep'
@@ -218,6 +219,7 @@ module postgresql '../modules/postgreSql/create.bicep' = {
     vnetId: vnet.outputs.virtualNetworkId
     enableHighAvailability: postgresConfiguration.enableHighAvailability
     backupRetentionDays: postgresConfiguration.backupRetentionDays
+    availabilityZone: postgresConfiguration.availabilityZone
     tags: tags
   }
 }

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -38,6 +38,7 @@ param postgresConfiguration = {
   enableQueryPerformanceInsight: false
   enableHighAvailability: true
   backupRetentionDays: 32
+  availabilityZone: '3'
 }
 
 param redisSku = {

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -38,6 +38,7 @@ param postgresConfiguration = {
   enableQueryPerformanceInsight: true
   enableHighAvailability: false
   backupRetentionDays: 7
+  availabilityZone: '2'
 }
 
 param redisSku = {

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -38,6 +38,7 @@ param postgresConfiguration = {
   enableQueryPerformanceInsight: true
   enableHighAvailability: false
   backupRetentionDays: 7
+  availabilityZone: '1'
 }
 
 param redisSku = {

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -40,6 +40,7 @@ param postgresConfiguration = {
   enableQueryPerformanceInsight: true
   enableHighAvailability: false
   backupRetentionDays: 7
+  availabilityZone: '1'
 }
 
 param redisSku = {

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -55,6 +55,9 @@ param appInsightWorkspaceName string
 @description('Enable high availability')
 param enableHighAvailability bool
 
+@description('The availability zone for the PostgreSQL primary server')
+param availabilityZone string
+
 @description('The number of days to retain backups. If not specified, the default value of 7 days will be used.')
 @minValue(7)
 @maxValue(35)
@@ -123,6 +126,7 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
       delegatedSubnetResourceId: subnetId
       privateDnsZoneArmResourceId: privateDnsZone.outputs.id
     }
+    availabilityZone: availabilityZone
     highAvailability: highAvailabilityConfig
   }
   sku: sku


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

We had an issue where we added HA for `prod`, but the bicep deployment didn't go through because we need to set the primary az. Setting the primary az to the one that it was added to when created. 

## Related Issue(s)

- #164

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
