### PR TITLE
test(serviceowner): add system label command tests

### DIFF
--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/DialogSystemLabels/BulkSetDialogSystemLabelTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/DialogSystemLabels/BulkSetDialogSystemLabelTests.cs
@@ -1,0 +1,93 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.SystemLabels;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogSystemLabels.Commands.BulkSet;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Create;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.ServiceOwner.DialogSystemLabels;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class BulkSetDialogSystemLabelTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    [Fact]
+    public async Task BulkSet_Updates_System_Labels()
+    {
+        var cmd1 = DialogGenerator.GenerateSimpleFakeCreateDialogCommand();
+        var cmd2 = DialogGenerator.GenerateSimpleFakeCreateDialogCommand();
+        var res1 = await Application.Send(cmd1);
+        var res2 = await Application.Send(cmd2);
+
+        var command = new BulkSetSystemLabelCommand
+        {
+            EnduserId = cmd1.Dto.Party,
+            Dto = new BulkSetSystemLabelDto
+            {
+                Dialogs = new[]
+                {
+                    new DialogRevisionDto { DialogId = res1.AsT0.DialogId },
+                    new DialogRevisionDto { DialogId = res2.AsT0.DialogId }
+                },
+                SystemLabels = new[] { SystemLabel.Values.Bin }
+            }
+        };
+
+        var result = await Application.Send(command);
+        result.TryPickT0(out _, out _).Should().BeTrue();
+
+        var get1 = await Application.Send(new GetDialogQuery { DialogId = res1.AsT0.DialogId });
+        get1.AsT0.SystemLabel.Should().Be(SystemLabel.Values.Bin);
+        var get2 = await Application.Send(new GetDialogQuery { DialogId = res2.AsT0.DialogId });
+        get2.AsT0.SystemLabel.Should().Be(SystemLabel.Values.Bin);
+    }
+
+    [Fact]
+    public async Task BulkSet_Returns_Forbidden_For_Invalid_Id()
+    {
+        var cmd = DialogGenerator.GenerateSimpleFakeCreateDialogCommand();
+        var res = await Application.Send(cmd);
+
+        var command = new BulkSetSystemLabelCommand
+        {
+            EnduserId = cmd.Dto.Party,
+            Dto = new BulkSetSystemLabelDto
+            {
+                Dialogs = new[]
+                {
+                    new DialogRevisionDto { DialogId = res.AsT0.DialogId },
+                    new DialogRevisionDto { DialogId = Guid.NewGuid() }
+                },
+                SystemLabels = new[] { SystemLabel.Values.Bin }
+            }
+        };
+
+        var result = await Application.Send(command);
+        result.TryPickT1(out var forbidden, out _).Should().BeTrue();
+        forbidden.Reasons.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task BulkSet_Returns_ConcurrencyError_On_Revision_Mismatch()
+    {
+        var cmd = DialogGenerator.GenerateSimpleFakeCreateDialogCommand();
+        var res = await Application.Send(cmd);
+
+        var command = new BulkSetSystemLabelCommand
+        {
+            EnduserId = cmd.Dto.Party,
+            Dto = new BulkSetSystemLabelDto
+            {
+                Dialogs = new[]
+                {
+                    new DialogRevisionDto { DialogId = res.AsT0.DialogId, EnduserContextRevision = Guid.NewGuid() }
+                },
+                SystemLabels = new[] { SystemLabel.Values.Bin }
+            }
+        };
+
+        var result = await Application.Send(command);
+        result.TryPickT4(out _, out _).Should().BeTrue();
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/DialogSystemLabels/SetDialogSystemLabelTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/DialogSystemLabels/SetDialogSystemLabelTests.cs
@@ -1,0 +1,34 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.SystemLabels;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogSystemLabels.Commands.Set;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Create;
+using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.ServiceOwner.DialogSystemLabels;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class SetDialogSystemLabelTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    [Fact]
+    public async Task Set_Updates_System_Label()
+    {
+        var createCommand = DialogGenerator.GenerateSimpleFakeCreateDialogCommand();
+        var create = await Application.Send(createCommand);
+
+        var command = new SetSystemLabelCommand
+        {
+            DialogId = create.AsT0.DialogId,
+            EnduserId = createCommand.Dto.Party,
+            SystemLabels = new[] { SystemLabel.Values.Bin }
+        };
+
+        var result = await Application.Send(command);
+        result.TryPickT0(out _, out _).Should().BeTrue();
+
+        var get = await Application.Send(new GetDialogQuery { DialogId = create.AsT0.DialogId });
+        get.AsT0.SystemLabel.Should().Be(SystemLabel.Values.Bin);
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/DialogSystemLabels/Commands/BulkSetSystemLabelCommandValidatorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/DialogSystemLabels/Commands/BulkSetSystemLabelCommandValidatorTests.cs
@@ -1,0 +1,48 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.SystemLabels;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogSystemLabels.Commands.BulkSet;
+using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Features.V1.ServiceOwner.DialogSystemLabels.Commands;
+
+public class BulkSetSystemLabelCommandValidatorTests
+{
+    [Fact]
+    public void Rejects_Multiple_System_Labels()
+    {
+        var command = new BulkSetSystemLabelCommand
+        {
+            EnduserId = "urn:altinn:person:identifier-no:01020312345",
+            Dto = new BulkSetSystemLabelDto
+            {
+                Dialogs = new[] { new DialogRevisionDto { DialogId = Guid.NewGuid() } },
+                SystemLabels = new[] { SystemLabel.Values.Bin, SystemLabel.Values.Archive }
+            }
+        };
+
+        var validator = new BulkSetSystemLabelCommandValidator();
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.ErrorMessage.Contains("Only one system label"));
+    }
+
+    [Fact]
+    public void Accepts_Single_System_Label()
+    {
+        var command = new BulkSetSystemLabelCommand
+        {
+            EnduserId = "urn:altinn:person:identifier-no:01020312345",
+            Dto = new BulkSetSystemLabelDto
+            {
+                Dialogs = new[] { new DialogRevisionDto { DialogId = Guid.NewGuid() } },
+                SystemLabels = new[] { SystemLabel.Values.Bin }
+            }
+        };
+
+        var validator = new BulkSetSystemLabelCommandValidator();
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/DialogSystemLabels/Commands/SetSystemLabelCommandValidatorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/DialogSystemLabels/Commands/SetSystemLabelCommandValidatorTests.cs
@@ -1,0 +1,39 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.DialogSystemLabels.Commands.Set;
+using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Features.V1.ServiceOwner.DialogSystemLabels.Commands;
+
+public class SetSystemLabelCommandValidatorTests
+{
+    [Fact]
+    public void Rejects_Multiple_System_Labels()
+    {
+        var command = new SetSystemLabelCommand
+        {
+            EnduserId = "urn:altinn:person:identifier-no:01020312345",
+            SystemLabels = new[] { SystemLabel.Values.Bin, SystemLabel.Values.Archive }
+        };
+
+        var validator = new SetDialogSystemLabelCommandValidator();
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.ErrorMessage.Contains("Only one system label"));
+    }
+
+    [Fact]
+    public void Accepts_Single_System_Label()
+    {
+        var command = new SetSystemLabelCommand
+        {
+            EnduserId = "urn:altinn:person:identifier-no:01020312345",
+            SystemLabels = new[] { SystemLabel.Values.Bin }
+        };
+
+        var validator = new SetDialogSystemLabelCommandValidator();
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- add validator tests for Set and BulkSet system label commands
- add integration tests for new bulk set endpoint and single-set endpoint

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln -c Release`
- `dotnet test Digdir.Domain.Dialogporten.sln -c Release` *(fails: unable to run integration tests)*