### PR TITLE
fix(infra): enable workload profiles for staging and prod

### DIFF
--- a/.azure/applications/graphql/main.bicep
+++ b/.azure/applications/graphql/main.bicep
@@ -154,7 +154,6 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     scale: scale
     userAssignedIdentityId: managedIdentity.id
     workloadProfileName: workloadProfileName
-    environment: environment
   }
 }
 

--- a/.azure/applications/service/main.bicep
+++ b/.azure/applications/service/main.bicep
@@ -183,7 +183,6 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     userAssignedIdentityId: managedIdentity.id
     scale: scale
     workloadProfileName: workloadProfileName
-    environment: environment
     // TODO: Once all container apps use user-assigned identities, remove this comment and ensure userAssignedIdentityId is always provided
   }
   dependsOn: [

--- a/.azure/applications/sync-resource-policy-information-job/main.bicep
+++ b/.azure/applications/sync-resource-policy-information-job/main.bicep
@@ -112,7 +112,6 @@ module migrationJob '../../modules/containerAppJob/main.bicep' = {
     args: 'sync-resource-policy-information'
     userAssignedIdentityId: managedIdentity.id
     replicaTimeOutInSeconds: replicaTimeOutInSeconds
-    environment: environment
     workloadProfileName: workloadProfileName
   }
 }

--- a/.azure/applications/sync-subject-resource-mappings-job/main.bicep
+++ b/.azure/applications/sync-subject-resource-mappings-job/main.bicep
@@ -112,7 +112,6 @@ module migrationJob '../../modules/containerAppJob/main.bicep' = {
     args: 'sync-subject-resource-mappings'
     userAssignedIdentityId: managedIdentity.id
     replicaTimeOutInSeconds: replicaTimeOutInSeconds
-    environment: environment
     workloadProfileName: workloadProfileName
   }
 }

--- a/.azure/applications/web-api-eu/main.bicep
+++ b/.azure/applications/web-api-eu/main.bicep
@@ -157,7 +157,6 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     scale: scale
     userAssignedIdentityId: managedIdentity.id
     workloadProfileName: workloadProfileName
-    environment: environment
   }
 }
 

--- a/.azure/applications/web-api-migration-job/main.bicep
+++ b/.azure/applications/web-api-migration-job/main.bicep
@@ -81,7 +81,6 @@ module migrationJob '../../modules/containerAppJob/main.bicep' = {
     userAssignedIdentityId: managedIdentity.id
     replicaTimeOutInSeconds: replicaTimeOutInSeconds
     workloadProfileName: workloadProfileName
-    environment: environment
   }
 }
 

--- a/.azure/applications/web-api-so/main.bicep
+++ b/.azure/applications/web-api-so/main.bicep
@@ -157,7 +157,6 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     scale: scale
     userAssignedIdentityId: managedIdentity.id
     workloadProfileName: workloadProfileName
-    environment: environment
   }
 }
 

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -305,7 +305,6 @@ module containerAppEnv '../modules/containerAppEnv/main.bicep' = {
     tags: tags
     zoneRedundancyEnabled: containerAppEnvZoneRedundancyEnabled
     workloadProfiles: workloadProfiles
-    environment: environment
   }
 }
 

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -17,7 +17,7 @@ param workloadProfiles = [
   {
     name: 'Dedicated-D8'
     workloadProfileType: 'D8'
-    minimumCount: 3
+    minimumCount: 2
     maximumCount: 5
   }
 ]

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -17,7 +17,7 @@ param workloadProfiles = [
   {
     name: 'Dedicated-D8'
     workloadProfileType: 'D8'
-    minimumCount: 2
+    minimumCount: 3
     maximumCount: 5
   }
 ]

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -31,12 +31,6 @@ param revisionSuffix string
 @description('The workload profile to use for the container app')
 param workloadProfileName string = 'Consumption'
 
-@description('The environment for the deployment')
-param environment string
-
-// Only set workload profile for test and yt01 environments
-var shouldSetWorkloadProfile = environment == 'yt01' || environment == 'test'
-
 @export()
 type ScaleRule = {
   name: string
@@ -194,7 +188,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
       ingress: ingress
     }
     environmentId: containerAppEnvId
-    workloadProfileName: shouldSetWorkloadProfile ? workloadProfileName : null
+    workloadProfileName: workloadProfileName
     template: {
       revisionSuffix: cleanedRevisionSuffix
       scale: scale

--- a/.azure/modules/containerAppEnv/main.bicep
+++ b/.azure/modules/containerAppEnv/main.bicep
@@ -30,12 +30,6 @@ param workloadProfiles array = [
   }
 ]
 
-@description('The environment for the deployment')
-param environment string
-
-// Only set workload profiles for test and yt01 environments
-var shouldSetWorkloadProfiles = environment == 'yt01' || environment == 'test'
-
 resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
   name: appInsightWorkspaceName
 }
@@ -72,7 +66,7 @@ resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-10-02-preview' 
         destinations: ['appInsights']
       }
     }
-    workloadProfiles: shouldSetWorkloadProfiles ? workloadProfiles : []
+    workloadProfiles: workloadProfiles
     zoneRedundant: zoneRedundancyEnabled
     availabilityZones: zoneRedundancyEnabled ? ['1', '2', '3'] : null
   }

--- a/.azure/modules/containerAppJob/main.bicep
+++ b/.azure/modules/containerAppJob/main.bicep
@@ -32,14 +32,8 @@ param userAssignedIdentityId string
 @description('The replica timeout for the job in seconds')
 param replicaTimeOutInSeconds int
 
-@description('The environment for the deployment')
-param environment string
-
 @description('The workload profile to use for the job')
 param workloadProfileName string = 'Consumption'
-
-// Only set workload profile for test and yt01 environments
-var shouldSetWorkloadProfile = environment == 'yt01' || environment == 'test'
 
 var isScheduled = !empty(cronExpression)
 
@@ -81,7 +75,7 @@ resource job 'Microsoft.App/jobs@2024-03-01' = {
       isScheduled ? scheduledJobProperties : manualJobProperties
     )
     environmentId: containerAppEnvId
-    workloadProfileName: shouldSetWorkloadProfile ? workloadProfileName : null
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Removing the temporary code that enabled workload profiles for `test` and `yt01` only. Need to recreate the CAE in `staging` and `prod` for this. 

## Related Issue(s)

- #2257

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
