### PR TITLE
feat(infrastructure): add DialogDocument migration

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Configurations/Dialogs/DialogDocumentConfiguration.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Configurations/Dialogs/DialogDocumentConfiguration.cs
@@ -2,6 +2,7 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Documents;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Digdir.Domain.Dialogporten.Infrastructure.Persistence.ValueConverters;
 using static Digdir.Domain.Dialogporten.Domain.Common.Constants;
 
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Configurations.Dialogs;
@@ -35,11 +36,8 @@ internal sealed class DialogDocumentConfiguration : IEntityTypeConfiguration<Dia
         builder.HasIndex(x => x.Process);
         builder.HasIndex(x => x.IsApiOnly);
 
-        builder.OwnsOne(x => x.DialogData, owned =>
-        {
-            owned.ToJson();
-            owned.HasColumnType("jsonb");
-        });
-        builder.Navigation(x => x.DialogData).IsRequired();
+        builder.Property(x => x.DialogData)
+            .HasConversion<DialogEntityJsonConverter>()
+            .HasColumnType("jsonb");
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20250616101347_AddDialogDocument.Designer.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20250616101347_AddDialogDocument.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DialogDbContext))]
-    partial class DialogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250616101347_AddDialogDocument")]
+    partial class AddDialogDocument
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20250616101347_AddDialogDocument.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20250616101347_AddDialogDocument.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDialogDocument : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DialogDocument",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "current_timestamp at time zone 'utc'"),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "current_timestamp at time zone 'utc'"),
+                    Deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    Org = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false, collation: "C"),
+                    ServiceResource = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false, collation: "C"),
+                    Party = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false, collation: "C"),
+                    ExtendedStatus = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    ExternalReference = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    VisibleFrom = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DueAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Process = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    PrecedingProcess = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    IsApiOnly = table.Column<bool>(type: "boolean", nullable: false),
+                    StatusId = table.Column<int>(type: "integer", nullable: false),
+                    DialogData = table.Column<string>(type: "jsonb", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DialogDocument", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_CreatedAt",
+                table: "DialogDocument",
+                column: "CreatedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_DueAt",
+                table: "DialogDocument",
+                column: "DueAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_ExtendedStatus",
+                table: "DialogDocument",
+                column: "ExtendedStatus");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_ExternalReference",
+                table: "DialogDocument",
+                column: "ExternalReference");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_IsApiOnly",
+                table: "DialogDocument",
+                column: "IsApiOnly");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_Org",
+                table: "DialogDocument",
+                column: "Org");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_Party",
+                table: "DialogDocument",
+                column: "Party");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_Process",
+                table: "DialogDocument",
+                column: "Process");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_ServiceResource",
+                table: "DialogDocument",
+                column: "ServiceResource");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_UpdatedAt",
+                table: "DialogDocument",
+                column: "UpdatedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DialogDocument_VisibleFrom",
+                table: "DialogDocument",
+                column: "VisibleFrom");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DialogDocument");
+        }
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/ValueConverters/DialogEntityJsonConverter.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/ValueConverters/DialogEntityJsonConverter.cs
@@ -1,0 +1,15 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.ValueConverters;
+
+internal sealed class DialogEntityJsonConverter : ValueConverter<DialogEntity, string>
+{
+    public DialogEntityJsonConverter()
+        : base(
+            v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+            v => JsonSerializer.Deserialize<DialogEntity>(v, (JsonSerializerOptions?)null)!)
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- support DialogDocument jsonb storage with custom value converter
- add EF migration for DialogDocument

## Testing
- `dotnet build Digdir.Domain.Dialogporten.sln`
- `dotnet test Digdir.Domain.Dialogporten.sln --filter 'FullyQualifiedName!~Integration' -c Release`


------
https://chatgpt.com/codex/tasks/task_e_684fec4fc69c832780ed0bf1b5300c6f