### PR TITLE
fix(infra): tighten the security for ssh-jumpers

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -192,7 +192,7 @@ module sshJumper '../modules/ssh-jumper/main.bicep' = {
   params: {
     namePrefix: namePrefix
     location: location
-    subnetId: vnet.outputs.defaultSubnetId
+    subnetId: vnet.outputs.sshJumperSubnetId
     tags: tags
     sshPublicKey: secrets.sourceKeyVaultSshJumperSshPublicKey
     adminLoginGroupObjectId: sshJumperAdminLoginGroupObjectId

--- a/.azure/modules/vnet/main.bicep
+++ b/.azure/modules/vnet/main.bicep
@@ -224,6 +224,45 @@ resource redisNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
   tags: tags
 }
 
+resource serviceBusNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+  name: '${namePrefix}-service-bus-nsg'
+  location: location
+  properties: {
+    securityRules: [
+      // todo: make more restrictive
+      {
+        name: 'AllowAnyCustomAnyInbound'
+        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
+        properties: {
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 100
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'AllowAnyCustomAnyOutbound'
+        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
+        properties: {
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 100
+          direction: 'Outbound'
+        }
+      }
+    ]
+  }
+  tags: tags
+}
+
 resource sshJumperNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
   name: '${namePrefix}-ssh-jumper-nsg'
   location: location
@@ -296,45 +335,6 @@ resource sshJumperNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
           destinationAddressPrefix: '*'
           access: 'Allow'
           priority: 130
-          direction: 'Outbound'
-        }
-      }
-    ]
-  }
-  tags: tags
-}
-
-resource serviceBusNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
-  name: '${namePrefix}-service-bus-nsg'
-  location: location
-  properties: {
-    securityRules: [
-      // todo: make more restrictive
-      {
-        name: 'AllowAnyCustomAnyInbound'
-        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
-        properties: {
-          protocol: '*'
-          sourcePortRange: '*'
-          destinationPortRange: '*'
-          sourceAddressPrefix: '*'
-          destinationAddressPrefix: '*'
-          access: 'Allow'
-          priority: 100
-          direction: 'Inbound'
-        }
-      }
-      {
-        name: 'AllowAnyCustomAnyOutbound'
-        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
-        properties: {
-          protocol: '*'
-          sourcePortRange: '*'
-          destinationPortRange: '*'
-          sourceAddressPrefix: '*'
-          destinationAddressPrefix: '*'
-          access: 'Allow'
-          priority: 100
           direction: 'Outbound'
         }
       }

--- a/.azure/modules/vnet/main.bicep
+++ b/.azure/modules/vnet/main.bicep
@@ -7,6 +7,17 @@ param location string
 @description('Tags to apply to resources')
 param tags object
 
+// Network address ranges
+var vnetAddressPrefix = '10.0.0.0/16'
+
+// Subnet address prefixes
+var defaultSubnetPrefix = '10.0.0.0/24'
+var postgresqlSubnetPrefix = '10.0.1.0/24'
+var containerAppEnvSubnetPrefix = '10.0.2.0/23'  // required size for the container app environment is /23
+var serviceBusSubnetPrefix = '10.0.4.0/24'
+var redisSubnetPrefix = '10.0.5.0/24'
+var sshJumperSubnetPrefix = '10.0.6.0/24'
+
 resource defaultNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
   name: '${namePrefix}-default-nsg'
   location: location
@@ -290,7 +301,7 @@ resource sshJumperNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
           sourcePortRange: '*'
           destinationPortRange: '5432'
           sourceAddressPrefix: '*'
-          destinationAddressPrefix: '10.0.1.0/24'  // PostgreSQL subnet
+          destinationAddressPrefix: postgresqlSubnetPrefix
           access: 'Allow'
           priority: 100
           direction: 'Outbound'
@@ -304,7 +315,7 @@ resource sshJumperNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
           sourcePortRange: '*'
           destinationPortRange: '6379-6380'  // Redis ports (including SSL)
           sourceAddressPrefix: '*'
-          destinationAddressPrefix: '10.0.5.0/24'  // Redis subnet
+          destinationAddressPrefix: redisSubnetPrefix
           access: 'Allow'
           priority: 110
           direction: 'Outbound'
@@ -349,14 +360,14 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   properties: {
     addressSpace: {
       addressPrefixes: [
-        '10.0.0.0/16'
+        vnetAddressPrefix
       ]
     }
     subnets: [
       {
         name: 'default'
         properties: {
-          addressPrefix: '10.0.0.0/24'
+          addressPrefix: defaultSubnetPrefix
           networkSecurityGroup: {
             id: defaultNSG.id
           }
@@ -365,7 +376,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
       {
         name: 'postgresqlSubnet'
         properties: {
-          addressPrefix: '10.0.1.0/24'
+          addressPrefix: postgresqlSubnetPrefix
           networkSecurityGroup: {
             id: postgresqlNSG.id
           }
@@ -388,8 +399,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
       {
         name: 'containerAppEnvSubnet'
         properties: {
-          // required size for the container app environment is /23
-          addressPrefix: '10.0.2.0/23'
+          addressPrefix: containerAppEnvSubnetPrefix
           networkSecurityGroup: {
             id: containerAppEnvironmentNSG.id
           }
@@ -399,7 +409,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
       {
         name: 'serviceBusSubnet'
         properties: {
-          addressPrefix: '10.0.4.0/24'
+          addressPrefix: serviceBusSubnetPrefix
           networkSecurityGroup: {
             id: serviceBusNSG.id
           }
@@ -408,7 +418,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
       {
         name: 'redisSubnet'
         properties: {
-          addressPrefix: '10.0.5.0/24'
+          addressPrefix: redisSubnetPrefix
           networkSecurityGroup: {
             id: redisNSG.id
           }
@@ -417,7 +427,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
       {
         name: 'sshJumperSubnet'
         properties: {
-          addressPrefix: '10.0.6.0/24'
+          addressPrefix: sshJumperSubnetPrefix
           networkSecurityGroup: {
             id: sshJumperNSG.id
           }

--- a/.azure/modules/vnet/main.bicep
+++ b/.azure/modules/vnet/main.bicep
@@ -280,16 +280,58 @@ resource sshJumperNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
   properties: {
     securityRules: [
       {
-        name: 'AllowAnyCustomAnyOutbound'
+        name: 'AllowPostgreSQLOutbound'
+        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '5432'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: postgresqlSubnetPrefix
+          access: 'Allow'
+          priority: 100
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'AllowRedisOutbound'
+        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '6379-6380'  // Redis ports (including SSL)
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: redisSubnetPrefix
+          access: 'Allow'
+          priority: 110
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'AllowHTTPSOutbound'
+        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 120
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'AllowDNSOutbound'
         type: 'Microsoft.Network/networkSecurityGroups/securityRules'
         properties: {
           protocol: '*'
           sourcePortRange: '*'
-          destinationPortRange: '*'
+          destinationPortRange: '53'
           sourceAddressPrefix: '*'
           destinationAddressPrefix: '*'
           access: 'Allow'
-          priority: 100
+          priority: 130
           direction: 'Outbound'
         }
       }

--- a/.azure/modules/vnet/main.bicep
+++ b/.azure/modules/vnet/main.bicep
@@ -280,72 +280,16 @@ resource sshJumperNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
   properties: {
     securityRules: [
       {
-        name: 'AllowSSHInbound'
-        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
-        properties: {
-          protocol: 'Tcp'
-          sourcePortRange: '*'
-          destinationPortRange: '22'
-          sourceAddressPrefix: '*'
-          destinationAddressPrefix: '*'
-          access: 'Allow'
-          priority: 100
-          direction: 'Inbound'
-        }
-      }
-      {
-        name: 'AllowPostgreSQLOutbound'
-        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
-        properties: {
-          protocol: 'Tcp'
-          sourcePortRange: '*'
-          destinationPortRange: '5432'
-          sourceAddressPrefix: '*'
-          destinationAddressPrefix: postgresqlSubnetPrefix
-          access: 'Allow'
-          priority: 100
-          direction: 'Outbound'
-        }
-      }
-      {
-        name: 'AllowRedisOutbound'
-        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
-        properties: {
-          protocol: 'Tcp'
-          sourcePortRange: '*'
-          destinationPortRange: '6379-6380'  // Redis ports (including SSL)
-          sourceAddressPrefix: '*'
-          destinationAddressPrefix: redisSubnetPrefix
-          access: 'Allow'
-          priority: 110
-          direction: 'Outbound'
-        }
-      }
-      {
-        name: 'AllowHTTPSOutbound'
-        type: 'Microsoft.Network/networkSecurityGroups/securityRules'
-        properties: {
-          protocol: 'Tcp'
-          sourcePortRange: '*'
-          destinationPortRange: '443'
-          sourceAddressPrefix: '*'
-          destinationAddressPrefix: '*'
-          access: 'Allow'
-          priority: 120
-          direction: 'Outbound'
-        }
-      }
-      {
-        name: 'AllowDNSOutbound'
+        name: 'AllowAnyCustomAnyOutbound'
         type: 'Microsoft.Network/networkSecurityGroups/securityRules'
         properties: {
           protocol: '*'
           sourcePortRange: '*'
-          destinationPortRange: '53'
+          destinationPortRange: '*'
           sourceAddressPrefix: '*'
           destinationAddressPrefix: '*'
           access: 'Allow'
-          priority: 130
+          priority: 100
           direction: 'Outbound'
         }
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Create a new subnet with a dedicated NSG for the ssh-jumpers. Adding some rules to tighten the security for the ssh-jumper. 

Only allow outbound traffic to postgres and redis and other necessary traffic. 
Only allow inbound traffic on port 22

## Related Issue(s)

- #1995

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
