### PR TITLE
fix: Fix TokenIssuerCache initialization semaphore

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/Common/Authentication/TokenIssuerCache.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Common/Authentication/TokenIssuerCache.cs
@@ -35,12 +35,20 @@ public sealed class TokenIssuerCache : ITokenIssuerCache, IDisposable
 
     private async Task EnsureInitializedAsync()
     {
-        if (_initialized) return;
+        if (_initialized)
+        {
+            return;
+        }
+
         await _initializationSemaphore.WaitAsync();
-        if (_initialized) return;
 
         try
         {
+            if (_initialized)
+            {
+                return;
+            }
+
             foreach (var schema in _jwtTokenSchemas)
             {
                 var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/TokenIssuerCache.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/TokenIssuerCache.cs
@@ -48,13 +48,13 @@ public sealed class TokenIssuerCache : ITokenIssuerCache, IDisposable
 
         await _initializationSemaphore.WaitAsync();
 
-        if (_initialized)
-        {
-            return;
-        }
-
         try
         {
+            if (_initialized)
+            {
+                return;
+            }
+
             foreach (var schema in _jwtTokenSchemas)
             {
                 var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/TokenIssuerCacheTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/TokenIssuerCacheTests.cs
@@ -1,8 +1,8 @@
-using Digdir.Domain.Dialogporten.WebApi.Common;
-using Digdir.Domain.Dialogporten.WebApi.Common.Authentication;
+using Digdir.Domain.Dialogporten.GraphQL.Common;
+using Digdir.Domain.Dialogporten.GraphQL.Common.Authentication;
 using Microsoft.Extensions.Options;
 
-namespace Digdir.Domain.Dialogporten.WebApi.Unit.Tests;
+namespace Digdir.Domain.Dialogporten.GraphQl.Unit.Tests;
 
 public class TokenIssuerCacheTests
 {
@@ -10,7 +10,7 @@ public class TokenIssuerCacheTests
     public async Task EnsureInitializedAsync_Should_Not_Deadlock_When_Called_Concurrently()
     {
         // Arrange
-        var settings = new WebApiSettings
+        var settings = new GraphQlSettings
         {
             Authentication = new AuthenticationOptions
             {

--- a/tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests/TokenIssuerCacheTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests/TokenIssuerCacheTests.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using Digdir.Domain.Dialogporten.WebApi.Common;
+using Digdir.Domain.Dialogporten.WebApi.Common.Authentication;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Unit.Tests;
+
+public class TokenIssuerCacheTests
+{
+    [Fact]
+    public async Task EnsureInitializedAsync_Should_Not_Deadlock_When_Called_Concurrently()
+    {
+        // Arrange
+        var settings = new WebApiSettings
+        {
+            Authentication = new AuthenticationOptions
+            {
+                JwtBearerTokenSchemas = new List<JwtBearerTokenSchemasOptions>()
+            }
+        };
+        var cache = new TokenIssuerCache(Options.Create(settings));
+
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => cache.GetIssuerForScheme("test"));
+
+        // Act
+        var allTasks = Task.WhenAll(tasks);
+        var completed = await Task.WhenAny(allTasks, Task.Delay(TimeSpan.FromSeconds(1)));
+
+        // Assert
+        Assert.Same(allTasks, completed);
+        await allTasks; // propagate exceptions if any
+
+        cache.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- fix semaphore release when returning early from TokenIssuerCache initialization
- add unit test ensuring concurrent calls don't deadlock

## Testing
- `dotnet build tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests.csproj -c Release --verbosity minimal`
- `dotnet test tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests.csproj -c Release --no-build --verbosity minimal`