### PR TITLE
fix(ci): Restore dependencies before 'dotnet pack'

### DIFF
--- a/.github/workflows/workflow-publish-nuget.yml
+++ b/.github/workflows/workflow-publish-nuget.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           global-json-file: ./global.json
 
+      - name: Restore dependencies
+        run: dotnet restore
+
       - name: Pack with debug symbols
         run: dotnet pack --configuration Release -p:Version="${{ inputs.version }}" -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --output . "${{ inputs.path }}"
 

--- a/src/Digdir.Library.Dialogporten.WebApiClient/README.md
+++ b/src/Digdir.Library.Dialogporten.WebApiClient/README.md
@@ -53,6 +53,7 @@ var dialogportenSettings = builder.Configuration
     .Get<DialogportenSettings>()!;
 builder.Services.AddDialogportenClient(dialogportenSettings);
 ```
+
 In this case, the configuration should look like this:
 ```json5
 {


### PR DESCRIPTION
#2423 changed from project ref. to Target BeforeBuild for WebAPI, this requires a `dotnet restore` before we do `dotnet pack`