### PR TITLE
feat: Add partyUuid to parties endpoint DTO

### DIFF
--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -70,6 +70,7 @@ type AuthorizedParty {
   hasOnlyAccessToSubParties: Boolean!
   subParties: [AuthorizedSubParty!]
   party: String!
+  partyUuid: UUID!
   name: String!
   partyType: String!
   isDeleted: Boolean!
@@ -81,6 +82,7 @@ type AuthorizedParty {
 
 type AuthorizedSubParty {
   party: String!
+  partyUuid: UUID!
   name: String!
   partyType: String!
   isDeleted: Boolean!

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -1856,6 +1856,11 @@
             "example": "urn:altinn:organization:identifier-no:912345678",
             "type": "string"
           },
+          "partyUuid": {
+            "description": "The UUID for the party",
+            "type": "string",
+            "format": "uuid"
+          },
           "partyType": {
             "description": "The type of the party, either \u0022Organization\u0022 or \u0022Person\u0022.",
             "example": "Organization",

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -1856,14 +1856,14 @@
             "example": "urn:altinn:organization:identifier-no:912345678",
             "type": "string"
           },
-          "partyUuid": {
-            "description": "The UUID for the party",
-            "type": "string",
-            "format": "uuid"
-          },
           "partyType": {
             "description": "The type of the party, either \u0022Organization\u0022 or \u0022Person\u0022.",
             "example": "Organization",
+            "type": "string"
+          },
+          "partyUuid": {
+            "description": "The UUID for the party.",
+            "format": "guid",
             "type": "string"
           },
           "subParties": {

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/AuthorizedPartiesResult.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/AuthorizedPartiesResult.cs
@@ -8,6 +8,7 @@ public sealed class AuthorizedPartiesResult
 public sealed class AuthorizedParty
 {
     public string Party { get; init; } = null!;
+    public Guid PartyUuid { get; init; }
     public string Name { get; init; } = null!;
     public AuthorizedPartyType PartyType { get; init; }
     public bool IsDeleted { get; init; }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Parties/Queries/Get/PartiesDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Parties/Queries/Get/PartiesDto.cs
@@ -14,6 +14,11 @@ public sealed class AuthorizedPartyDto
     public string Party { get; init; } = null!;
 
     /// <summary>
+    /// The UUID for the party.
+    /// </summary>
+    public Guid PartyUuid { get; init; }
+
+    /// <summary>
     /// The name of the party (verbatim from CCR, usually in all caps)
     /// </summary>
     /// <example>CONTOSO REAL ESTATE AS</example>

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/Parties/ObjectTypes.cs
@@ -3,6 +3,7 @@ namespace Digdir.Domain.Dialogporten.GraphQL.EndUser.Parties;
 public class AuthorizedPartyBase
 {
     public string Party { get; init; } = null!;
+    public Guid PartyUuid { get; init; }
     public string Name { get; init; } = null!;
     public string PartyType { get; init; } = null!;
     public bool IsDeleted { get; init; }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesHelper.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesHelper.cs
@@ -40,6 +40,7 @@ internal static class AuthorizedPartiesHelper
         return new AuthorizedParty
         {
             Party = party,
+            PartyUuid = dto.PartyUuid,
             Name = dto.Name,
             PartyType = dto.Type switch
             {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesResultDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesResultDto.cs
@@ -6,6 +6,7 @@ internal sealed class AuthorizedPartiesResultDto
     public required string OrganizationNumber { get; set; }
     public string? PersonId { get; set; }
     public required int PartyId { get; set; }
+    public required Guid PartyUuid { get; set; }
     public required string Type { get; set; }
     public required bool IsDeleted { get; set; }
     public required bool OnlyHierarchyElementWithNoAccess { get; set; }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/LocalDevelopmentAltinnAuthorization.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/LocalDevelopmentAltinnAuthorization.cs
@@ -57,12 +57,14 @@ internal sealed class LocalDevelopmentAltinnAuthorization : IAltinnAuthorization
             {
                 Name = "Local Party",
                 Party = authenticatedParty.FullId,
+                PartyUuid = Guid.NewGuid(),
                 IsCurrentEndUser = true,
                 SubParties = [
                     new()
                     {
                         Name = "Local Sub Party",
                         Party = NorwegianOrganizationIdentifier.PrefixWithSeparator + "123456789",
+                        PartyUuid = Guid.NewGuid(),
                         IsCurrentEndUser = true
                     }
                 ]


### PR DESCRIPTION
## Summary
- extend AuthorizedParty data structures with `PartyUuid`
- expose `partyUuid` in the end user parties API documentation and GraphQL schema
- include UUIDs in local development stub data

## Testing
- `dotnet test --no-build --configuration Release` *(fails: The argument <path>.dll is invalid)*