### PR TITLE
feat(infra): enable JIT for ssh-jumper

### DIFF
--- a/.azure/modules/ssh-jumper/main.bicep
+++ b/.azure/modules/ssh-jumper/main.bicep
@@ -83,6 +83,7 @@ module virtualMachine '../../modules/virtualMachine/main.bicep' = {
     location: location
     tags: tags
     adminLoginGroupObjectId: adminLoginGroupObjectId
+    enableJit: true
     hardwareProfile: {
       vmSize: 'Standard_B1s'
     }

--- a/.azure/modules/virtualMachine/main.bicep
+++ b/.azure/modules/virtualMachine/main.bicep
@@ -75,6 +75,9 @@ param adminLoginGroupObjectId string
 @secure()
 param sshPublicKey string
 
+@description('Enable Just-in-Time access for the virtual machine')
+param enableJit bool = false
+
 resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-07-01' = {
   name: name
   location: location
@@ -119,6 +122,25 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-07-01' = {
     type: 'SystemAssigned'
   }
   tags: tags
+}
+
+resource jitPolicy 'Microsoft.Security/locations/jitNetworkAccessPolicies@2020-01-01' = if (enableJit) {
+  name: '${location}/${name}'
+  properties: {
+    virtualMachines: [
+      {
+        id: virtualMachine.id
+        ports: [
+          {
+            number: 22
+            protocol: '*'
+            allowedSourceAddressPrefix: '*'
+            maxRequestAccessDuration: 'PT1H'
+          }
+        ]
+      }
+    ]
+  }
 }
 
 resource aadLoginExtension 'Microsoft.Compute/virtualMachines/extensions@2024-07-01' = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enables just-in-time for the ssh-jumpers. In order to use the database-forwarder, you need to enable JIT in the portal. I will add this as a script in the database-forwarder ASAP so it will happen automatically so we don't need to go to the portal each time. 

![CleanShot 2025-03-20 at 15 31 47](https://github.com/user-attachments/assets/6ae56d06-2739-4a98-9eeb-bb9b0aa6f441)

Tips for later:
- Add Office IP only for production
- Increase the max duration for all other envs than production (1HR is a bit low)

<!--- Describe your changes in detail -->

## Related Issue(s)

- #1995

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
