### PR TITLE
fix(infra): remove ssl check in availability tests

### DIFF
--- a/.azure/modules/applicationInsights/availabilityTest.bicep
+++ b/.azure/modules/applicationInsights/availabilityTest.bicep
@@ -47,8 +47,7 @@ resource availabilityTest 'Microsoft.Insights/webtests@2022-06-15' = {
     }
     ValidationRules: {
       ExpectedHttpStatusCode: 200
-      SSLCheck: true
-      SSLCertRemainingLifetimeCheck: 7
+      SSLCheck: false
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The availability test is failing in `production`: https://digdir.slack.com/archives/C079XRW5G5A/p1744178965215129

The reason is that the SSL certificate expires in 7 days. The SSL certificate is handled in APIM. No need for us to handle this. 

## Related Issue(s)

- #N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
