### PR TITLE
fix: Reduce isolation level for outbox

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.ApiClients.Maskinporten.Extensions;
+﻿using System.Data;
+using Altinn.ApiClients.Maskinporten.Extensions;
 using Altinn.ApiClients.Maskinporten.Interfaces;
 using Altinn.ApiClients.Maskinporten.Services;
 using Digdir.Domain.Dialogporten.Application.Externals;
@@ -195,6 +196,12 @@ public static class InfrastructureExtensions
             {
                 o.UsePostgres();
                 o.UseBusOutbox();
+
+                // This lowers the isolation level from Serializable to ReadCommitted. This avoids contention issues
+                // and provides sufficient guarantees for the outbox bus using polling with FOR UPDATE SKIP LOCKED,
+                // where MassTransit only perform message forwarding to Azure Service Bus and isn't performing any
+                // mutation of the outbox besides deleting rows after successful passing to ASB.
+                o.IsolationLevel = IsolationLevel.ReadCommitted;
             });
 
             foreach (var customConfiguration in customConfigurations)


### PR DESCRIPTION
## Description

This is an attempt to reduce lock contention with MassTransit and outbox usage.

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
