### PR TITLE
fix(infra): supply principal name as param for postgresql

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -79,6 +79,8 @@ param postgresConfiguration {
   availabilityZone: string
 }
 
+param deployerPrincipalName string
+
 import { Sku as ServiceBusSku } from '../modules/serviceBus/main.bicep'
 param serviceBusSku ServiceBusSku
 
@@ -233,6 +235,7 @@ module postgresql '../modules/postgreSql/create.bicep' = {
     highAvailability: postgresConfiguration.?highAvailability
     backupRetentionDays: postgresConfiguration.backupRetentionDays
     availabilityZone: postgresConfiguration.availabilityZone
+    deployerPrincipalName: deployerPrincipalName
     tags: tags
   }
 }

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -60,6 +60,8 @@ param postgresConfiguration = {
   availabilityZone: '3'
 }
 
+param deployerPrincipalName = 'GitHub: altinn/dialogporten - Prod'
+
 param redisSku = {
   name: 'Basic'
   family: 'C'

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -42,6 +42,8 @@ param postgresConfiguration = {
   availabilityZone: '2'
 }
 
+param deployerPrincipalName = 'GitHub: altinn/dialogporten - Prod'
+
 param redisSku = {
   name: 'Basic'
   family: 'C'

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -42,6 +42,8 @@ param postgresConfiguration = {
   availabilityZone: '1'
 }
 
+param deployerPrincipalName = 'GitHub: altinn/dialogporten - Dev'
+
 param redisSku = {
   name: 'Basic'
   family: 'C'

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -44,6 +44,8 @@ param postgresConfiguration = {
   availabilityZone: '1'
 }
 
+param deployerPrincipalName = 'GitHub: altinn/dialogporten - Dev'
+
 param redisSku = {
   name: 'Basic'
   family: 'C'

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -77,6 +77,9 @@ param srcKeyVault object
 @secure()
 param administratorLoginPassword string
 
+@description('The name of the deployer principal')
+param deployerPrincipalName string
+
 var administratorLogin = 'dialogportenPgAdmin'
 var databaseName = 'dialogporten'
 var postgresServerNameMaxLength = 63
@@ -158,7 +161,7 @@ resource postgresAdministrators 'Microsoft.DBforPostgreSQL/flexibleServers/admin
   name: deployer().objectId
   parent: postgres
   properties: {
-    principalName: deployer().userPrincipalName
+    principalName: deployerPrincipalName
     principalType: 'ServicePrincipal'
     tenantId: deployer().tenantId
   }

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -77,7 +77,8 @@ param srcKeyVault object
 @secure()
 param administratorLoginPassword string
 
-@description('The name of the deployer principal')
+@description('The name of the deployer principal used as the PostgreSQL administrator')
+@minLength(3)
 param deployerPrincipalName string
 
 var administratorLogin = 'dialogportenPgAdmin'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Seems like principalName is empty if the "user" is a service principal, so supplying it directly from params

## Related Issue(s)

- #2171 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
