### PR TITLE
test(enduser): validate single system label

### DIFF
--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/EndUser/DialogSystemLabels/Commands/BulkSet/BulkSetSystemLabelCommandValidatorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/EndUser/DialogSystemLabels/Commands/BulkSet/BulkSetSystemLabelCommandValidatorTests.cs
@@ -53,4 +53,23 @@ public class BulkSetSystemLabelCommandValidatorTests
         Assert.Single(result.Errors);
         Assert.Contains(id.ToString(), result.Errors[0].ErrorMessage);
     }
+
+    [Fact]
+    public void Multiple_System_Labels_Should_Return_Error()
+    {
+        var command = new BulkSetSystemLabelCommand
+        {
+            Dto = new BulkSetSystemLabelDto
+            {
+                Dialogs = new[] { new DialogRevisionDto { DialogId = Guid.NewGuid() } },
+                SystemLabels = new[] { SystemLabel.Values.Bin, SystemLabel.Values.Archive }
+            }
+        };
+
+        var result = _validator.Validate(command);
+
+        Assert.False(result.IsValid);
+        Assert.Single(result.Errors);
+        Assert.Contains("Only one system label", result.Errors[0].ErrorMessage);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure BulkSetSystemLabelCommand validator rejects multiple system labels for end users

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln`
- `dotnet test -c Release Digdir.Domain.Dialogporten.sln --filter 'FullyQualifiedName!~Integration'`