### PR TITLE
feat: add enduser context revision to get dialog

### DIFF
--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -688,6 +688,11 @@
             "nullable": true,
             "type": "string"
           },
+          "enduserContextRevision": {
+            "description": "The unique identifier for the end user context revision in UUIDv4 format.",
+            "format": "guid",
+            "type": "string"
+          },
           "expiresAt": {
             "description": "The expiration date for the dialog. This is the last date when the dialog is available for the end user.\n            \nAfter this date is passed, the dialog will be considered expired and no longer available for the end user in any\nAPI. If not supplied, the dialog will be considered to never expire. This field can be changed by the service\nowner after the dialog has been created.",
             "example": "2022-12-31T23:59:59Z",
@@ -3612,6 +3617,11 @@
             "example": "2022-12-31T23:59:59Z",
             "format": "date-time",
             "nullable": true,
+            "type": "string"
+          },
+          "enduserContextRevision": {
+            "description": "The unique identifier for the end user context revision in UUIDv4 format.",
+            "format": "guid",
             "type": "string"
           },
           "expiresAt": {

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/DialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/DialogDto.cs
@@ -26,6 +26,11 @@ public sealed class DialogDto
     public Guid Revision { get; set; }
 
     /// <summary>
+    /// The unique identifier for the end user context revision in UUIDv4 format.
+    /// </summary>
+    public Guid EnduserContextRevision { get; set; }
+
+    /// <summary>
     /// The service owner code representing the organization (service owner) related to this dialog.
     /// </summary>
     /// <example>ske</example>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/MappingProfile.cs
@@ -16,6 +16,7 @@ internal sealed class MappingProfile : Profile
     {
         CreateMap<DialogEntity, DialogDto>()
             .ForMember(dest => dest.Revision, opt => opt.MapFrom(src => src.Revision))
+            .ForMember(dest => dest.EnduserContextRevision, opt => opt.MapFrom(src => src.DialogEndUserContext.Revision))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
             .ForMember(dest => dest.SeenSinceLastUpdate, opt => opt.Ignore())
             .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId));

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/DialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/DialogDto.cs
@@ -31,6 +31,11 @@ public sealed class DialogDto
     public Guid Revision { get; set; }
 
     /// <summary>
+    /// The unique identifier for the end user context revision in UUIDv4 format.
+    /// </summary>
+    public Guid EnduserContextRevision { get; set; }
+
+    /// <summary>
     /// The service owner code representing the organization (service owner) related to this dialog.
     /// </summary>
     /// <example>ske</example>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/MappingProfile.cs
@@ -17,6 +17,7 @@ internal sealed class MappingProfile : Profile
     {
         CreateMap<DialogEntity, DialogDto>()
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
+            .ForMember(dest => dest.EnduserContextRevision, opt => opt.MapFrom(src => src.DialogEndUserContext.Revision))
             .ForMember(dest => dest.SeenSinceLastUpdate, opt => opt.Ignore())
             .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId));
 

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/MappingProfile.cs
@@ -9,7 +9,8 @@ public sealed class MappingProfile : Profile
     public MappingProfile()
     {
         CreateMap<DialogDto, Dialog>()
-            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status));
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status))
+            .ForMember(dest => dest.EnduserContextRevision, opt => opt.MapFrom(src => src.EnduserContextRevision));
 
         CreateMap<DialogAttachmentDto, Attachment>();
         CreateMap<DialogAttachmentUrlDto, AttachmentUrl>()

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/ObjectTypes.cs
@@ -39,6 +39,7 @@ public sealed class Dialog
 {
     public Guid Id { get; set; }
     public Guid Revision { get; set; }
+    public Guid EnduserContextRevision { get; set; }
     public string Org { get; set; } = null!;
     public string ServiceResource { get; set; } = null!;
     public string ServiceResourceType { get; set; } = null!;

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/EnduserContextRevisionTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/EnduserContextRevisionTests.cs
@@ -1,0 +1,22 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.EndUser.Dialogs.Queries.Get;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class EnduserContextRevisionTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    [Fact]
+    public async Task Get_Should_Populate_EnduserContextRevision()
+    {
+        var createCmd = DialogGenerator.GenerateSimpleFakeCreateDialogCommand();
+        var createRes = await Application.Send(createCmd);
+
+        var response = await Application.Send(new GetDialogQuery { DialogId = createRes.AsT0.DialogId });
+
+        response.TryPickT0(out var result, out _).Should().BeTrue();
+        result.EnduserContextRevision.Should().NotBeEmpty();
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Get/EnduserContextRevisionTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Get/EnduserContextRevisionTests.cs
@@ -1,0 +1,22 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.ServiceOwner.Dialogs.Queries.Get;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class EnduserContextRevisionTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    [Fact]
+    public async Task Get_Should_Populate_EnduserContextRevision()
+    {
+        var createCmd = DialogGenerator.GenerateSimpleFakeCreateDialogCommand();
+        var createRes = await Application.Send(createCmd);
+
+        var response = await Application.Send(new GetDialogQuery { DialogId = createRes.AsT0.DialogId });
+
+        response.TryPickT0(out var result, out _).Should().BeTrue();
+        result.EnduserContextRevision.Should().NotBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- expose EnduserContextRevision on get-single-dialog DTOs
- map revision in handlers and GraphQL
- test that EnduserContextRevision is present for both enduser and service owner
- update swagger spec

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln -c Release`
- `dotnet test Digdir.Domain.Dialogporten.sln -c Release --no-build --filter 'FullyQualifiedName!~Integration'`