### PR TITLE
feat(search): expose service owner context revision

### DIFF
--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -4483,6 +4483,11 @@
           "serviceOwnerContext": {
             "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesSearch_DialogServiceOwnerContext"
           },
+          "serviceOwnerContextRevision": {
+            "description": "The unique identifier for the service owner context revision in UUIDv4 format.",
+            "format": "guid",
+            "type": "string"
+          },
           "serviceResource": {
             "description": "The service identifier for the service that the dialog is related to in URN-format.\nThis corresponds to a service resource in the Altinn Resource Registry.",
             "example": "urn:altinn:resource:some-service-identifier",

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDtoBase.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDtoBase.cs
@@ -32,6 +32,11 @@ public class DialogDtoBase
     public Guid EnduserContextRevision { get; set; }
 
     /// <summary>
+    /// The unique identifier for the service owner context revision in UUIDv4 format.
+    /// </summary>
+    public Guid ServiceOwnerContextRevision { get; set; }
+
+    /// <summary>
     /// The service identifier for the service that the dialog is related to in URN-format.
     /// This corresponds to a service resource in the Altinn Resource Registry.
     /// </summary>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
@@ -29,7 +29,8 @@ internal sealed class MappingProfile : Profile
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content.Where(x => x.Type.OutputInList)))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
             .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId))
-            .ForMember(dest => dest.EnduserContextRevision, opt => opt.MapFrom(src => src.DialogEndUserContext.Revision));
+            .ForMember(dest => dest.EnduserContextRevision, opt => opt.MapFrom(src => src.DialogEndUserContext.Revision))
+            .ForMember(dest => dest.ServiceOwnerContextRevision, opt => opt.MapFrom(src => src.ServiceOwnerContext.Revision));
 
         CreateMap<DialogServiceOwnerContext, DialogServiceOwnerContextDto>();
         CreateMap<DialogServiceOwnerLabel, ServiceOwnerLabelDto>();

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Search/ServiceOwnerContextRevisionTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Search/ServiceOwnerContextRevisionTests.cs
@@ -1,0 +1,26 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Search;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Tool.Dialogporten.GenerateFakeData;
+using FluentAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.ServiceOwner.Dialogs.Queries.Search;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class ServiceOwnerContextRevisionTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    [Fact]
+    public async Task Search_Should_Populate_ServiceOwnerContextRevision()
+    {
+        var createCmd = DialogGenerator.GenerateSimpleFakeCreateDialogCommand();
+        var createRes = await Application.Send(createCmd);
+
+        var response = await Application.Send(new SearchDialogQuery
+        {
+            ServiceResource = [createCmd.Dto.ServiceResource]
+        });
+
+        response.TryPickT0(out var result, out _).Should().BeTrue();
+        var dialog = result.Items.Single(x => x.Id == createRes.AsT0.DialogId);
+        dialog.ServiceOwnerContextRevision.Should().NotBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- expose `ServiceOwnerContextRevision` in service owner search dialog dto
- map new property in search mapping
- update Swagger docs
- add integration test for service owner context revision

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln -c Release`
- `dotnet test Digdir.Domain.Dialogporten.sln --filter 'FullyQualifiedName!~Integration' -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6847217809c48327870ab71ab1f37c42