### PR TITLE
test(e2e): update label setting tests

### DIFF
--- a/tests/k6/tests/enduser/dialogSystemLabelLog.js
+++ b/tests/k6/tests/enduser/dialogSystemLabelLog.js
@@ -17,7 +17,7 @@ export default function () {
 
     describe('Update label as enduser', () => {
         let body = {
-            'label': 'Bin'
+            'systemLabels': ['Bin']
         }
         let response = putEU('dialogs/' + dialogId + '/context/systemlabels', body);
         expectStatusFor(response).to.equal(204);
@@ -30,7 +30,7 @@ export default function () {
     describe('Changing labels trigger 2 logs', () => {
 
         let body = {
-            'label': 'archive'
+            'systemLabels': ['archive']
         }
         let response = putEU('dialogs/' + dialogId + '/context/systemlabels', body);
         expectStatusFor(response).to.equal(204);
@@ -40,10 +40,20 @@ export default function () {
         expect(response.json(), 'response body').to.have.lengthOf(3);
     })
 
+    describe('Multiple labels are rejected', () => {
+
+        let body = {
+            'systemLabels': ['Bin', 'Archive']
+        }
+
+        let response = putEU('dialogs/' + dialogId + '/context/systemlabels', body);
+        expectStatusFor(response).to.equal(400);
+    })
+
     describe('Invalid revision if-match header results in 412 Precondition Failed', () => {
 
         let body = {
-            'label': 'bin'
+            'systemLabels': ['bin']
         }
 
         let invalidRevision = uuidv4();

--- a/tests/k6/tests/serviceowner/all-tests.js
+++ b/tests/k6/tests/serviceowner/all-tests.js
@@ -14,6 +14,7 @@ import { default as dialogDetails } from './dialogDetails.js';
 import { default as dialogRestore } from './dialogRestore.js';
 import { default as dialogSearch } from './dialogSearch.js';
 import { default as dialogUpdateActivity } from './dialogUpdateActivity.js';
+import { default as dialogSystemLabels } from './dialogSystemLabels.js';
 
 export default function() {
   authentication();
@@ -31,4 +32,5 @@ export default function() {
   dialogRestore();
   dialogSearch();
   dialogUpdateActivity();
+  dialogSystemLabels();
 }

--- a/tests/k6/tests/serviceowner/dialogSystemLabels.js
+++ b/tests/k6/tests/serviceowner/dialogSystemLabels.js
@@ -1,0 +1,63 @@
+import {
+    describe,
+    expect,
+    expectStatusFor,
+    postSO,
+    putSO,
+    getSO,
+    purgeSO,
+    uuidv4
+} from '../../common/testimports.js'
+import { default as dialogToInsert } from './testdata/01-create-dialog.js'
+import { getDefaultEnduserSsn } from '../../common/token.js'
+
+export default function () {
+    let dialogId = null;
+    const enduserId = 'urn:altinn:person:identifier-no:' + getDefaultEnduserSsn();
+
+    describe('Create dialog', () => {
+        let r = postSO('dialogs', dialogToInsert());
+        expectStatusFor(r).to.equal(201);
+        dialogId = r.json();
+    });
+
+    describe('Update label as service owner', () => {
+        let body = {
+            'systemLabels': ['Bin']
+        }
+        let r = putSO(`dialogs/${dialogId}/endusercontext/systemlabels?enduserId=${enduserId}`, body);
+        expectStatusFor(r).to.equal(204);
+    });
+
+    describe('Verify dialog has updated label', () => {
+        let r = getSO(`dialogs/${dialogId}?endUserId=${enduserId}`);
+        expectStatusFor(r).to.equal(200);
+        expect(r.json()['systemLabel'], 'system label').to.equal('Bin');
+    });
+
+    describe('Reject multiple system labels', () => {
+        let body = {
+            'systemLabels': ['Bin', 'Archive']
+        }
+        let r = putSO(`dialogs/${dialogId}/endusercontext/systemlabels?enduserId=${enduserId}`, body);
+        expectStatusFor(r).to.equal(400);
+    });
+
+    describe('Invalid revision if-match header results in 412 Precondition Failed', () => {
+        let body = {
+            'systemLabels': ['Archive']
+        }
+        let params = {
+            headers: {
+                'If-Match': uuidv4()
+            }
+        }
+        let r = putSO(`dialogs/${dialogId}/endusercontext/systemlabels?enduserId=${enduserId}`, body, params);
+        expectStatusFor(r).to.equal(412);
+    });
+
+    describe('Cleanup', () => {
+        let r = purgeSO('dialogs/' + dialogId);
+        expectStatusFor(r).to.equal(204);
+    });
+}


### PR DESCRIPTION
## Summary
- update k6 enduser label tests to new `systemLabels` array
- cover invalid multi-label scenario
- add serviceowner label e2e test and wire into suite

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln -c Release`
- `dotnet test Digdir.Domain.Dialogporten.sln --no-build --filter 'FullyQualifiedName!~Integration' -c Release`