### PR TITLE
trivial: Remove Content ordering on GetDialogQuery

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -56,7 +56,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
         // This is to ensure that the get is consistent, and that PATCH in the API presentation
         // layer behaviours in an expected manner. Therefore, we need to be a bit more verbose about it.
         var dialog = await _db.Dialogs
-            .Include(x => x.Content.OrderBy(x => x.Id).ThenBy(x => x.CreatedAt))
+            .Include(x => x.Content)
                 .ThenInclude(x => x.Value.Localizations.OrderBy(x => x.LanguageCode))
             .Include(x => x.Attachments.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
                 .ThenInclude(x => x.DisplayName!.Localizations.OrderBy(x => x.LanguageCode))


### PR DESCRIPTION
No need to order this. The list is mapped to properties on the outgoing DTO