### PR TITLE
feat(search): expose enduser context revision

### DIFF
--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -227,6 +227,7 @@ type SearchContent {
 type SearchDialog {
   id: UUID!
   org: String!
+  enduserContextRevision: UUID!
   serviceResource: String!
   serviceResourceType: String!
   party: String!

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -1332,6 +1332,11 @@
             "nullable": true,
             "type": "string"
           },
+          "enduserContextRevision": {
+            "description": "The unique identifier for the end user context revision in UUIDv4 format.",
+            "format": "guid",
+            "type": "string"
+          },
           "extendedStatus": {
             "description": "Arbitrary string with a service-specific indicator of status, typically used to indicate a fine-grained state of\nthe dialog to further specify the \u0022status\u0022 enum.\n            \nRefer to the service-specific documentation provided by the service owner for details on the possible values (if\nin use).",
             "nullable": true,
@@ -4307,6 +4312,11 @@
             "example": "2022-12-31T23:59:59Z",
             "format": "date-time",
             "nullable": true,
+            "type": "string"
+          },
+          "enduserContextRevision": {
+            "description": "The unique identifier for the end user context revision in UUIDv4 format.",
+            "format": "guid",
             "type": "string"
           },
           "extendedStatus": {

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/DialogDtoBase.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/DialogDtoBase.cs
@@ -21,6 +21,11 @@ public class DialogDtoBase
     public string Org { get; set; } = null!;
 
     /// <summary>
+    /// The unique identifier for the end user context revision in UUIDv4 format.
+    /// </summary>
+    public Guid EnduserContextRevision { get; set; }
+
+    /// <summary>
     /// The service identifier for the service that the dialog is related to in URN-format.
     /// This corresponds to a service resource in the Altinn Resource Registry.
     /// </summary>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/MappingProfile.cs
@@ -27,7 +27,8 @@ internal sealed class MappingProfile : Profile
                     .Any(url => url.ConsumerTypeId == AttachmentUrlConsumerType.Values.Gui))))
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content.Where(x => x.Type.OutputInList)))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
-            .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId));
+            .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId))
+            .ForMember(dest => dest.EnduserContextRevision, opt => opt.MapFrom(src => src.DialogEndUserContext.Revision));
 
         CreateMap<DialogSeenLog, DialogSeenLogDto>()
             .ForMember(dest => dest.SeenAt, opt => opt.MapFrom(src => src.CreatedAt));

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDtoBase.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDtoBase.cs
@@ -27,6 +27,11 @@ public class DialogDtoBase
     public Guid Revision { get; set; }
 
     /// <summary>
+    /// The unique identifier for the end user context revision in UUIDv4 format.
+    /// </summary>
+    public Guid EnduserContextRevision { get; set; }
+
+    /// <summary>
     /// The service identifier for the service that the dialog is related to in URN-format.
     /// This corresponds to a service resource in the Altinn Resource Registry.
     /// </summary>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
@@ -27,7 +27,8 @@ internal sealed class MappingProfile : Profile
                     .Any(url => url.ConsumerTypeId == AttachmentUrlConsumerType.Values.Gui))))
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content.Where(x => x.Type.OutputInList)))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
-            .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId));
+            .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId))
+            .ForMember(dest => dest.EnduserContextRevision, opt => opt.MapFrom(src => src.DialogEndUserContext.Revision));
 
         CreateMap<DialogSeenLog, DialogSeenLogDto>()
             .ForMember(dest => dest.SeenAt, opt => opt.MapFrom(src => src.CreatedAt));

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/SearchDialogs/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/SearchDialogs/MappingProfile.cs
@@ -19,6 +19,7 @@ public sealed class MappingProfile : Profile
 
         CreateMap<ContentDto, SearchContent>();
 
-        CreateMap<DialogDto, SearchDialog>();
+        CreateMap<DialogDto, SearchDialog>()
+            .ForMember(dest => dest.EnduserContextRevision, opt => opt.MapFrom(src => src.EnduserContextRevision));
     }
 }

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/SearchDialogs/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/SearchDialogs/ObjectTypes.cs
@@ -54,6 +54,7 @@ public sealed class SearchDialog
 {
     public Guid Id { get; set; }
     public string Org { get; set; } = null!;
+    public Guid EnduserContextRevision { get; set; }
     public string ServiceResource { get; set; } = null!;
     public string ServiceResourceType { get; set; } = null!;
     public string Party { get; set; } = null!;

--- a/src/Digdir.Library.Dialogporten.WebApiClient/Features/V1/RefitterInterface.cs
+++ b/src/Digdir.Library.Dialogporten.WebApiClient/Features/V1/RefitterInterface.cs
@@ -2493,6 +2493,13 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         public System.Guid Revision { get; set; }
 
         /// <summary>
+        /// The unique identifier for the end user context revision in UUIDv4 format.
+        /// </summary>
+
+        [JsonPropertyName("enduserContextRevision")]
+        public System.Guid EnduserContextRevision { get; set; }
+
+        /// <summary>
         /// The service identifier for the service that the dialog is related to in URN-format.
         /// <br/>This corresponds to a service resource in the Altinn Resource Registry.
         /// </summary>

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Search/EnduserContextRevisionTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Search/EnduserContextRevisionTests.cs
@@ -1,0 +1,26 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Search;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.EndUser.Dialogs.Queries.Search;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class EnduserContextRevisionTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    [Fact]
+    public async Task Search_Should_Populate_EnduserContextRevision()
+    {
+        var createCmd = DialogGenerator.GenerateSimpleFakeCreateDialogCommand();
+        var createRes = await Application.Send(createCmd);
+
+        var response = await Application.Send(new SearchDialogQuery
+        {
+            Party = [createCmd.Dto.Party]
+        });
+
+        response.TryPickT0(out var result, out _).Should().BeTrue();
+        var dialog = result.Items.Single(x => x.Id == createRes.AsT0.DialogId);
+        dialog.EnduserContextRevision.Should().NotBeEmpty();
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Search/EnduserContextRevisionTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Search/EnduserContextRevisionTests.cs
@@ -1,0 +1,26 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Search;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.ServiceOwner.Dialogs.Queries.Search;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class EnduserContextRevisionTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    [Fact]
+    public async Task Search_Should_Populate_EnduserContextRevision()
+    {
+        var createCmd = DialogGenerator.GenerateSimpleFakeCreateDialogCommand();
+        var createRes = await Application.Send(createCmd);
+
+        var response = await Application.Send(new SearchDialogQuery
+        {
+            ServiceResource = [createCmd.Dto.ServiceResource]
+        });
+
+        response.TryPickT0(out var result, out _).Should().BeTrue();
+        var dialog = result.Items.Single(x => x.Id == createRes.AsT0.DialogId);
+        dialog.EnduserContextRevision.Should().NotBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- include EnduserContextRevision in search DTOs
- map EnduserContextRevision from domain
- expose via GraphQL and update refit client
- update API schemas
- cover new field in integration tests

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln -c Release`
- `dotnet test Digdir.Domain.Dialogporten.sln -c Release` *(fails: many integration tests)*