### PR TITLE
chore(app): Disable FluentValidation language manager

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/ApplicationExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/ApplicationExtensions.cs
@@ -32,6 +32,10 @@ public static class ApplicationExtensions
         // display names without an added space.
         // 'CreatedAt', not 'Created At'.
         ValidatorOptions.Global.DisplayNameResolver = (_, member, _) => member?.Name;
+
+        // Disable FluentValidation localization
+        ValidatorOptions.Global.LanguageManager.Enabled = false;
+
         services
             // Framework
             .AddAutoMapper(thisAssembly)


### PR DESCRIPTION
Keeping validation errors in English, regardless of the local language