### PR TITLE
Refactor search

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/DbSetExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/DbSetExtensions.cs
@@ -17,14 +17,14 @@ public static class DbSetExtensions
         var deletedFilterCondition = deletedFilter switch
         {
             DeletedFilter.Include => "",
-            DeletedFilter.Exclude => "NOT \"Deleted\" AND ",
+            DeletedFilter.Exclude => "NOT \"Deleted\" AND",
             DeletedFilter.Only => "\"Deleted\" AND",
             _ => throw new ArgumentOutOfRangeException(nameof(deletedFilter), deletedFilter, null)
         };
 
         var sb = new StringBuilder()
             .AppendLine(CultureInfo.InvariantCulture, $"""
-                SELECT "Id", "ServiceResource"
+                SELECT "Id", "Deleted", "Party", "ServiceResource", "CreatedAt", "UpdatedAt", "DueAt"
                 FROM "Dialog"
                 WHERE {deletedFilterCondition} ("Id" = ANY(@p{parameters.Count})
                 """);
@@ -61,7 +61,7 @@ public static class DbSetExtensions
         DeletedFilter? deletedFilter)
     {
         var (sql, parameters) = GeneratePrefilterAuthorizedDialogsSql(authorizedResources, deletedFilter ?? DeletedFilter.Exclude);
-        return dialogs.FromSqlRaw(sql, parameters);
+        return dialogs.FromSqlRaw(sql, parameters).IgnoreQueryFilters();
     }
 }
 

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Pagination/PaginatedList.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Pagination/PaginatedList.cs
@@ -64,4 +64,9 @@ public sealed class PaginatedList<T>
             hasNextPage: false,
             @continue: parameter.ContinuationToken?.Raw,
             orderBy: parameter.OrderBy.DefaultIfNull().GetOrderString());
+
+    public bool Contains(T item)
+    {
+        return Items.Contains(item);
+    }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -56,6 +56,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
         // This is to ensure that the get is consistent, and that PATCH in the API presentation
         // layer behaviours in an expected manner. Therefore, we need to be a bit more verbose about it.
         var dialog = await _db.Dialogs
+            .AsNoTracking()
             .Include(x => x.Content)
                 .ThenInclude(x => x.Value.Localizations.OrderBy(x => x.LanguageCode))
             .Include(x => x.Attachments.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/MappingProfile.cs
@@ -12,6 +12,8 @@ internal sealed class MappingProfile : Profile
     public MappingProfile()
     {
         // See IntermediateSearchDialogDto
+        CreateMap<Guid, IntermediateDialogDto>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src));
         CreateMap<IntermediateDialogDto, DialogDto>();
         CreateMap<DialogEntity, IntermediateDialogDto>()
             .ForMember(dest => dest.LatestActivity, opt => opt.MapFrom(src => src.Activities

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQuery.cs
@@ -8,6 +8,8 @@ using Digdir.Domain.Dialogporten.Application.Common.Pagination.OrderOption;
 using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Search;
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Localizations;
@@ -121,6 +123,18 @@ public sealed class SearchDialogQueryOrderDefinition : IOrderDefinition<Intermed
             .Build();
 }
 
+public sealed class SearchDialogQueryOrderDefinitionForIds : IOrderDefinition<DialogIds>
+{
+    public static IOrderOptions<IntermediateDialogDto> Configure(IOrderOptionsBuilder<IntermediateDialogDto> options) =>
+        options.AddId(x => x.Id)
+            .AddDefault("createdAt", x => x.CreatedAt)
+            .AddOption("updatedAt", x => x.UpdatedAt)
+            .AddOption("dueAt", x => x.DueAt)
+            .Build();
+
+    public static IOrderOptions<DialogIds> Configure(IOrderOptionsBuilder<DialogIds> options) => throw new NotImplementedException();
+}
+
 [GenerateOneOf]
 public sealed partial class SearchDialogResult : OneOfBase<PaginatedList<DialogDto>, ValidationError, Forbidden>;
 
@@ -160,7 +174,7 @@ internal sealed class SearchDialogQueryHandler : IRequestHandler<SearchDialogQue
         }
 
         var paginatedList = await _db.Dialogs
-            .PrefilterAuthorizedDialogs(authorizedResources)
+            .PrefilterAuthorizedDialogs(authorizedResources, DeletedFilter.Exclude)
             .AsNoTracking()
             .Include(x => x.Content)
                 .ThenInclude(x => x.Value.Localizations)

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQuery.cs
@@ -122,7 +122,7 @@ public sealed class SearchDialogQueryOrderDefinition : IOrderDefinition<Intermed
             .AddOption("dueAt", x => x.DueAt)
             .Build();
 }
-
+/*
 public sealed class SearchDialogQueryOrderDefinitionForIds : IOrderDefinition<DialogIds>
 {
     public static IOrderOptions<IntermediateDialogDto> Configure(IOrderOptionsBuilder<IntermediateDialogDto> options) =>
@@ -133,8 +133,7 @@ public sealed class SearchDialogQueryOrderDefinitionForIds : IOrderDefinition<Di
             .Build();
 
     public static IOrderOptions<DialogIds> Configure(IOrderOptionsBuilder<DialogIds> options) => throw new NotImplementedException();
-}
-
+}*/
 [GenerateOneOf]
 public sealed partial class SearchDialogResult : OneOfBase<PaginatedList<DialogDto>, ValidationError, Forbidden>;
 

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -59,6 +59,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
         // This is to ensure that the get is consistent, and that PATCH in the API presentation
         // layer behaviours in an expected manner. Therefore we need to be a bit more verbose about it.
         var dialog = await _db.Dialogs
+            .AsNoTracking()
             .Include(x => x.Content.OrderBy(x => x.Id).ThenBy(x => x.CreatedAt))
                 .ThenInclude(x => x.Value.Localizations.OrderBy(x => x.LanguageCode))
             .Include(x => x.SearchTags.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDto.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Contents;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Search;
@@ -58,9 +60,15 @@ public sealed class ContentDto
 public sealed class IntermediateDialogDto : DialogDtoBase
 {
     public List<DialogContent> Content { get; set; } = [];
+    public List<DialogActivity> Activities { get; set; } = [];
+    public List<DialogAttachment> Attachments { get; set; } = [];
 }
 
-public sealed class DialogIds
+
+public sealed class PaginatedDialogIds
 {
-    public List<Guid> Ids { get; set; } = [];
+    public Guid Id { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public DateTimeOffset? DueAt { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDto.cs
@@ -59,3 +59,8 @@ public sealed class IntermediateDialogDto : DialogDtoBase
 {
     public List<DialogContent> Content { get; set; } = [];
 }
+
+public sealed class DialogIds
+{
+    public List<Guid> Ids { get; set; } = [];
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDtoBase.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/DialogDtoBase.cs
@@ -130,7 +130,7 @@ public class DialogDtoBase
     /// <summary>
     /// The latest entry in the dialog's activity log.
     /// </summary>
-    public DialogActivityDto? LatestActivity { get; set; }
+    public DialogActivityDto LatestActivity { get; set; } = null!;
 
     /// <summary>
     /// The list of seen log entries for the dialog newer than the dialog ChangedAt date.

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
@@ -15,6 +15,7 @@ internal sealed class MappingProfile : Profile
         // See IntermediateSearchDialogDto
         CreateMap<IntermediateDialogDto, DialogDto>();
         CreateMap<DialogEntity, IntermediateDialogDto>()
+            /*
             .ForMember(dest => dest.LatestActivity, opt => opt.MapFrom(src => src.Activities
                 .OrderByDescending(activity => activity.CreatedAt).ThenByDescending(activity => activity.Id)
                 .FirstOrDefault()
@@ -26,6 +27,7 @@ internal sealed class MappingProfile : Profile
             .ForMember(dest => dest.GuiAttachmentCount, opt => opt.MapFrom(src => src.Attachments
                 .Count(x => x.Urls
                     .Any(url => url.ConsumerTypeId == AttachmentUrlConsumerType.Values.Gui))))
+            */
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content.Where(x => x.Type.OutputInList)))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
             .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId));

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Search/MappingProfile.cs
@@ -13,22 +13,31 @@ internal sealed class MappingProfile : Profile
     public MappingProfile()
     {
         // See IntermediateSearchDialogDto
-        CreateMap<IntermediateDialogDto, DialogDto>();
-        CreateMap<DialogEntity, IntermediateDialogDto>()
-            /*
+        CreateMap<IntermediateDialogDto, DialogDto>()
             .ForMember(dest => dest.LatestActivity, opt => opt.MapFrom(src => src.Activities
-                .OrderByDescending(activity => activity.CreatedAt).ThenByDescending(activity => activity.Id)
                 .FirstOrDefault()
+            ))
+            .ForMember(dest => dest.GuiAttachmentCount, opt => opt.MapFrom(src => src.Attachments
+                .Count(x => x.Urls
+                    .Any(url => url.ConsumerTypeId == AttachmentUrlConsumerType.Values.Gui))
+            ))
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content));
+
+        CreateMap<DialogEntity, IntermediateDialogDto>()
+            .ForMember(dest => dest.Activities, opt => opt.MapFrom(src => src.Activities
+                .OrderByDescending(activity => activity.CreatedAt).ThenByDescending(activity => activity.Id)
+            // Avoid FirstOrDefault here, as this causes EF to generate a large amount of inefficient of SQL
+            // Same with Take(1), which results in a very expensive PARTITION OVER query. Works better to handle the final
+            // in the IntermediateDialogDto to DialogDto mapping
             ))
             .ForMember(dest => dest.SeenSinceLastUpdate, opt => opt.MapFrom(src => src.SeenLog
                 .Where(x => x.CreatedAt >= x.Dialog.UpdatedAt)
                 .OrderByDescending(x => x.CreatedAt)
             ))
-            .ForMember(dest => dest.GuiAttachmentCount, opt => opt.MapFrom(src => src.Attachments
-                .Count(x => x.Urls
-                    .Any(url => url.ConsumerTypeId == AttachmentUrlConsumerType.Values.Gui))))
-            */
-            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content.Where(x => x.Type.OutputInList)))
+            // Works much better to handle the final count in the IntermediateDialogDto to DialogDto mapping
+            .ForMember(dest => dest.Attachments, opt => opt.MapFrom(src => src.Attachments))
+            // Not filtering for OutputInList here results in a simpler SQL query that performs better. The DTO only contains the correct fields anyway
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.StatusId))
             .ForMember(dest => dest.SystemLabel, opt => opt.MapFrom(src => src.DialogEndUserContext.SystemLabelId));
 

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -62,6 +62,7 @@ public static class InfrastructureExtensions
                 {
                     o.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
                 })
+                .EnableSensitiveDataLogging()
                 .AddInterceptors(
                     services.GetRequiredService<PopulateActorNameInterceptor>(),
                     services.GetRequiredService<ConvertDomainEventsToOutboxMessagesInterceptor>()


### PR DESCRIPTION
This attempts to adress several issues with todays search
- As these queries must be split anyway to avoid cartesian explosions, the handler is changed to initially fetch a minimal list of dialog ids (without any joins, but with all filters). The resulting dialog-id list is then used as input for subsequent calls.
- The automapper profile for DialogEntity->IntermediateDialogDto is simplified, and mapping logic is moved to IntermediateDialogDto->DialogDto. This creates much simpler SQL which appears to perform better. 
- The deleted-query filter is ignored, and deleted handling is moved to dialog Id-materialization step

Local testing (with appx 1M dialogs) seems to reduce cold service owner requests filtering on party from ~600ms to 350ms, hot lookups from ~100ms to ~60ms. This _appears_ to be due to CPU-wins in postgresql. I/O overhead for cold requests are still assumed to dominate time spent. 

Issues
- Sorting and pagination is broken (not sure how to fix it, pagination code is very opaque)
- ServiceOwnerContext and EnduserContext is JOINed for every sub-query (not clear why)
- Only implemented in serviceowner (easy to port to enduser when done)

Further improvements
- Intersect serviceowner resourceIds when supplying enduser id to improve performance of dialog id materialization
- Partial index with Deleted
- Create index with INCLUDING on the timestamp columns, deleted, serviceowner and party. This will cause the initial id-loopkup to be a index-only scan, avoiding the heap for even cold lookups
- Change default sort order i API to match arbeidsflate (contentupdatedat DESC)
- Cluster all immediate children of Dialog on DialogId