### PR TITLE
feat: Loosen transmission hierarchy restrictions

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
@@ -100,8 +100,8 @@ internal sealed class CreateDialogCommandHandler : IRequestHandler<CreateDialogC
             keySelector: x => x.Id,
             parentKeySelector: x => x.RelatedTransmissionId,
             propertyName: nameof(CreateDialogDto.Transmissions),
-            maxDepth: 100,
-            maxWidth: 1));
+            maxDepth: 20,
+            maxWidth: 20));
 
         await _db.Dialogs.AddAsync(dialog, cancellationToken);
 

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
@@ -126,8 +126,8 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
             keySelector: x => x.Id,
             parentKeySelector: x => x.RelatedTransmissionId,
             propertyName: nameof(UpdateDialogDto.Transmissions),
-            maxDepth: 100,
-            maxWidth: 1));
+            maxDepth: 20,
+            maxWidth: 20));
 
         VerifyActivityTransmissionRelations(dialog);
 


### PR DESCRIPTION
Pending final decision on how transmission hierarchy should be restricted, we need to increase max width to unblock Skatt. At the same time, the max depth has been reduced to 20. As the transmission feature is not widely used, future restrictions is deemed to be manageable to roll out without too much breakage.