### PR TITLE
ci: send deployment information to swarmia

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -169,3 +169,14 @@ jobs:
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_CI_CD_STATUS }}
+
+  send-deployment-to-swarmia:
+    name: Send deployment to Swarmia
+    if: ${{ always() && !failure() && !cancelled() }}
+    uses: ./.github/workflows/workflow-swarmia-deployment.yml
+    needs: [ deploy-infra, deploy-apps ]
+    with:
+      app-name: dialogporten
+      environment: 'test'
+    secrets:
+      token: ${{ secrets.SWARMIA_DEPLOYMENTS_AUTHORIZATION }}

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -134,3 +134,14 @@ jobs:
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_CI_CD_STATUS }}
+
+  send-deployment-to-swarmia:
+    name: Send deployment to Swarmia
+    if: ${{ always() && !failure() && !cancelled() }}
+    uses: ./.github/workflows/workflow-swarmia-deployment.yml
+    needs: [ deploy-infra, deploy-apps ]
+    with:
+      app-name: dialogporten
+      environment: 'prod'
+    secrets:
+      token: ${{ secrets.SWARMIA_DEPLOYMENTS_AUTHORIZATION }}

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -149,3 +149,14 @@ jobs:
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_CI_CD_STATUS }}
+
+  send-deployment-to-swarmia:
+    name: Send deployment to Swarmia
+    if: ${{ always() && !failure() && !cancelled() }}
+    uses: ./.github/workflows/workflow-swarmia-deployment.yml
+    needs: [ deploy-infra, deploy-apps ]
+    with:
+      app-name: dialogporten
+      environment: 'staging'
+    secrets:
+      token: ${{ secrets.SWARMIA_DEPLOYMENTS_AUTHORIZATION }}

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -158,3 +158,14 @@ jobs:
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_CI_CD_STATUS }}
+
+  send-deployment-to-swarmia:
+    name: Send deployment to Swarmia
+    if: ${{ always() && !failure() && !cancelled() }}
+    uses: ./.github/workflows/workflow-swarmia-deployment.yml
+    needs: [ deploy-infra, deploy-apps ]
+    with:
+      app-name: dialogporten
+      environment: 'yt01'
+    secrets:
+      token: ${{ secrets.SWARMIA_DEPLOYMENTS_AUTHORIZATION }}

--- a/.github/workflows/workflow-swarmia-deployment.yml
+++ b/.github/workflows/workflow-swarmia-deployment.yml
@@ -1,0 +1,34 @@
+# this workflow is taken from the Swarmia docs: https://help.swarmia.com/sending-deployment-information-to-swarmia
+name: Send deployment to Swarmia Deployment API
+
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+    secrets:
+      token:
+        required: true
+
+jobs:
+  send-deployment-to-swarmia:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Send deployment to Swarmia
+      run: |
+        JSON_STRING=$( jq --null-input --compact-output \
+          --arg version "${{ github.sha }}" \
+          --arg appName "${{ inputs.app-name }}" \
+          --arg environment "${{ inputs.environment }}" \
+          --arg commitSha "${{ github.sha }}" \
+          --arg repositoryFullName "${{ github.repository }}" \
+          '{"version": $version, "appName": $appName, "environment": $environment, "commitSha": $commitSha, "repositoryFullName": $repositoryFullName}' )
+
+        curl -H "Authorization: ${{ secrets.token }}" \
+          -H "Content-Type: application/json" \
+          -d "$JSON_STRING" \
+          https://hook.swarmia.com/deployments


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Swarmia by default uses the deployment from github. We trigger a deployment way too often because a deployment is registered whenever we use a workflow related to an environment. This leads to multiple registered deployments per deployment. 

## Related Issue(s)

- #N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
