### PR TITLE
feat(search): optimize dialog search queries

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/MappingProfile.cs
@@ -14,17 +14,6 @@ internal sealed class MappingProfile : Profile
         // See IntermediateSearchDialogDto
         CreateMap<IntermediateDialogDto, DialogDto>();
         CreateMap<DialogEntity, IntermediateDialogDto>()
-            .ForMember(dest => dest.LatestActivity, opt => opt.MapFrom(src => src.Activities
-                .OrderByDescending(activity => activity.CreatedAt).ThenByDescending(activity => activity.Id)
-                .FirstOrDefault()
-            ))
-            .ForMember(dest => dest.SeenSinceLastUpdate, opt => opt.MapFrom(src => src.SeenLog
-                .Where(x => x.CreatedAt >= x.Dialog.UpdatedAt)
-                .OrderByDescending(x => x.CreatedAt)
-            ))
-            .ForMember(dest => dest.GuiAttachmentCount, opt => opt.MapFrom(src => src.Attachments
-                .Count(x => x.Urls
-                    .Any(url => url.ConsumerTypeId == AttachmentUrlConsumerType.Values.Gui))))
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content.Where(x => x.Type.OutputInList)))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
             .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId));

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQueryValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQueryValidator.cs
@@ -3,6 +3,7 @@ using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
 using Digdir.Domain.Dialogporten.Application.Common.Pagination;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Localizations;
 using FluentValidation;
 using static Digdir.Domain.Dialogporten.Application.Features.V1.Common.ValidationErrorStrings;
@@ -13,7 +14,7 @@ internal sealed class SearchDialogQueryValidator : AbstractValidator<SearchDialo
 {
     public SearchDialogQueryValidator()
     {
-        Include(new PaginationParameterValidator<SearchDialogQueryOrderDefinition, IntermediateDialogDto>());
+        Include(new PaginationParameterValidator<SearchDialogQueryOrderDefinition, DialogEntity>());
         RuleFor(x => x.Search)
             .MinimumLength(3)
             .When(x => x.Search is not null);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
@@ -15,17 +15,6 @@ internal sealed class MappingProfile : Profile
         // See IntermediateSearchDialogDto
         CreateMap<IntermediateDialogDto, DialogDto>();
         CreateMap<DialogEntity, IntermediateDialogDto>()
-            .ForMember(dest => dest.LatestActivity, opt => opt.MapFrom(src => src.Activities
-                .OrderByDescending(activity => activity.CreatedAt).ThenByDescending(activity => activity.Id)
-                .FirstOrDefault()
-            ))
-            .ForMember(dest => dest.SeenSinceLastUpdate, opt => opt.MapFrom(src => src.SeenLog
-                .Where(x => x.CreatedAt >= x.Dialog.UpdatedAt)
-                .OrderByDescending(x => x.CreatedAt)
-            ))
-            .ForMember(dest => dest.GuiAttachmentCount, opt => opt.MapFrom(src => src.Attachments
-                .Count(x => x.Urls
-                    .Any(url => url.ConsumerTypeId == AttachmentUrlConsumerType.Values.Gui))))
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content.Where(x => x.Type.OutputInList)))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
             .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId));

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQueryValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/SearchDialogQueryValidator.cs
@@ -3,6 +3,7 @@ using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
 using Digdir.Domain.Dialogporten.Application.Common.Pagination;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Parties;
 using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
@@ -15,7 +16,7 @@ internal sealed class SearchDialogQueryValidator : AbstractValidator<SearchDialo
 {
     public SearchDialogQueryValidator()
     {
-        Include(new PaginationParameterValidator<SearchDialogQueryOrderDefinition, IntermediateDialogDto>());
+        Include(new PaginationParameterValidator<SearchDialogQueryOrderDefinition, DialogEntity>());
 
         RuleForEach(x => x.ServiceOwnerLabels)
             .MinimumLength(Constants.MinSearchStringLength)

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogQueries.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogQueries.cs
@@ -6,6 +6,7 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Search;
 using Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogById;
 using Digdir.Domain.Dialogporten.GraphQL.EndUser.SearchDialogs;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using MediatR;
 
 namespace Digdir.Domain.Dialogporten.GraphQL.EndUser;
@@ -50,7 +51,7 @@ public partial class Queries
     {
         var searchDialogQuery = mapper.Map<SearchDialogQuery>(input);
 
-        if (!ContinuationTokenSet<SearchDialogQueryOrderDefinition, IntermediateDialogDto>.TryParse(
+        if (!ContinuationTokenSet<SearchDialogQueryOrderDefinition, DialogEntity>.TryParse(
                 input.ContinuationToken, out var continuationTokenSet) && input.ContinuationToken != null)
         {
             return new SearchDialogsPayload

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/SearchDialogs/SearchDialogSortTypeExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/SearchDialogs/SearchDialogSortTypeExtensions.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Digdir.Domain.Dialogporten.Application.Common.Pagination;
 using Digdir.Domain.Dialogporten.Application.Common.Pagination.Order;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Search;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 
 namespace Digdir.Domain.Dialogporten.GraphQL.EndUser.SearchDialogs;
 
@@ -45,7 +46,7 @@ internal static class SearchDialogSortTypeExtensions
     }
 
     public static bool TryToOrderSet(this List<SearchDialogSortType>? searchDialogSortTypes,
-        out OrderSet<SearchDialogQueryOrderDefinition, IntermediateDialogDto>? orderSet)
+        out OrderSet<SearchDialogQueryOrderDefinition, DialogEntity>? orderSet)
     {
         if (searchDialogSortTypes is null)
         {
@@ -74,7 +75,7 @@ internal static class SearchDialogSortTypeExtensions
             }
         }
 
-        if (OrderSet<SearchDialogQueryOrderDefinition, IntermediateDialogDto>.TryParse(stringBuilder.ToString(),
+        if (OrderSet<SearchDialogQueryOrderDefinition, DialogEntity>.TryParse(stringBuilder.ToString(),
                 out var parsedOrderSet))
         {
             orderSet = parsedOrderSet;


### PR DESCRIPTION
## Summary
- refactor search handlers to fetch dialog IDs before loading details
- map additional dialog metadata through separate queries
- update validators, sorting helpers, and GraphQL bindings

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln -c Release`
- `dotnet test Digdir.Domain.Dialogporten.sln -c Release --filter 'FullyQualifiedName!~Integration'`

------
https://chatgpt.com/codex/tasks/task_e_684e9cd339f88327a1a114f0d3854222