### PR TITLE
trivial(ci): Set correct version for bicep-deploy

### DIFF
--- a/.github/workflows/workflow-deploy-infra.yml
+++ b/.github/workflows/workflow-deploy-infra.yml
@@ -104,14 +104,14 @@ jobs:
           scope: subscription
           type: deployment
           operation: whatIf
-          name: dp-be-${{ inputs.environment }}-${{ inputs.version }} 
+          name: dp-be-${{ inputs.environment }}-${{ inputs.version }}
           template-file: ./.azure/infrastructure/main.bicep
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           location: ${{ inputs.region }}
           parameters-file: ./.azure/infrastructure/${{ inputs.environment }}.bicepparam
 
       - name: Deploy infrastructure (${{ inputs.environment }})
-        uses: azure/bicep-deploy@b63eaec8b9f6816ac93b70400c64e60fae54530f # v2.0.0
+        uses: azure/bicep-deploy@b63eaec8b9f6816ac93b70400c64e60fae54530f # v2.1.0
         if: ${{ !inputs.dryRun }}
         id: deploy
         env:
@@ -127,7 +127,7 @@ jobs:
           scope: subscription
           type: deployment
           operation: create
-          name: dp-be-${{ inputs.environment }}-${{ inputs.version }} 
+          name: dp-be-${{ inputs.environment }}-${{ inputs.version }}
           template-file: ./.azure/infrastructure/main.bicep
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           location: ${{ inputs.region }}


### PR DESCRIPTION
One version tag was incorrect, causing renovate to re-tag with an earlier version
- #2193 