### PR TITLE
fix: Use correct systemuser prefix

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Domain/Parties/SystemUserIdentifier.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Parties/SystemUserIdentifier.cs
@@ -5,7 +5,7 @@ namespace Digdir.Domain.Dialogporten.Domain.Parties;
 
 public sealed record SystemUserIdentifier : IPartyIdentifier
 {
-    public static string Prefix => "urn:altinn:systemuser";
+    public static string Prefix => "urn:altinn:systemuser:uuid";
     public static string PrefixWithSeparator => Prefix + PartyIdentifier.Separator;
     public string FullId { get; }
     public string Id { get; }


### PR DESCRIPTION
The list auth for system users fails because we're using the wrong prefix in the call to authorized parties.
