### PR TITLE
chore(performance): avoid rate limit exceeded in performance tests

### DIFF
--- a/.github/workflows/workflow-run-k6-performance.yml
+++ b/.github/workflows/workflow-run-k6-performance.yml
@@ -62,7 +62,7 @@ jobs:
       id: populate_kubeconfig_with_k6_context
       shell: bash
       run: |
-        if ! az aks install-cli; then
+        if ! az aks install-cli --client-version 1.32 ; then
           echo "Failed to install kubectl CLI"
           exit 1
         fi

--- a/.github/workflows/workflow-run-k6-performance.yml
+++ b/.github/workflows/workflow-run-k6-performance.yml
@@ -62,7 +62,7 @@ jobs:
       id: populate_kubeconfig_with_k6_context
       shell: bash
       run: |
-        if ! az aks install-cli --client-version 1.32 ; then
+        if ! az aks install-cli --client-version 1.32.2 ; then
           echo "Failed to install kubectl CLI"
           exit 1
         fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set newest kubernetes client in az aks install-cli to hopefully avoid getting the rate limit exceed error when running ci/cd performance test in yt01.
If it works and when latest > 1.32.2, remove --client-version 1.32.2 from the az aks install-cli command

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
