### PR TITLE
feat(validation): enforce unique bulk-set dialog ids

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogSystemLabels/Commands/BulkSet/BulkSetDialogSystemLabelCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogSystemLabels/Commands/BulkSet/BulkSetDialogSystemLabelCommandValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
 using FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.DialogSystemLabels.Commands.BulkSet;
 
@@ -12,7 +13,8 @@ public sealed class BulkSetSystemLabelCommandValidator : AbstractValidator<BulkS
         RuleFor(x => x.Dto.Dialogs)
             .NotNull()
             .Must(x => x.Count is > 0 and <= MaxDialogsPerRequest)
-            .WithMessage($"Must supply between 1 and {MaxDialogsPerRequest} dialogs to update");
+            .WithMessage($"Must supply between 1 and {MaxDialogsPerRequest} dialogs to update")
+            .UniqueBy(x => x.DialogId);
 
         RuleFor(x => x.Dto.SystemLabels)
             .NotNull()

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogSystemLabels/Commands/BulkSet/BulkSetSystemLabelCommandValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogSystemLabels/Commands/BulkSet/BulkSetSystemLabelCommandValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogSystemLabels.Commands.BulkSet;
 
@@ -15,7 +16,8 @@ public sealed class BulkSetSystemLabelCommandValidator : AbstractValidator<BulkS
         RuleFor(x => x.Dto.Dialogs)
             .NotNull()
             .Must(x => x.Count is > 0 and <= MaxDialogsPerRequest)
-            .WithMessage($"Must supply between 1 and {MaxDialogsPerRequest} dialogs to update");
+            .WithMessage($"Must supply between 1 and {MaxDialogsPerRequest} dialogs to update")
+            .UniqueBy(x => x.DialogId);
 
         RuleFor(x => x.Dto.SystemLabels)
             .NotNull()

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/EndUser/DialogSystemLabels/Commands/BulkSet/BulkSetSystemLabelCommandValidatorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/EndUser/DialogSystemLabels/Commands/BulkSet/BulkSetSystemLabelCommandValidatorTests.cs
@@ -1,0 +1,56 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.DialogSystemLabels.Commands.BulkSet;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.SystemLabels;
+using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
+using Xunit;
+
+namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Features.V1.EndUser.DialogSystemLabels.Commands.BulkSet;
+
+public class BulkSetSystemLabelCommandValidatorTests
+{
+    private readonly BulkSetSystemLabelCommandValidator _validator = new();
+
+    [Fact]
+    public void Unique_DialogIds_Should_Be_Valid()
+    {
+        var command = new BulkSetSystemLabelCommand
+        {
+            Dto = new BulkSetSystemLabelDto
+            {
+                Dialogs = new[]
+                {
+                    new DialogRevisionDto { DialogId = Guid.NewGuid() },
+                    new DialogRevisionDto { DialogId = Guid.NewGuid() }
+                },
+                SystemLabels = new[] { SystemLabel.Values.Archive }
+            }
+        };
+
+        var result = _validator.Validate(command);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Duplicate_DialogIds_Should_Return_Error()
+    {
+        var id = Guid.NewGuid();
+        var command = new BulkSetSystemLabelCommand
+        {
+            Dto = new BulkSetSystemLabelDto
+            {
+                Dialogs = new[]
+                {
+                    new DialogRevisionDto { DialogId = id },
+                    new DialogRevisionDto { DialogId = id }
+                },
+                SystemLabels = new[] { SystemLabel.Values.Archive }
+            }
+        };
+
+        var result = _validator.Validate(command);
+
+        Assert.False(result.IsValid);
+        Assert.Single(result.Errors);
+        Assert.Contains(id.ToString(), result.Errors[0].ErrorMessage);
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/DialogSystemLabels/Commands/BulkSet/BulkSetSystemLabelCommandValidatorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/DialogSystemLabels/Commands/BulkSet/BulkSetSystemLabelCommandValidatorTests.cs
@@ -1,0 +1,58 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogSystemLabels.Commands.BulkSet;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.SystemLabels;
+using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
+using Xunit;
+
+namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Features.V1.ServiceOwner.DialogSystemLabels.Commands.BulkSet;
+
+public class BulkSetSystemLabelCommandValidatorTests
+{
+    private readonly BulkSetSystemLabelCommandValidator _validator = new();
+
+    [Fact]
+    public void Unique_DialogIds_Should_Be_Valid()
+    {
+        var command = new BulkSetSystemLabelCommand
+        {
+            EnduserId = "01017512345",
+            Dto = new BulkSetSystemLabelDto
+            {
+                Dialogs = new[]
+                {
+                    new DialogRevisionDto { DialogId = Guid.NewGuid() },
+                    new DialogRevisionDto { DialogId = Guid.NewGuid() }
+                },
+                SystemLabels = new[] { SystemLabel.Values.Archive }
+            }
+        };
+
+        var result = _validator.Validate(command);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Duplicate_DialogIds_Should_Return_Error()
+    {
+        var id = Guid.NewGuid();
+        var command = new BulkSetSystemLabelCommand
+        {
+            EnduserId = "01017512345",
+            Dto = new BulkSetSystemLabelDto
+            {
+                Dialogs = new[]
+                {
+                    new DialogRevisionDto { DialogId = id },
+                    new DialogRevisionDto { DialogId = id }
+                },
+                SystemLabels = new[] { SystemLabel.Values.Archive }
+            }
+        };
+
+        var result = _validator.Validate(command);
+
+        Assert.False(result.IsValid);
+        Assert.Single(result.Errors);
+        Assert.Contains(id.ToString(), result.Errors[0].ErrorMessage);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce unique `DialogId` values in bulk set validators
- add unit tests for duplicate `DialogId`s

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln -v minimal`
- `dotnet test Digdir.Domain.Dialogporten.sln --no-build --logger "trx;LogFileName=TestResults.trx"` *(fails: several integration tests fail)*