### PR TITLE
feat(breaking): Disallow so search without enduserid

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQueryValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQueryValidator.cs
@@ -37,6 +37,11 @@ internal sealed class SearchDialogQueryValidator : AbstractValidator<SearchDialo
                          $"must be specified if '{nameof(SearchDialogQuery.EndUserId)}' is provided.")
             .When(x => x.EndUserId is not null);
 
+        RuleFor(x => x.Search)
+            .Must((x, _) => x.EndUserId is not null)
+            .WithMessage($"'{nameof(SearchDialogQuery.EndUserId)}' must be specified if {{PropertyName}} is provided.")
+            .When(x => x.Search is not null);
+
         RuleForEach(x => x.Party)
             .IsValidPartyIdentifier();
 

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogTests.cs
@@ -1,0 +1,48 @@
+﻿using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Search;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.ServiceOwner.Dialogs.Queries.Search;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class SearchDialogTests : ApplicationCollectionFixture
+{
+    public SearchDialogTests(DialogApplication application) : base(application) { }
+
+    [Fact]
+    public async Task SearchWithFreetextRequiresEndUserId_OK()
+    {
+        // Arrange
+        var searchDialogQuery = new SearchDialogQuery
+        {
+            Search = "foobar",
+            Party = [DialogGenerator.GenerateRandomParty()],
+            EndUserId = DialogGenerator.GenerateRandomParty(forcePerson: true)
+        };
+
+        // Act
+        var response = await Application.Send(searchDialogQuery);
+
+        // Assert
+        response.TryPickT0(out var result, out _).Should().BeTrue();
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SearchWithFreetextRequiresEndUserId_MissingShouldFail()
+    {
+        // Arrange
+        var searchDialogQuery = new SearchDialogQuery
+        {
+            Search = "foobar"
+        };
+
+        // Act
+        var response = await Application.Send(searchDialogQuery);
+
+        // Assert
+        response.TryPickT1(out var result, out _).Should().BeTrue();
+        result.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
This removes the ability to use free text search on the SO API without supplying a enduserid
