### PR TITLE
test(k6): add bulk API e2e tests

### DIFF
--- a/tests/k6/tests/enduser/all-tests.js
+++ b/tests/k6/tests/enduser/all-tests.js
@@ -2,11 +2,13 @@
 import { default as dialogDetails } from './dialogDetails.js';
 import { default as dialogSearch } from './dialogSearch.js';
 import { default as dialogSystemLabelLog } from './dialogSystemLabelLog.js';
+import { default as dialogBulkSystemLabels } from './dialogBulkSystemLabels.js';
 import { default as parties } from './parties.js';
 
 export default function() {
   dialogDetails();
   dialogSearch();
   dialogSystemLabelLog();
+  dialogBulkSystemLabels();
   parties();
 }

--- a/tests/k6/tests/enduser/dialogBulkSystemLabels.js
+++ b/tests/k6/tests/enduser/dialogBulkSystemLabels.js
@@ -1,0 +1,48 @@
+import { describe, expect, expectStatusFor, postSO, postEU, getEU, purgeSO, setParty } from '../../common/testimports.js'
+import { default as dialogToInsert } from '../serviceowner/testdata/01-create-dialog.js'
+import { defaultServiceOwnerOrgNo } from '../../common/config.js'
+
+export default function () {
+    const accessibleDialogs = [];
+    let forbiddenDialog = null;
+
+    describe('Create dialogs to bulk update', () => {
+        for (let i = 0; i < 2; i++) {
+            const r = postSO('dialogs', dialogToInsert());
+            expectStatusFor(r).to.equal(201);
+            accessibleDialogs.push(r.json());
+        }
+        const d = dialogToInsert();
+        setParty(d, 'urn:altinn:organization:identifier-no:' + defaultServiceOwnerOrgNo);
+        const r = postSO('dialogs', d);
+        expectStatusFor(r).to.equal(201);
+        forbiddenDialog = r.json();
+    });
+
+    describe('Bulk set labels for accessible dialogs', () => {
+        const body = { dialogs: accessibleDialogs.map(id => ({ dialogId: id })), systemLabels: ['Bin'] };
+        const r = postEU('dialogs/context/systemlabels/actions/bulkset', body);
+        expectStatusFor(r).to.equal(204);
+        accessibleDialogs.forEach(id => {
+            const r2 = getEU('dialogs/' + id);
+            expectStatusFor(r2).to.equal(200);
+            expect(r2.json()['systemLabel'], 'system label').to.equal('Bin');
+        });
+    });
+
+    describe('Bulk set containing unauthorized dialog returns 403', () => {
+        const body = {
+            dialogs: accessibleDialogs.concat([forbiddenDialog]).map(id => ({ dialogId: id })),
+            systemLabels: ['Archive']
+        };
+        const r = postEU('dialogs/context/systemlabels/actions/bulkset', body);
+        expectStatusFor(r).to.equal(403);
+    });
+
+    describe('Cleanup', () => {
+        accessibleDialogs.concat([forbiddenDialog]).forEach(id => {
+            const r = purgeSO('dialogs/' + id);
+            expectStatusFor(r).to.equal(204);
+        });
+    });
+}

--- a/tests/k6/tests/serviceowner/all-tests.js
+++ b/tests/k6/tests/serviceowner/all-tests.js
@@ -14,6 +14,7 @@ import { default as dialogDetails } from './dialogDetails.js';
 import { default as dialogRestore } from './dialogRestore.js';
 import { default as dialogSearch } from './dialogSearch.js';
 import { default as dialogSystemLabels } from './dialogSystemLabels.js';
+import { default as dialogBulkSystemLabels } from './dialogBulkSystemLabels.js';
 import { default as dialogUpdateActivity } from './dialogUpdateActivity.js';
 
 export default function() {
@@ -32,5 +33,6 @@ export default function() {
   dialogRestore();
   dialogSearch();
   dialogSystemLabels();
+  dialogBulkSystemLabels();
   dialogUpdateActivity();
 }

--- a/tests/k6/tests/serviceowner/dialogBulkSystemLabels.js
+++ b/tests/k6/tests/serviceowner/dialogBulkSystemLabels.js
@@ -1,0 +1,40 @@
+import { describe, expect, expectStatusFor, postSO, getSO, purgeSO } from '../../common/testimports.js'
+import { default as dialogToInsert } from './testdata/01-create-dialog.js'
+import { getDefaultEnduserSsn } from '../../common/token.js'
+
+export default function () {
+    const dialogIds = [];
+    const enduserId = 'urn:altinn:person:identifier-no:' + getDefaultEnduserSsn();
+
+    describe('Create dialogs for bulk update', () => {
+        for (let i = 0; i < 2; i++) {
+            const r = postSO('dialogs', dialogToInsert());
+            expectStatusFor(r).to.equal(201);
+            dialogIds.push(r.json());
+        }
+    });
+
+    describe('Bulk set system labels as service owner', () => {
+        const body = {
+            dialogs: dialogIds.map(id => ({ dialogId: id })),
+            systemLabels: ['Archive']
+        };
+        const r = postSO(`dialogs/endusercontext/systemlabels/actions/bulkset?enduserId=${enduserId}`, body);
+        expectStatusFor(r).to.equal(204);
+    });
+
+    describe('Verify dialogs have updated labels', () => {
+        dialogIds.forEach(id => {
+            const r = getSO(`dialogs/${id}?endUserId=${enduserId}`);
+            expectStatusFor(r).to.equal(200);
+            expect(r.json()['systemLabel'], 'system label').to.equal('Archive');
+        });
+    });
+
+    describe('Cleanup', () => {
+        dialogIds.forEach(id => {
+            const r = purgeSO('dialogs/' + id);
+            expectStatusFor(r).to.equal(204);
+        });
+    });
+}


### PR DESCRIPTION
## Summary
- add k6 tests for service owner bulk system label API
- add k6 tests for end user bulk system label API including unauthorized case

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln -c Release`
- `dotnet test Digdir.Domain.Dialogporten.sln --no-build --configuration Release --filter 'FullyQualifiedName!~Integration'`