### PR TITLE
fix(apps): ensure we use at23 as backend instead of tt02 in test env

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.Development.json
@@ -17,10 +17,10 @@
       // Any additional settings are specific for the selected client definition type.
       // See below for examples using other types.
       "EncodedJwk": "TODO: Add to local secrets",
-      "TokenExchangeEnvironment": "tt02"
+      "TokenExchangeEnvironment": "at23"
     },
     "Altinn": {
-      "BaseUri": "https://platform.tt02.altinn.no/",
+      "BaseUri": "https://platform.at23.altinn.cloud/",
       "SubscriptionKey": "TODO: Add to local secrets"
     },
     "AltinnCdn": {
@@ -41,7 +41,7 @@
         },
         {
           "Name": "Altinn",
-          "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
+          "WellKnown": "https://platform.at23.altinn.cloud/authentication/api/v1/openid/.well-known/openid-configuration"
         },
         {
           "Name": "Idporten",

--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.test.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.test.json
@@ -17,10 +17,10 @@
       // Any additional settings are specific for the selected client definition type.
       // See below for examples using other types.
       "EncodedJwk": "TODO: Add to local secrets",
-      "TokenExchangeEnvironment": "tt02"
+      "TokenExchangeEnvironment": "at23"
     },
     "Altinn": {
-      "BaseUri": "https://platform.tt02.altinn.no/",
+      "BaseUri": "https://platform.at23.altinn.cloud/",
       "EventsBaseUri": "Secret webhook sink URL in source key vault",
       "SubscriptionKey": "TODO: Add to local secrets"
     }
@@ -51,7 +51,7 @@
         },
         {
           "Name": "Altinn",
-          "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
+          "WellKnown": "https://platform.at23.altinn.cloud/authentication/api/v1/openid/.well-known/openid-configuration"
         },
         {
           "Name": "Idporten",

--- a/src/Digdir.Domain.Dialogporten.Janitor/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.Janitor/appsettings.Development.json
@@ -11,7 +11,7 @@
       "EncodedJwk": "TODO: Add to local secrets"
     },
     "Altinn": {
-      "BaseUri": "https://platform.tt02.altinn.no/",
+      "BaseUri": "https://platform.at23.altinn.cloud/",
       "SubscriptionKey": "TODO: Add to local secrets"
     },
     "AltinnCdn": {
@@ -44,7 +44,7 @@
         },
         {
           "Name": "Altinn",
-          "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
+          "WellKnown": "https://platform.at23.altinn.cloud/authentication/api/v1/openid/.well-known/openid-configuration"
         },
         {
           "Name": "Idporten",

--- a/src/Digdir.Domain.Dialogporten.Janitor/appsettings.test.json
+++ b/src/Digdir.Domain.Dialogporten.Janitor/appsettings.test.json
@@ -11,7 +11,7 @@
       "EncodedJwk": "TODO: Add to local secrets"
     },
     "Altinn": {
-      "BaseUri": "https://platform.tt02.altinn.no/",
+      "BaseUri": "https://platform.at23.altinn.cloud/",
       "EventsBaseUri": "Secret webhook sink URL in source key vault",
       "SubscriptionKey": "TODO: Add to local secrets"
     }
@@ -42,7 +42,7 @@
         },
         {
           "Name": "Altinn",
-          "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
+          "WellKnown": "https://platform.at23.altinn.cloud/authentication/api/v1/openid/.well-known/openid-configuration"
         },
         {
           "Name": "Idporten",

--- a/src/Digdir.Domain.Dialogporten.Service/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.Service/appsettings.Development.json
@@ -9,20 +9,17 @@
     "Maskinporten": {
       // 1. Valid values are test and prod
       "Environment": "test",
-
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-
       // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
-
       // --------------------------
       // Any additional settings are specific for the selected client definition type.
       // See below for examples using other types.
       "EncodedJwk": "TODO: Add to local secrets"
     },
     "Altinn": {
-      "BaseUri": "https://platform.tt02.altinn.no/",
+      "BaseUri": "https://platform.at23.altinn.cloud/",
       "SubscriptionKey": "TODO: Add to local secrets"
     },
     "AltinnCdn": {

--- a/src/Digdir.Domain.Dialogporten.Service/appsettings.test.json
+++ b/src/Digdir.Domain.Dialogporten.Service/appsettings.test.json
@@ -20,10 +20,10 @@
       // Any additional settings are specific for the selected client definition type.
       // See below for examples using other types.
       "EncodedJwk": "TODO: Add to local secrets",
-      "TokenExchangeEnvironment": "tt02"
+      "TokenExchangeEnvironment": "at23"
     },
     "Altinn": {
-      "BaseUri": "https://platform.tt02.altinn.no/",
+      "BaseUri": "https://platform.at23.altinn.cloud/",
       "EventsBaseUri": "Secret webhook sink URL in source key vault",
       "SubscriptionKey": "TODO: Add to local secrets"
     }

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.Development.json
@@ -9,21 +9,18 @@
     "Maskinporten": {
       // 1. Valid values are test and prod
       "Environment": "test",
-
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-
       // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
-
       // --------------------------
       // Any additional settings are specific for the selected client definition type.
       // See below for examples using other types.
       "EncodedJwk": "TODO: Add to local secrets",
-      "TokenExchangeEnvironment": "tt02"
+      "TokenExchangeEnvironment": "at23"
     },
     "Altinn": {
-      "BaseUri": "https://platform.tt02.altinn.no/",
+      "BaseUri": "https://platform.at23.altinn.cloud/",
       "SubscriptionKey": "TODO: Add to local secrets"
     },
     "AltinnCdn": {
@@ -57,7 +54,7 @@
         },
         {
           "Name": "Altinn",
-          "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
+          "WellKnown": "https://platform.at23.altinn.cloud/authentication/api/v1/openid/.well-known/openid-configuration"
         },
         {
           "Name": "Idporten",

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.test.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.test.json
@@ -1,6 +1,6 @@
 {
   "Infrastructure": {
-    "Redis":{
+    "Redis": {
       "ConnectionString": "TODO: Add to local secrets"
     },
     "DialogDbConnectionString": "TODO: Add to local secrets",
@@ -9,21 +9,18 @@
     "Maskinporten": {
       // 1. Valid values are test and prod
       "Environment": "test",
-
       // 2. Client Id/integration as configured in Maskinporten
       "ClientId": "TODO: Add to local secrets",
-
       // 3. Scope(s) requested, space separated. Must be provisioned on the supplied client id.
       "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin altinn:accessmanagement/authorizedparties.admin",
-
       // --------------------------
       // Any additional settings are specific for the selected client definition type.
       // See below for examples using other types.
       "EncodedJwk": "TODO: Add to local secrets",
-      "TokenExchangeEnvironment": "tt02"
+      "TokenExchangeEnvironment": "at23"
     },
     "Altinn": {
-      "BaseUri": "https://platform.tt02.altinn.no/",
+      "BaseUri": "https://platform.at23.altinn.cloud/",
       "EventsBaseUri": "Secret webhook sink URL in source key vault",
       "SubscriptionKey": "TODO: Add to local secrets"
     }
@@ -54,7 +51,7 @@
         },
         {
           "Name": "Altinn",
-          "WellKnown": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
+          "WellKnown": "https://platform.at23.altinn.cloud/authentication/api/v1/openid/.well-known/openid-configuration"
         },
         {
           "Name": "Idporten",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Dependent on the resources being created in resource registry for `at23`

## Related Issue(s)

- #1966

TODO before merge: Update subscription id for test environment in key vault
