### PR TITLE
Fix typo in OAuth endpoint documentation

### DIFF
--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -4919,7 +4919,7 @@
   "paths": {
     "/api/v1/.well-known/jwks.json": {
       "get": {
-        "description": "This endpoint can be used by client integrations supporting automatic discovery of \u0022OAuth 2.0 Authorization Server\u0022 metadata, enabling verification of dialog tokens issues by Dialogporten.",
+        "description": "This endpoint can be used by client integrations supporting automatic discovery of \u0022OAuth 2.0 Authorization Server\u0022 metadata, enabling verification of dialog tokens issued by Dialogporten.",
         "operationId": "V1WellKnownJwksGet_Jwks",
         "responses": {
           "200": {
@@ -4941,7 +4941,7 @@
     },
     "/api/v1/.well-known/oauth-authorization-server": {
       "get": {
-        "description": "This endpoint can be used by client integrations supporting automatic discovery of \u0022OAuth 2.0 Authorization Server\u0022 metadata, enabling verification of dialog tokens issues by Dialogporten.",
+        "description": "This endpoint can be used by client integrations supporting automatic discovery of \u0022OAuth 2.0 Authorization Server\u0022 metadata, enabling verification of dialog tokens issued by Dialogporten.",
         "operationId": "V1WellKnownOauthAuthorizationServerGet_OauthAuthorizationServer",
         "responses": {
           "200": {

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/WellKnown/Jwks/Get/GetJwksEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/WellKnown/Jwks/Get/GetJwksEndpointSummary.cs
@@ -8,7 +8,7 @@ public sealed class GetJwksEndpointSummary : Summary<GetJwksEndpoint>
     {
         Summary = "Gets the JSON Web Key Set (JWKS) containing the public keys used to verify dialog token signatures";
         Description = """
-                      This endpoint can be used by client integrations supporting automatic discovery of "OAuth 2.0 Authorization Server" metadata, enabling verification of dialog tokens issues by Dialogporten.
+                      This endpoint can be used by client integrations supporting automatic discovery of "OAuth 2.0 Authorization Server" metadata, enabling verification of dialog tokens issued by Dialogporten.
                       """;
         Responses[StatusCodes.Status200OK] = "The OAuth 2.0 Authorization Server Metadata";
     }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/WellKnown/OauthAuthorizationServer/Get/GetOauthAuthorizationServerEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/WellKnown/OauthAuthorizationServer/Get/GetOauthAuthorizationServerEndpointSummary.cs
@@ -8,7 +8,7 @@ public sealed class GetOauthAuthorizationServerEndpointSummary : Summary<GetOaut
     {
         Summary = "Gets the OAuth 2.0 Metadata for automatic configuration of clients verifying dialog tokens";
         Description = """
-                      This endpoint can be used by client integrations supporting automatic discovery of "OAuth 2.0 Authorization Server" metadata, enabling verification of dialog tokens issues by Dialogporten.
+                      This endpoint can be used by client integrations supporting automatic discovery of "OAuth 2.0 Authorization Server" metadata, enabling verification of dialog tokens issued by Dialogporten.
                       """;
         Responses[StatusCodes.Status200OK] = "The OAuth 2.0 Authorization Server Metadata";
     }


### PR DESCRIPTION
## Summary
- correct 'issues' -> 'issued' in OAuth Authorization Server and JWKS endpoint summaries
- update swagger snapshot to reflect new description

## Testing
- `dotnet test` *(fails: many tests)*
