### PR TITLE
chore: Fix actor DTO summaries

### DIFF
--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -378,19 +378,19 @@
         "additionalProperties": false,
         "properties": {
           "actorId": {
-            "description": "The identifier of the person or organization that sent the transmission. Mutually exclusive with ActorName.\nMight be omitted if ActorType is \u0022ServiceOwner\u0022.",
+            "description": "The identifier (national identity number or organization number) of the actor.",
             "example": "urn:altinn:person:identifier-no:12018212345",
             "nullable": true,
             "type": "string"
           },
           "actorName": {
-            "description": "Specifies the name of the entity that sent the transmission. Mutually exclusive with ActorId. If ActorId\nis supplied, the name will be automatically populated from the name registries.",
+            "description": "The name of the actor.",
             "example": "Ola Nordmann",
             "nullable": true,
             "type": "string"
           },
           "actorType": {
-            "description": "The type of actor that sent the transmission.",
+            "description": "The type of actor; either the service owner, or someone representing the party.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/Actors_ActorType"
@@ -1876,19 +1876,19 @@
         "additionalProperties": false,
         "properties": {
           "actorId": {
-            "description": "The identifier of the person or organization that sent the transmission. Mutually exclusive with ActorName.\nMight be omitted if ActorType is \u0022ServiceOwner\u0022.",
+            "description": "The identifier (national identity number or organization number) of the actor.",
             "example": "urn:altinn:person:identifier-no:12018212345",
             "nullable": true,
             "type": "string"
           },
           "actorName": {
-            "description": "Specifies the name of the entity that sent the transmission. Mutually exclusive with ActorId. If ActorId\nis supplied, the name will be automatically populated from the name registries.",
+            "description": "The name of the actor.",
             "example": "Ola Nordmann",
             "nullable": true,
             "type": "string"
           },
           "actorType": {
-            "description": "The type of actor that sent the transmission.",
+            "description": "The type of actor; either the service owner, or someone representing the party.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/Actors_ActorType"

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Common/Actors/ActorDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Common/Actors/ActorDto.cs
@@ -5,22 +5,20 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.Acto
 public sealed class ActorDto
 {
     /// <summary>
-    /// The type of actor that sent the transmission.
+    /// The type of actor; either the service owner, or someone representing the party.
     /// </summary>
     public ActorType.Values ActorType { get; set; }
 
     /// <summary>
-    /// Specifies the name of the entity that sent the transmission. Mutually exclusive with ActorId. If ActorId
-    /// is supplied, the name will be automatically populated from the name registries.
+    /// The name of the actor.
     /// </summary>
     /// <example>Ola Nordmann</example>
     public string? ActorName { get; set; }
 
     /// <summary>
-    /// The identifier of the person or organization that sent the transmission. Mutually exclusive with ActorName.
-    /// Might be omitted if ActorType is "ServiceOwner".
+    /// The identifier (national identity number or organization number) of the actor.
     /// </summary>
     /// <example>urn:altinn:person:identifier-no:12018212345</example>
     public string? ActorId { get; set; }
-
 }
+

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Common/Actors/ActorDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Common/Actors/ActorDto.cs
@@ -5,20 +5,18 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common
 public sealed class ActorDto
 {
     /// <summary>
-    /// The type of actor that sent the transmission.
+    /// The type of actor; either the service owner, or someone representing the party.
     /// </summary>
     public ActorType.Values ActorType { get; set; }
 
     /// <summary>
-    /// Specifies the name of the entity that sent the transmission. Mutually exclusive with ActorId. If ActorId
-    /// is supplied, the name will be automatically populated from the name registries.
+    /// The name of the actor.
     /// </summary>
     /// <example>Ola Nordmann</example>
     public string? ActorName { get; set; }
 
     /// <summary>
-    /// The identifier of the person or organization that sent the transmission. Mutually exclusive with ActorName.
-    /// Might be omitted if ActorType is "ServiceOwner".
+    /// The identifier (national identity number or organization number) of the actor.
     /// </summary>
     /// <example>urn:altinn:person:identifier-no:12018212345</example>
     public string? ActorId { get; set; }

--- a/src/Digdir.Library.Dialogporten.WebApiClient/Features/V1/RefitterInterface.cs
+++ b/src/Digdir.Library.Dialogporten.WebApiClient/Features/V1/RefitterInterface.cs
@@ -994,7 +994,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
     public partial class V1ServiceOwnerCommonActors_Actor
     {
         /// <summary>
-        /// The type of actor that sent the transmission.
+        /// The type of actor; either the service owner, or someone representing the party.
         /// </summary>
 
         [JsonPropertyName("actorType")]
@@ -1002,16 +1002,14 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         public Actors_ActorType ActorType { get; set; }
 
         /// <summary>
-        /// Specifies the name of the entity that sent the transmission. Mutually exclusive with ActorId. If ActorId
-        /// <br/>is supplied, the name will be automatically populated from the name registries.
+        /// The name of the actor.
         /// </summary>
 
         [JsonPropertyName("actorName")]
         public string ActorName { get; set; }
 
         /// <summary>
-        /// The identifier of the person or organization that sent the transmission. Mutually exclusive with ActorName.
-        /// <br/>Might be omitted if ActorType is "ServiceOwner".
+        /// The identifier (national identity number or organization number) of the actor.
         /// </summary>
 
         [JsonPropertyName("actorId")]


### PR DESCRIPTION
The summaries used on the common ActorDto was referring to transmissions, and including information only relevant for serviceowner POST. Reworded/simplified so that the summaries make sense in any context.