### PR TITLE
trivial(forwarder): ensure script doesn't hang when new cli version is available

### DIFF
--- a/scripts/database-forwarder/forward.sh
+++ b/scripts/database-forwarder/forward.sh
@@ -9,6 +9,16 @@
 set -euo pipefail
 
 # =========================================================================
+# Azure CLI Configuration
+# =========================================================================
+# Disable Azure CLI auto-update checks and telemetry to prevent interactive prompts
+export AZURE_CORE_COLLECT_TELEMETRY=false
+export AZURE_CORE_NO_COLOR=true
+export AZURE_CORE_DISABLE_PROGRESS_BAR=true
+export AZURE_CORE_ONLY_SHOW_ERRORS=false
+export AZURE_CORE_DISABLE_UPGRADE_WARNINGS=yes
+
+# =========================================================================
 # Constants
 # =========================================================================
 readonly PRODUCT_TAG="Dialogporten"
@@ -145,6 +155,11 @@ Options:
 
     -h, --help           Show this help message
 
+Prerequisites:
+    - Azure CLI must be installed and you must be logged in
+    - If Azure CLI prompts for upgrades, the script will detect this and provide guidance
+    - You must have appropriate permissions for the target Azure subscription
+
 Examples:
     # Interactive mode (will prompt for all options)
     $0
@@ -156,6 +171,10 @@ Examples:
     # Connect to Redis in prod with custom local port
     $0 -e prod -t redis -p 6380
     $0 --environment prod --type redis --port 6380
+
+Troubleshooting:
+    If the script hangs or times out, it might be due to Azure CLI upgrade prompts.
+    Run 'az version' manually to resolve any pending prompts, then re-run this script.
 
 EOF
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

When there was any upgrade prompts for `az cli`, the script would hang on "Connecting to host ..."

Adding env variables to ensure it doesn't give any interactive prompts. 

## Related Issue(s)

- #N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
