### PR TITLE
feat(search): project latest activity via expression

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/DialogDtoBase.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/DialogDtoBase.cs
@@ -3,6 +3,8 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.Actors;
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Search;
 
@@ -191,4 +193,29 @@ public sealed class DialogActivityDto
     /// Unstructured text describing the activity. Only set if the activity type is "Information".
     /// </summary>
     public List<LocalizationDto> Description { get; set; } = [];
+
+    public static Expression<Func<DialogActivity, DialogActivityDto>> LatestActivityProjection =>
+        activity => new DialogActivityDto
+        {
+            Id = activity.Id,
+            CreatedAt = activity.CreatedAt,
+            ExtendedType = activity.ExtendedType,
+            Type = activity.TypeId,
+            TransmissionId = activity.TransmissionId,
+            PerformedBy = new ActorDto
+            {
+                ActorType = activity.PerformedBy.ActorTypeId,
+                ActorName = activity.PerformedBy.ActorNameEntity != null ? activity.PerformedBy.ActorNameEntity.Name : null,
+                ActorId = activity.PerformedBy.ActorNameEntity != null ? activity.PerformedBy.ActorNameEntity.ActorId : null
+            },
+            Description = activity.Description == null
+                ? new List<LocalizationDto>()
+                : activity.Description.Localizations
+                    .Select(l => new LocalizationDto
+                    {
+                        LanguageCode = l.LanguageCode,
+                        Value = l.Value
+                    })
+                    .ToList()
+        };
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/MappingProfile.cs
@@ -3,6 +3,7 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Domain.Attachments;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using System.Linq;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Contents;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Search;
@@ -23,7 +24,13 @@ internal sealed class MappingProfile : Profile
                     .Any(url => url.ConsumerTypeId == AttachmentUrlConsumerType.Values.Gui))))
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content.Where(x => x.Type.OutputInList)))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
-            .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId));
+            .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId))
+            .ForMember(dest => dest.LatestActivity, opt => opt.MapFrom(src => src.Activities
+                .AsQueryable()
+                .OrderByDescending(a => a.CreatedAt)
+                .ThenByDescending(a => a.Id)
+                .Select(DialogActivityDto.LatestActivityProjection)
+                .FirstOrDefault()));
 
         CreateMap<DialogSeenLog, DialogSeenLogDto>()
             .ForMember(dest => dest.SeenAt, opt => opt.MapFrom(src => src.CreatedAt));

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDtoBase.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDtoBase.cs
@@ -3,6 +3,8 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Act
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Search;
 
@@ -224,4 +226,29 @@ public sealed class DialogActivityDto
     /// Unstructured text describing the activity. Only set if the activity type is "Information".
     /// </summary>
     public List<LocalizationDto> Description { get; set; } = [];
+
+    public static Expression<Func<DialogActivity, DialogActivityDto>> LatestActivityProjection =>
+        activity => new DialogActivityDto
+        {
+            Id = activity.Id,
+            CreatedAt = activity.CreatedAt,
+            ExtendedType = activity.ExtendedType,
+            Type = activity.TypeId,
+            TransmissionId = activity.TransmissionId,
+            PerformedBy = new ActorDto
+            {
+                ActorType = activity.PerformedBy.ActorTypeId,
+                ActorName = activity.PerformedBy.ActorNameEntity != null ? activity.PerformedBy.ActorNameEntity.Name : null,
+                ActorId = activity.PerformedBy.ActorNameEntity != null ? activity.PerformedBy.ActorNameEntity.ActorId : null
+            },
+            Description = activity.Description == null
+                ? new List<LocalizationDto>()
+                : activity.Description.Localizations
+                    .Select(l => new LocalizationDto
+                    {
+                        LanguageCode = l.LanguageCode,
+                        Value = l.Value
+                    })
+                    .ToList()
+        };
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
@@ -5,6 +5,7 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Contents;
 using Digdir.Domain.Dialogporten.Domain.DialogServiceOwnerContexts.Entities;
+using System.Linq;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Search;
 
@@ -24,7 +25,13 @@ internal sealed class MappingProfile : Profile
                     .Any(url => url.ConsumerTypeId == AttachmentUrlConsumerType.Values.Gui))))
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content.Where(x => x.Type.OutputInList)))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
-            .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId));
+            .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId))
+            .ForMember(dest => dest.LatestActivity, opt => opt.MapFrom(src => src.Activities
+                .AsQueryable()
+                .OrderByDescending(a => a.CreatedAt)
+                .ThenByDescending(a => a.Id)
+                .Select(DialogActivityDto.LatestActivityProjection)
+                .FirstOrDefault()));
 
         CreateMap<DialogServiceOwnerContext, DialogServiceOwnerContextDto>();
         CreateMap<DialogServiceOwnerLabel, ServiceOwnerLabelDto>();

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQuery.cs
@@ -15,6 +15,8 @@ using Digdir.Domain.Dialogporten.Domain.Attachments;
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Localizations;
+using AutoMapper.QueryableExtensions;
+using System.Linq;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using OneOf;
@@ -233,80 +235,7 @@ internal sealed class SearchDialogQueryHandler : IRequestHandler<SearchDialogQue
             .WhereIf(request.ExcludeApiOnly == true, x => !x.IsApiOnly)
             .Where(x => resourceIds.Contains(x.ServiceResource))
             .IgnoreQueryFilters()
-            .SelectMany(dialog => dialog.Activities
-                    .OrderByDescending(a => a.CreatedAt)
-                    .ThenByDescending(a => a.Id)
-                    .Take(1)
-                    .DefaultIfEmpty(),
-                (dialog, latestActivity) => new IntermediateDialogDto
-                {
-                    Id = dialog.Id,
-                    Revision = dialog.Revision,
-                    Org = dialog.Org,
-                    ServiceResource = dialog.ServiceResource,
-                    ServiceResourceType = dialog.ServiceResourceType,
-                    Party = dialog.Party,
-                    Progress = dialog.Progress,
-                    Process = dialog.Process,
-                    PrecedingProcess = dialog.PrecedingProcess,
-                    GuiAttachmentCount = dialog.Attachments
-                        .Count(x => x.Urls.Any(url =>
-                            url.ConsumerTypeId == AttachmentUrlConsumerType.Values.Gui)),
-                    ExtendedStatus = dialog.ExtendedStatus,
-                    ExternalReference = dialog.ExternalReference,
-                    CreatedAt = dialog.CreatedAt,
-                    UpdatedAt = dialog.UpdatedAt,
-                    DueAt = dialog.DueAt,
-                    DeletedAt = dialog.DeletedAt,
-                    VisibleFrom = dialog.VisibleFrom,
-                    Status = dialog.StatusId,
-                    SystemLabel = dialog.DialogEndUserContext.SystemLabelId,
-                    IsApiOnly = dialog.IsApiOnly,
-                    Content = dialog.Content.Where(x => x.Type.OutputInList).ToList(),
-                    ServiceOwnerContext = new DialogServiceOwnerContextDto
-                    {
-                        ServiceOwnerLabels = dialog.ServiceOwnerContext.ServiceOwnerLabels
-                            .Select(l => new ServiceOwnerLabelDto { Value = l.Value })
-                            .ToList()
-                    },
-                    SeenSinceLastUpdate = dialog.SeenLog
-                        .Where(x => x.CreatedAt >= x.Dialog.UpdatedAt)
-                        .OrderByDescending(x => x.CreatedAt)
-                        .Select(x => new DialogSeenLogDto
-                        {
-                            Id = x.Id,
-                            SeenAt = x.CreatedAt,
-                            SeenBy = new ActorDto
-                            {
-                                ActorType = x.SeenBy.ActorTypeId,
-                                ActorName = x.SeenBy.ActorNameEntity != null ? x.SeenBy.ActorNameEntity.Name : null,
-                                ActorId = x.SeenBy.ActorNameEntity != null ? x.SeenBy.ActorNameEntity.ActorId : null
-                            },
-                            IsViaServiceOwner = x.IsViaServiceOwner
-                        }).ToList(),
-                    LatestActivity = latestActivity == null ? null : new DialogActivityDto
-                    {
-                        Id = latestActivity.Id,
-                        CreatedAt = latestActivity.CreatedAt,
-                        ExtendedType = latestActivity.ExtendedType,
-                        Type = latestActivity.TypeId,
-                        TransmissionId = latestActivity.TransmissionId,
-                        PerformedBy = new ActorDto
-                        {
-                            ActorType = latestActivity.PerformedBy.ActorTypeId,
-                            ActorName = latestActivity.PerformedBy.ActorNameEntity != null ? latestActivity.PerformedBy.ActorNameEntity.Name : null,
-                            ActorId = latestActivity.PerformedBy.ActorNameEntity != null ? latestActivity.PerformedBy.ActorNameEntity.ActorId : null
-                        },
-                        Description = latestActivity.Description == null
-                            ? new List<LocalizationDto>()
-                            : latestActivity.Description.Localizations
-                                .Select(l => new LocalizationDto
-                                {
-                                    LanguageCode = l.LanguageCode,
-                                    Value = l.Value
-                                }).ToList()
-                    }
-                })
+            .ProjectTo<IntermediateDialogDto>(_mapper.ConfigurationProvider)
             .ToPaginatedListAsync(request, cancellationToken: cancellationToken);
 
         if (request.EndUserId is not null)


### PR DESCRIPTION
## Summary
- map latest dialog activity using LatestActivityProjection expression
- leverage AutoMapper's `ProjectTo` for search dialog queries

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln -v minimal`
- `dotnet test Digdir.Domain.Dialogporten.sln --filter 'FullyQualifiedName!~Integration' -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684dbbed1bf08327b0e2ae065797018e