### PR TITLE
docs(api): add summaries for system label endpoints

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/DialogSystemLabels/BulkSet/BulkSetDialogSystemLabelsEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/DialogSystemLabels/BulkSet/BulkSetDialogSystemLabelsEndpointSummary.cs
@@ -1,0 +1,23 @@
+using Digdir.Domain.Dialogporten.WebApi.Common;
+using Digdir.Domain.Dialogporten.WebApi.Common.Extensions;
+using FastEndpoints;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.EndUser.DialogSystemLabels.BulkSet;
+
+public sealed class BulkSetDialogSystemLabelsEndpointSummary : Summary<BulkSetDialogSystemLabelsEndpoint>
+{
+    public BulkSetDialogSystemLabelsEndpointSummary()
+    {
+        Summary = "Sets system labels for multiple dialogs";
+        Description = """
+                      Sets the system label for a list of dialogs.
+                      """;
+
+        Responses[StatusCodes.Status204NoContent] = Constants.SwaggerSummary.Updated.FormatInvariant("system labels");
+        Responses[StatusCodes.Status400BadRequest] = Constants.SwaggerSummary.ValidationError;
+        Responses[StatusCodes.Status401Unauthorized] = Constants.SwaggerSummary.EndUserAuthenticationFailure;
+        Responses[StatusCodes.Status403Forbidden] = Constants.SwaggerSummary.AccessDeniedToDialog.FormatInvariant("update");
+        Responses[StatusCodes.Status412PreconditionFailed] = Constants.SwaggerSummary.RevisionMismatch;
+        Responses[StatusCodes.Status422UnprocessableEntity] = Constants.SwaggerSummary.DomainError;
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/DialogSystemLabels/Set/SetDialogSystemLabelEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/EndUser/DialogSystemLabels/Set/SetDialogSystemLabelEndpointSummary.cs
@@ -1,0 +1,29 @@
+using Digdir.Domain.Dialogporten.WebApi.Common;
+using Digdir.Domain.Dialogporten.WebApi.Common.Extensions;
+using Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.Common.Headers;
+using FastEndpoints;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.EndUser.DialogSystemLabels.Set;
+
+public sealed class SetDialogSystemLabelEndpointSummary : Summary<SetDialogSystemLabelEndpoint>
+{
+    public SetDialogSystemLabelEndpointSummary()
+    {
+        Summary = "Sets the system label of a dialog";
+        Description = $"""
+                       Sets the system label of the dialog.
+
+                       {Constants.SwaggerSummary.OptimisticConcurrencyNote}
+                       """;
+
+        ResponseHeaders = [HttpResponseHeaderExamples.NewDialogETagHeader(StatusCodes.Status204NoContent)];
+        Responses[StatusCodes.Status204NoContent] = Constants.SwaggerSummary.Updated.FormatInvariant("system label");
+        Responses[StatusCodes.Status400BadRequest] = Constants.SwaggerSummary.ValidationError;
+        Responses[StatusCodes.Status401Unauthorized] = Constants.SwaggerSummary.EndUserAuthenticationFailure;
+        Responses[StatusCodes.Status403Forbidden] = Constants.SwaggerSummary.AccessDeniedToDialog.FormatInvariant("update");
+        Responses[StatusCodes.Status404NotFound] = Constants.SwaggerSummary.DialogNotFound;
+        Responses[StatusCodes.Status410Gone] = Constants.SwaggerSummary.DialogDeleted;
+        Responses[StatusCodes.Status412PreconditionFailed] = Constants.SwaggerSummary.RevisionMismatch;
+        Responses[StatusCodes.Status422UnprocessableEntity] = Constants.SwaggerSummary.DomainError;
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSystemLabels/BulkSet/BulkSetDialogSystemLabelsEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSystemLabels/BulkSet/BulkSetDialogSystemLabelsEndpointSummary.cs
@@ -1,0 +1,24 @@
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
+using Digdir.Domain.Dialogporten.WebApi.Common.Extensions;
+using FastEndpoints;
+using Constants = Digdir.Domain.Dialogporten.WebApi.Common.Constants;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.ServiceOwner.DialogSystemLabels.BulkSet;
+
+public sealed class BulkSetDialogSystemLabelsEndpointSummary : Summary<BulkSetDialogSystemLabelsEndpoint>
+{
+    public BulkSetDialogSystemLabelsEndpointSummary()
+    {
+        Summary = "Sets system labels for multiple dialogs";
+        Description = """
+                      Sets the system label for a list of dialogs.
+                      """;
+
+        Responses[StatusCodes.Status204NoContent] = Constants.SwaggerSummary.Updated.FormatInvariant("system labels");
+        Responses[StatusCodes.Status400BadRequest] = Constants.SwaggerSummary.ValidationError;
+        Responses[StatusCodes.Status401Unauthorized] = Constants.SwaggerSummary.ServiceOwnerAuthenticationFailure.FormatInvariant(AuthorizationScope.ServiceProvider);
+        Responses[StatusCodes.Status403Forbidden] = Constants.SwaggerSummary.AccessDeniedToDialog.FormatInvariant("update");
+        Responses[StatusCodes.Status412PreconditionFailed] = Constants.SwaggerSummary.RevisionMismatch;
+        Responses[StatusCodes.Status422UnprocessableEntity] = Constants.SwaggerSummary.DomainError;
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSystemLabels/Set/SetDialogSystemLabelEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/ServiceOwner/DialogSystemLabels/Set/SetDialogSystemLabelEndpointSummary.cs
@@ -1,0 +1,30 @@
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
+using Digdir.Domain.Dialogporten.WebApi.Common.Extensions;
+using Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.Common.Headers;
+using FastEndpoints;
+using Constants = Digdir.Domain.Dialogporten.WebApi.Common.Constants;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.ServiceOwner.DialogSystemLabels.Set;
+
+public sealed class SetDialogSystemLabelEndpointSummary : Summary<SetDialogSystemLabelEndpoint>
+{
+    public SetDialogSystemLabelEndpointSummary()
+    {
+        Summary = "Sets the system label of a dialog";
+        Description = $"""
+                       Sets the system label of the dialog.
+
+                       {Constants.SwaggerSummary.OptimisticConcurrencyNote}
+                       """;
+
+        ResponseHeaders = [HttpResponseHeaderExamples.NewDialogETagHeader(StatusCodes.Status204NoContent)];
+        Responses[StatusCodes.Status204NoContent] = Constants.SwaggerSummary.Updated.FormatInvariant("system label");
+        Responses[StatusCodes.Status400BadRequest] = Constants.SwaggerSummary.ValidationError;
+        Responses[StatusCodes.Status401Unauthorized] = Constants.SwaggerSummary.ServiceOwnerAuthenticationFailure.FormatInvariant(AuthorizationScope.ServiceProvider);
+        Responses[StatusCodes.Status403Forbidden] = Constants.SwaggerSummary.AccessDeniedToDialog.FormatInvariant("update");
+        Responses[StatusCodes.Status404NotFound] = Constants.SwaggerSummary.DialogNotFound;
+        Responses[StatusCodes.Status410Gone] = Constants.SwaggerSummary.DialogDeleted;
+        Responses[StatusCodes.Status412PreconditionFailed] = Constants.SwaggerSummary.RevisionMismatch;
+        Responses[StatusCodes.Status422UnprocessableEntity] = Constants.SwaggerSummary.DomainError;
+    }
+}


### PR DESCRIPTION
## Summary
- document service owner bulk-set system labels endpoint
- document service owner set system label endpoint
- document end user bulk-set system labels endpoint
- document end user set system label endpoint

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*
