### PR TITLE
feat(persistence): add dialog document

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Mapping/DialogDocumentProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Mapping/DialogDocumentProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+
+namespace Digdir.Domain.Dialogporten.Application.Common.Mapping;
+
+internal sealed class DialogDocumentProfile : Profile
+{
+    public DialogDocumentProfile()
+    {
+        CreateMap<DialogEntity, DialogDocument>()
+            .ForMember(d => d.DialogData, o => o.MapFrom(s => s));
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/IDialogDbContext.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/IDialogDbContext.cs
@@ -12,6 +12,7 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions.Contents;
 using Digdir.Domain.Dialogporten.Domain.DialogServiceOwnerContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.ResourcePolicyInformation;
 using Digdir.Domain.Dialogporten.Domain.SubjectResources;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
 
 namespace Digdir.Domain.Dialogporten.Application.Externals;
 
@@ -50,6 +51,7 @@ public interface IDialogDbContext
 
     DbSet<ActorName> ActorName { get; }
     DbSet<DialogAttachment> DialogAttachments { get; }
+    DbSet<DialogDocument> DialogDocuments { get; }
 
     /// <summary>
     /// Validate a property on the <typeparamref name="TEntity"/> using a lambda

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/IDialogDocumentRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/IDialogDocumentRepository.cs
@@ -1,9 +1,19 @@
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
+using System.Linq.Expressions;
 
 namespace Digdir.Domain.Dialogporten.Application.Externals;
 
 public interface IDialogDocumentRepository
 {
     Task Add(DialogDocument document, CancellationToken cancellationToken = default);
+
+    Task Update(DialogDocument document, CancellationToken cancellationToken = default);
+
+    Task Remove(DialogDocument document, CancellationToken cancellationToken = default);
+
     Task<DialogDocument?> Get(Guid id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyCollection<DialogDocument>> Find(
+        Expression<Func<DialogDocument, bool>> predicate,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/IDialogDocumentRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/IDialogDocumentRepository.cs
@@ -1,0 +1,9 @@
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
+
+namespace Digdir.Domain.Dialogporten.Application.Externals;
+
+public interface IDialogDocumentRepository
+{
+    Task Add(DialogDocument document, CancellationToken cancellationToken = default);
+    Task<DialogDocument?> Get(Guid id, CancellationToken cancellationToken = default);
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -6,8 +6,8 @@ using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using OneOf;
 using static Digdir.Domain.Dialogporten.Application.Features.V1.Common.Authorization.Constants;
 
@@ -23,7 +23,7 @@ public sealed partial class GetDialogResult : OneOfBase<DialogDto, EntityNotFoun
 
 internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, GetDialogResult>
 {
-    private readonly IDialogDbContext _db;
+    private readonly IDialogDocumentRepository _documents;
     private readonly IMapper _mapper;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IClock _clock;
@@ -32,7 +32,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
     private readonly IDialogTokenGenerator _dialogTokenGenerator;
 
     public GetDialogQueryHandler(
-        IDialogDbContext db,
+        IDialogDocumentRepository documents,
         IMapper mapper,
         IUnitOfWork unitOfWork,
         IClock clock,
@@ -40,7 +40,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
         IAltinnAuthorization altinnAuthorization,
         IDialogTokenGenerator dialogTokenGenerator)
     {
-        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _documents = documents ?? throw new ArgumentNullException(nameof(documents));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
@@ -55,50 +55,14 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
         // However, we need to guarantee an order for sub resources of the dialog aggregate.
         // This is to ensure that the get is consistent, and that PATCH in the API presentation
         // layer behaviours in an expected manner. Therefore, we need to be a bit more verbose about it.
-        var dialog = await _db.Dialogs
-            .Include(x => x.Content)
-                .ThenInclude(x => x.Value.Localizations.OrderBy(x => x.LanguageCode))
-            .Include(x => x.Attachments.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
-                .ThenInclude(x => x.DisplayName!.Localizations.OrderBy(x => x.LanguageCode))
-            .Include(x => x.Attachments.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
-                .ThenInclude(x => x.Urls.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
-            .Include(x => x.GuiActions.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
-                .ThenInclude(x => x.Title!.Localizations.OrderBy(x => x.LanguageCode))
-            .Include(x => x.GuiActions.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
-                .ThenInclude(x => x.Prompt!.Localizations.OrderBy(x => x.LanguageCode))
-            .Include(x => x.ApiActions.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
-                .ThenInclude(x => x.Endpoints.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
-            .Include(x => x.Transmissions)
-                .ThenInclude(x => x.Content)
-                .ThenInclude(x => x.Value.Localizations)
-            .Include(x => x.Transmissions)
-                .ThenInclude(x => x.Sender)
-                .ThenInclude(x => x.ActorNameEntity)
-            .Include(x => x.Transmissions)
-                .ThenInclude(x => x.Attachments)
-                .ThenInclude(x => x.Urls)
-            .Include(x => x.Transmissions)
-                .ThenInclude(x => x.Attachments)
-                .ThenInclude(x => x.DisplayName!.Localizations)
-            .Include(x => x.Activities)
-                .ThenInclude(x => x.Description!.Localizations)
-            .Include(x => x.Activities)
-                .ThenInclude(x => x.PerformedBy)
-                .ThenInclude(x => x.ActorNameEntity)
-            .Include(x => x.SeenLog
-                    .Where(x => x.CreatedAt >= x.Dialog.UpdatedAt)
-                    .OrderBy(x => x.CreatedAt))
-                .ThenInclude(x => x.SeenBy)
-                    .ThenInclude(x => x.ActorNameEntity)
-            .Include(x => x.DialogEndUserContext)
-            .Where(x => !x.VisibleFrom.HasValue || x.VisibleFrom < _clock.UtcNowOffset)
-            .IgnoreQueryFilters()
-            .FirstOrDefaultAsync(x => x.Id == request.DialogId, cancellationToken);
+        var document = await _documents.Get(request.DialogId, cancellationToken);
 
-        if (dialog is null)
+        if (document is null || (document.VisibleFrom.HasValue && document.VisibleFrom > _clock.UtcNowOffset))
         {
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }
+
+        var dialog = document.DialogData;
 
         var authorizationResult = await _altinnAuthorization.GetDialogDetailsAuthorization(
             dialog,

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
@@ -11,6 +11,7 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common;
 using Digdir.Domain.Dialogporten.Domain.Actors;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
 using Digdir.Domain.Dialogporten.Domain.DialogServiceOwnerContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.Parties;
 using Digdir.Library.Entity.Abstractions.Features.Identifiable;
@@ -34,6 +35,7 @@ public sealed partial class CreateDialogResult : OneOfBase<CreateDialogSuccess, 
 internal sealed class CreateDialogCommandHandler : IRequestHandler<CreateDialogCommand, CreateDialogResult>
 {
     private readonly IDialogDbContext _db;
+    private readonly IDialogDocumentRepository _documents;
     private readonly IMapper _mapper;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IDomainContext _domainContext;
@@ -44,6 +46,7 @@ internal sealed class CreateDialogCommandHandler : IRequestHandler<CreateDialogC
     public CreateDialogCommandHandler(
         IUser user,
         IDialogDbContext db,
+        IDialogDocumentRepository documents,
         IMapper mapper,
         IUnitOfWork unitOfWork,
         IDomainContext domainContext,
@@ -52,6 +55,7 @@ internal sealed class CreateDialogCommandHandler : IRequestHandler<CreateDialogC
     {
         _user = user ?? throw new ArgumentNullException(nameof(user));
         _db = db ?? throw new ArgumentNullException(nameof(db));
+        _documents = documents ?? throw new ArgumentNullException(nameof(documents));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _domainContext = domainContext ?? throw new ArgumentNullException(nameof(domainContext));
@@ -113,6 +117,7 @@ internal sealed class CreateDialogCommandHandler : IRequestHandler<CreateDialogC
             maxWidth: 20));
 
         _db.Dialogs.Add(dialog);
+        await _documents.Add(_mapper.Map<DialogDocument>(dialog), cancellationToken);
 
         var saveResult = await _unitOfWork.SaveChangesAsync(cancellationToken);
         return saveResult.Match<CreateDialogResult>(

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Documents/DialogDocument.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Documents/DialogDocument.cs
@@ -1,0 +1,25 @@
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Library.Entity.Abstractions;
+
+namespace Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
+
+public sealed class DialogDocument : IEntity
+{
+    public Guid Id { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public bool Deleted { get; set; }
+    public string Org { get; set; } = null!;
+    public string ServiceResource { get; set; } = null!;
+    public string Party { get; set; } = null!;
+    public string? ExtendedStatus { get; set; }
+    public string? ExternalReference { get; set; }
+    public DateTimeOffset? VisibleFrom { get; set; }
+    public DateTimeOffset? DueAt { get; set; }
+    public DateTimeOffset? ExpiresAt { get; set; }
+    public string? Process { get; set; }
+    public string? PrecedingProcess { get; set; }
+    public bool IsApiOnly { get; set; }
+    public DialogStatus.Values StatusId { get; set; }
+    public DialogEntity DialogData { get; set; } = null!;
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -89,6 +89,7 @@ public static class InfrastructureExtensions
             // Transient
             .AddTransient<ISubjectResourceRepository, SubjectResourceRepository>()
             .AddTransient<IResourcePolicyInformationRepository, ResourcePolicyInformationRepository>()
+            .AddTransient<IDialogDocumentRepository, DialogDocumentRepository>()
             .AddTransient<Lazy<IPublishEndpoint>>(x =>
                 new Lazy<IPublishEndpoint>(x.GetRequiredService<IPublishEndpoint>))
             .AddTransient<Lazy<ITopicEventSender>>(x =>

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Configurations/Dialogs/DialogDocumentConfiguration.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Configurations/Dialogs/DialogDocumentConfiguration.cs
@@ -2,6 +2,7 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Digdir.Domain.Dialogporten.Infrastructure.Persistence.ValueConverters;
 using static Digdir.Domain.Dialogporten.Domain.Common.Constants;
 
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Configurations.Dialogs;
@@ -35,11 +36,8 @@ internal sealed class DialogDocumentConfiguration : IEntityTypeConfiguration<Dia
         builder.HasIndex(x => x.Process);
         builder.HasIndex(x => x.IsApiOnly);
 
-        builder.OwnsOne(x => x.DialogData, owned =>
-        {
-            owned.ToJson();
-            owned.HasColumnType("jsonb");
-        });
-        builder.Navigation(x => x.DialogData).IsRequired();
+        builder.Property(x => x.DialogData)
+            .HasConversion<DialogEntityJsonConverter>()
+            .HasColumnType("jsonb");
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Configurations/Dialogs/DialogDocumentConfiguration.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Configurations/Dialogs/DialogDocumentConfiguration.cs
@@ -1,0 +1,45 @@
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using static Digdir.Domain.Dialogporten.Domain.Common.Constants;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Configurations.Dialogs;
+
+internal sealed class DialogDocumentConfiguration : IEntityTypeConfiguration<DialogDocument>
+{
+    public void Configure(EntityTypeBuilder<DialogDocument> builder)
+    {
+        builder.ToTable("DialogDocument");
+
+        builder.HasIndex(x => x.ServiceResource);
+        builder.Property(x => x.ServiceResource)
+            .HasMaxLength(DefaultMaxStringLength)
+            .UseCollation("C");
+
+        builder.HasIndex(x => x.Party);
+        builder.Property(x => x.Party)
+            .UseCollation("C");
+
+        builder.HasIndex(x => x.Org);
+        builder.Property(x => x.Org)
+            .UseCollation("C");
+
+        builder.HasIndex(x => x.CreatedAt);
+        builder.HasIndex(x => x.UpdatedAt);
+        builder.HasIndex(x => x.DueAt);
+        builder.HasIndex(x => x.VisibleFrom);
+
+        builder.HasIndex(x => x.ExtendedStatus);
+        builder.HasIndex(x => x.ExternalReference);
+        builder.HasIndex(x => x.Process);
+        builder.HasIndex(x => x.IsApiOnly);
+
+        builder.OwnsOne(x => x.DialogData, owned =>
+        {
+            owned.ToJson();
+            owned.HasColumnType("jsonb");
+        });
+        builder.Navigation(x => x.DialogData).IsRequired();
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/DialogDbContext.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/DialogDbContext.cs
@@ -2,6 +2,7 @@
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence.ValueConverters;
 using Digdir.Library.Entity.Abstractions.Features.Identifiable;
 using Digdir.Library.Entity.Abstractions.Features.Versionable;
@@ -53,6 +54,7 @@ internal sealed class DialogDbContext : DbContext, IDialogDbContext
     public DbSet<ResourcePolicyInformation> ResourcePolicyInformation => Set<ResourcePolicyInformation>();
     public DbSet<ActorName> ActorName => Set<ActorName>();
     public DbSet<DialogAttachment> DialogAttachments => Set<DialogAttachment>();
+    public DbSet<DialogDocument> DialogDocuments => Set<DialogDocument>();
 
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20250616101347_AddDialogDocument.Designer.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20250616101347_AddDialogDocument.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DialogDbContext))]
-    partial class DialogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250616101347_AddDialogDocument")]
+    partial class AddDialogDocument
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20250616101347_AddDialogDocument.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20250616101347_AddDialogDocument.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDialogDocument : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DialogDocument",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "current_timestamp at time zone 'utc'"),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "current_timestamp at time zone 'utc'"),
+                    Deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    Org = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false, collation: "C"),
+                    ServiceResource = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false, collation: "C"),
+                    Party = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false, collation: "C"),
+                    ExtendedStatus = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    ExternalReference = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    VisibleFrom = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DueAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Process = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    PrecedingProcess = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    IsApiOnly = table.Column<bool>(type: "boolean", nullable: false),
+                    StatusId = table.Column<int>(type: "integer", nullable: false),
+                    DialogData = table.Column<string>(type: "jsonb", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DialogDocument", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_CreatedAt",
+                table: "DialogDocument",
+                column: "CreatedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_DueAt",
+                table: "DialogDocument",
+                column: "DueAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_ExtendedStatus",
+                table: "DialogDocument",
+                column: "ExtendedStatus");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_ExternalReference",
+                table: "DialogDocument",
+                column: "ExternalReference");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_IsApiOnly",
+                table: "DialogDocument",
+                column: "IsApiOnly");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_Org",
+                table: "DialogDocument",
+                column: "Org");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_Party",
+                table: "DialogDocument",
+                column: "Party");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_Process",
+                table: "DialogDocument",
+                column: "Process");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_ServiceResource",
+                table: "DialogDocument",
+                column: "ServiceResource");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_UpdatedAt",
+                table: "DialogDocument",
+                column: "UpdatedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_VisibleFrom",
+                table: "DialogDocument",
+                column: "VisibleFrom");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DialogDocument");
+        }
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogDocumentRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogDocumentRepository.cs
@@ -1,0 +1,25 @@
+using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
+using Microsoft.EntityFrameworkCore;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories;
+
+internal sealed class DialogDocumentRepository : IDialogDocumentRepository
+{
+    private readonly DialogDbContext _db;
+
+    public DialogDocumentRepository(DialogDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public Task Add(DialogDocument document, CancellationToken cancellationToken = default)
+    {
+        return _db.DialogDocuments.AddAsync(document, cancellationToken).AsTask();
+    }
+
+    public Task<DialogDocument?> Get(Guid id, CancellationToken cancellationToken = default)
+    {
+        return _db.DialogDocuments.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogDocumentRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogDocumentRepository.cs
@@ -1,6 +1,7 @@
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
 using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
 
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories;
 
@@ -18,8 +19,30 @@ internal sealed class DialogDocumentRepository : IDialogDocumentRepository
         return _db.DialogDocuments.AddAsync(document, cancellationToken).AsTask();
     }
 
+    public Task Update(DialogDocument document, CancellationToken cancellationToken = default)
+    {
+        _db.DialogDocuments.Update(document);
+        return Task.CompletedTask;
+    }
+
+    public Task Remove(DialogDocument document, CancellationToken cancellationToken = default)
+    {
+        _db.DialogDocuments.Remove(document);
+        return Task.CompletedTask;
+    }
+
     public Task<DialogDocument?> Get(Guid id, CancellationToken cancellationToken = default)
     {
         return _db.DialogDocuments.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+    }
+
+    public Task<IReadOnlyCollection<DialogDocument>> Find(
+        Expression<Func<DialogDocument, bool>> predicate,
+        CancellationToken cancellationToken = default)
+    {
+        return _db.DialogDocuments
+            .Where(predicate)
+            .ToListAsync(cancellationToken)
+            .ContinueWith(t => (IReadOnlyCollection<DialogDocument>)t.Result, cancellationToken);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/ValueConverters/DialogEntityJsonConverter.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/ValueConverters/DialogEntityJsonConverter.cs
@@ -1,0 +1,15 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.ValueConverters;
+
+internal sealed class DialogEntityJsonConverter : ValueConverter<DialogEntity, string>
+{
+    public DialogEntityJsonConverter()
+        : base(
+            v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+            v => JsonSerializer.Deserialize<DialogEntity>(v, (JsonSerializerOptions?)null)!)
+    {
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogTests.cs
@@ -17,7 +17,9 @@ public class CreateDialogTests
     public async Task CreateDialogCommand_Should_Return_Forbidden_When_Scope_Is_Missing()
     {
         // Arrange
+
         var dialogDbContextSub = Substitute.For<IDialogDbContext>();
+        var documentRepositorySub = Substitute.For<IDialogDocumentRepository>();
 
         var mapper = new MapperConfiguration(cfg =>
         {
@@ -41,7 +43,7 @@ public class CreateDialogTests
             .Returns(new ServiceResourceInformation(createCommand.Dto.ServiceResource, "foo", "912345678", "ttd"));
 
         var commandHandler = new CreateDialogCommandHandler(userSub, dialogDbContextSub,
-            mapper, unitOfWorkSub, domainContextSub,
+            documentRepositorySub, mapper, unitOfWorkSub, domainContextSub,
             resourceRegistrySub, serviceAuthorizationSub);
 
         // Act
@@ -56,6 +58,7 @@ public class CreateDialogTests
     {
         // Arrange
         var dialogDbContextSub = Substitute.For<IDialogDbContext>();
+        var documentRepositorySub = Substitute.For<IDialogDocumentRepository>();
 
         var mapper = new MapperConfiguration(cfg =>
         {
@@ -78,7 +81,7 @@ public class CreateDialogTests
             .Returns(new ServiceResourceInformation(createCommand.Dto.ServiceResource, "foo", "912345678", "ttd"));
 
         var commandHandler = new CreateDialogCommandHandler(userSub, dialogDbContextSub,
-            mapper, unitOfWorkSub, domainContextSub,
+            documentRepositorySub, mapper, unitOfWorkSub, domainContextSub,
             resourceRegistrySub, serviceAuthorizationSub);
 
         // Act


### PR DESCRIPTION
## Summary
- add `DialogDocument` aggregate snapshot entity
- configure database mapping for `DialogDocument`
- expose `DialogDocuments` set on DbContext and IDialogDbContext
- implement `DialogDocumentRepository` and wire up DI
- support DialogDocument jsonb storage with custom value converter
- add EF migration for DialogDocument
- add CRUD and find methods to IDialogDocumentRepository
- implement new repository methods for DialogDocument
- fetch dialog via IDialogDocumentRepository in GetDialogQuery
