### PR TITLE
fix(infra): revert workload profiles for CAE

### DIFF
--- a/.azure/applications/graphql/main.bicep
+++ b/.azure/applications/graphql/main.bicep
@@ -49,9 +49,6 @@ param environmentKeyVaultName string
 @minLength(1)
 param otelTraceSamplerRatio string
 
-@description('The workload profile name to use, defaults to "Consumption"')
-param workloadProfileName string = 'Consumption'
-
 var namePrefix = 'dp-be-${environment}'
 var baseImageUrl = 'ghcr.io/altinn/dialogporten-'
 
@@ -153,7 +150,6 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     revisionSuffix: revisionSuffix
     scale: scale
     userAssignedIdentityId: managedIdentity.id
-    workloadProfileName: workloadProfileName
   }
 }
 

--- a/.azure/applications/graphql/prod.bicepparam
+++ b/.azure/applications/graphql/prod.bicepparam
@@ -14,9 +14,6 @@ param resources = {
 
 param otelTraceSamplerRatio = '1'
 
-// Use dedicated workload profile
-param workloadProfileName = 'Dedicated-D8'
-
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')

--- a/.azure/applications/graphql/yt01.bicepparam
+++ b/.azure/applications/graphql/yt01.bicepparam
@@ -12,9 +12,6 @@ param resources = {
 
 param otelTraceSamplerRatio = '0.0'
 
-// Use dedicated workload profile
-param workloadProfileName = 'Dedicated-D8'
-
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')

--- a/.azure/applications/service/main.bicep
+++ b/.azure/applications/service/main.bicep
@@ -46,9 +46,6 @@ param environmentKeyVaultName string
 @minLength(1)
 param otelTraceSamplerRatio string
 
-@description('The workload profile name to use, defaults to "Consumption"')
-param workloadProfileName string = 'Consumption'
-
 @description('Minimum number of replicas')
 @minValue(1)
 param minReplicas int = 1
@@ -182,7 +179,6 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     revisionSuffix: revisionSuffix
     userAssignedIdentityId: managedIdentity.id
     scale: scale
-    workloadProfileName: workloadProfileName
     // TODO: Once all container apps use user-assigned identities, remove this comment and ensure userAssignedIdentityId is always provided
   }
   dependsOn: [

--- a/.azure/applications/web-api-eu/main.bicep
+++ b/.azure/applications/web-api-eu/main.bicep
@@ -49,9 +49,6 @@ param environmentKeyVaultName string
 @minLength(1)
 param otelTraceSamplerRatio string
 
-@description('The workload profile name to use, defaults to "Consumption"')
-param workloadProfileName string = 'Consumption'
-
 var namePrefix = 'dp-be-${environment}'
 var baseImageUrl = 'ghcr.io/altinn/dialogporten-'
 var tags = {
@@ -156,7 +153,6 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     revisionSuffix: revisionSuffix
     scale: scale
     userAssignedIdentityId: managedIdentity.id
-    workloadProfileName: workloadProfileName
   }
 }
 

--- a/.azure/applications/web-api-eu/prod.bicepparam
+++ b/.azure/applications/web-api-eu/prod.bicepparam
@@ -14,9 +14,6 @@ param resources = {
 
 param otelTraceSamplerRatio = '1'
 
-// Use dedicated workload profile
-param workloadProfileName = 'Dedicated-D8'
-
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')

--- a/.azure/applications/web-api-eu/yt01.bicepparam
+++ b/.azure/applications/web-api-eu/yt01.bicepparam
@@ -12,9 +12,6 @@ param resources = {
 
 param otelTraceSamplerRatio = '0.0'
 
-// Use dedicated workload profile
-param workloadProfileName = 'Dedicated-D8'
-
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')

--- a/.azure/applications/web-api-so/main.bicep
+++ b/.azure/applications/web-api-so/main.bicep
@@ -49,9 +49,6 @@ param environmentKeyVaultName string
 @minLength(1)
 param otelTraceSamplerRatio string
 
-@description('The workload profile name to use, defaults to "Consumption"')
-param workloadProfileName string = 'Consumption'
-
 @description('Minimum number of replicas')
 @minValue(1)
 param minReplicas int = 1
@@ -156,7 +153,6 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     revisionSuffix: revisionSuffix
     scale: scale
     userAssignedIdentityId: managedIdentity.id
-    workloadProfileName: workloadProfileName
   }
 }
 

--- a/.azure/applications/web-api-so/prod.bicepparam
+++ b/.azure/applications/web-api-so/prod.bicepparam
@@ -14,9 +14,6 @@ param resources = {
 
 param otelTraceSamplerRatio = '1'
 
-// Use dedicated workload profile
-param workloadProfileName = 'Dedicated-D8'
-
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')

--- a/.azure/applications/web-api-so/yt01.bicepparam
+++ b/.azure/applications/web-api-so/yt01.bicepparam
@@ -12,9 +12,6 @@ param resources = {
 
 param otelTraceSamplerRatio = '0.0'
 
-// Use dedicated workload profile
-param workloadProfileName = 'Dedicated-D8'
-
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -53,6 +53,8 @@ param workloadProfiles array = [
   {
     name: 'Consumption'
     workloadProfileType: 'Consumption'
+    minimumCount: 0
+    maximumCount: 10
   }
 ]
 

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -48,16 +48,6 @@ param appInsightsPurgeDataOn30Days bool = false
 @description('Whether zone redundancy should be enabled for the container app environment')
 param containerAppEnvZoneRedundancyEnabled bool
 
-@description('Workload profiles to enable in the container app environment')
-param workloadProfiles array = [
-  {
-    name: 'Consumption'
-    workloadProfileType: 'Consumption'
-    minimumCount: 0
-    maximumCount: 10
-  }
-]
-
 import { Sku as KeyVaultSku } from '../modules/keyvault/create.bicep'
 param keyVaultSku KeyVaultSku
 
@@ -305,7 +295,6 @@ module containerAppEnv '../modules/containerAppEnv/main.bicep' = {
     subnetId: vnet.outputs.containerAppEnvironmentSubnetId
     tags: tags
     zoneRedundancyEnabled: containerAppEnvZoneRedundancyEnabled
-    workloadProfiles: workloadProfiles
   }
 }
 

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -13,6 +13,8 @@ param workloadProfiles = [
   {
     name: 'Consumption'
     workloadProfileType: 'Consumption'
+    minimumCount: 0
+    maximumCount: 10
   }
   {
     name: 'Dedicated-D8'

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -8,22 +8,6 @@ param redisVersion = '6.0'
 
 param containerAppEnvZoneRedundancyEnabled = true
 
-// Workload profiles configuration
-param workloadProfiles = [
-  {
-    name: 'Consumption'
-    workloadProfileType: 'Consumption'
-    minimumCount: 0
-    maximumCount: 10
-  }
-  {
-    name: 'Dedicated-D8'
-    workloadProfileType: 'D8'
-    minimumCount: 2
-    maximumCount: 5
-  }
-]
-
 // secrets
 param dialogportenPgAdminPassword = readEnvironmentVariable('PG_ADMIN_PASSWORD')
 param sourceKeyVaultSubscriptionId = readEnvironmentVariable('AZURE_SOURCE_KEY_VAULT_SUBSCRIPTION_ID')

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -59,19 +59,3 @@ param serviceBusSku = {
 param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
 
 param apimUrl = 'https://platform.yt01.altinn.cloud/dialogporten'
-
-// Workload profiles configuration
-param workloadProfiles = [
-  {
-    name: 'Consumption'
-    workloadProfileType: 'Consumption'
-    minimumCount: 0
-    maximumCount: 10
-  }
-  {
-    name: 'Dedicated-D8'
-    workloadProfileType: 'D8'
-    minimumCount: 2
-    maximumCount: 5
-  }
-]

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -65,6 +65,8 @@ param workloadProfiles = [
   {
     name: 'Consumption'
     workloadProfileType: 'Consumption'
+    minimumCount: 0
+    maximumCount: 10
   }
   {
     name: 'Dedicated-D8'

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -28,9 +28,6 @@ param resources object?
 @description('The suffix for the revision of the container app')
 param revisionSuffix string
 
-@description('The workload profile to use for the container app')
-param workloadProfileName string = 'Consumption'
-
 @export()
 type ScaleRule = {
   name: string
@@ -188,7 +185,6 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
       ingress: ingress
     }
     environmentId: containerAppEnvId
-    workloadProfileName: workloadProfileName
     template: {
       revisionSuffix: cleanedRevisionSuffix
       scale: scale

--- a/.azure/modules/containerAppEnv/main.bicep
+++ b/.azure/modules/containerAppEnv/main.bicep
@@ -27,6 +27,8 @@ param workloadProfiles array = [
   {
     name: 'Consumption'
     workloadProfileType: 'Consumption'
+    minimumCount: 0
+    maximumCount: 10
   }
 ]
 

--- a/.azure/modules/containerAppEnv/main.bicep
+++ b/.azure/modules/containerAppEnv/main.bicep
@@ -22,16 +22,6 @@ param userAssignedIdentityId string
 @description('Whether zone redundancy should be enabled for the container app environment')
 param zoneRedundancyEnabled bool
 
-@description('Workload profiles to enable in the container app environment')
-param workloadProfiles array = [
-  {
-    name: 'Consumption'
-    workloadProfileType: 'Consumption'
-    minimumCount: 0
-    maximumCount: 10
-  }
-]
-
 resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
   name: appInsightWorkspaceName
 }
@@ -68,7 +58,6 @@ resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-10-02-preview' 
         destinations: ['appInsights']
       }
     }
-    workloadProfiles: workloadProfiles
     zoneRedundant: zoneRedundancyEnabled
     availabilityZones: zoneRedundancyEnabled ? ['1', '2', '3'] : null
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Reverting because a network change is needed in order to change from consumption only to workload profiles. 

https://learn.microsoft.com/en-us/azure/container-apps/environment#types

## Related Issue(s)

- #2257

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
