### PR TITLE
fix: Add user type per endpoint policy validation

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/UserTypeValidationMiddleware.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/UserTypeValidationMiddleware.cs
@@ -1,12 +1,22 @@
+using System.Diagnostics.CodeAnalysis;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.WebApi.Common.Extensions;
-using UserIdType = Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.DialogUserType.Values;
+using Microsoft.AspNetCore.Authorization;
+using UserType = Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.DialogUserType.Values;
+using Policy = Digdir.Domain.Dialogporten.WebApi.Common.Authorization.AuthorizationPolicy;
 
 namespace Digdir.Domain.Dialogporten.WebApi.Common.Authentication;
 
 public sealed class UserTypeValidationMiddleware
 {
     private readonly RequestDelegate _next;
+    private static readonly Dictionary<string, List<UserType>> ValidUserTypesForPolicy = new()
+    {
+        { Policy.EndUser, [UserType.Person, UserType.SystemUser] },
+        { Policy.ServiceProvider, [UserType.ServiceOwner, UserType.ServiceOwnerOnBehalfOfPerson] },
+        { Policy.ServiceProviderSearch, [UserType.ServiceOwner, UserType.ServiceOwnerOnBehalfOfPerson] },
+        { Policy.ServiceProviderAdmin, [UserType.ServiceOwner] }
+    };
 
     public UserTypeValidationMiddleware(RequestDelegate next)
     {
@@ -17,15 +27,14 @@ public sealed class UserTypeValidationMiddleware
     {
         if (context.User.Identity is { IsAuthenticated: true })
         {
-            var (userType, _) = context.User.GetUserType();
-            if (userType == UserIdType.Unknown)
+            if (!IsValidUserTypeForEndpoint(context, out var validUserTypes))
             {
                 context.Response.StatusCode = StatusCodes.Status403Forbidden;
                 var response = context.GetResponseOrDefault(
                     context.Response.StatusCode,
                     [
                         new("Type",
-                            "The request was authenticated, but we were unable to determine valid user type (person or system user) in order to authorize the request.")
+                            $"The request was authenticated, but we were unable to determine valid user type in order to authorize the request. Valid user types for this endpoint are: {string.Join(", ", validUserTypes)}")
                     ]
                 );
                 await context.Response.WriteAsJsonAsync(response, response.GetType());
@@ -35,6 +44,25 @@ public sealed class UserTypeValidationMiddleware
         }
 
         await _next(context);
+    }
+
+    private static bool IsValidUserTypeForEndpoint(
+        HttpContext context,
+        [NotNullWhen(false)] out List<UserType>? validUserTypes)
+    {
+        var policy = context.GetEndpoint()?
+            .Metadata.GetOrderedMetadata<AuthorizeAttribute>() is { Count: > 0 } metadata
+            ? metadata[0].Policy
+            : null;
+
+        if (policy is null || !ValidUserTypesForPolicy.TryGetValue(policy, out validUserTypes))
+        {
+            validUserTypes = null;
+            return true;
+        }
+
+        var (userType, _) = context.User.GetUserType();
+        return validUserTypes.Contains(userType);
     }
 }
 

--- a/tests/k6/common/token.js
+++ b/tests/k6/common/token.js
@@ -3,11 +3,16 @@ import encoding from "k6/encoding";
 import { extend } from "./extend.js";
 import { defaultEndUserSsn, defaultServiceOwnerOrgNo, tokenGeneratorEnv } from "./config.js";
 
-let defaultTokenOptions = {
-  scopes: "digdir:dialogporten digdir:dialogporten.serviceprovider digdir:dialogporten.serviceprovider.search",
+let defaultTokenOptionsForServiceOwner = {
+  scopes: "digdir:dialogporten.serviceprovider digdir:dialogporten.serviceprovider.search",
   orgName: "digdir",
-  orgNo: defaultServiceOwnerOrgNo,
-  ssn: defaultEndUserSsn
+  orgNo: defaultServiceOwnerOrgNo
+};
+
+let defaultTokenOptionsForEndUser = {
+    scopes: "digdir:dialogporten",
+    ssn: defaultEndUserSsn,
+    orgNo: defaultServiceOwnerOrgNo // a organzation number for a party that the end user has access to
 };
 
 const tokenUsername = __ENV.TOKEN_GENERATOR_USERNAME;
@@ -56,19 +61,19 @@ export function fetchToken(url, tokenOptions, type) {
 }
 
 export function getServiceOwnerTokenFromGenerator(tokenOptions = null) {
-  let fullTokenOptions = extend({}, defaultTokenOptions, tokenOptions);
+  let fullTokenOptions = extend({}, defaultTokenOptionsForServiceOwner, tokenOptions);
   const url = `http://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken?env=${tokenGeneratorEnv}&scopes=${encodeURIComponent(fullTokenOptions.scopes)}&org=${fullTokenOptions.orgName}&orgNo=${fullTokenOptions.orgNo}&ttl=${tokenTtl}`;
   return fetchToken(url, fullTokenOptions, `service owner (orgno:${fullTokenOptions.orgNo} orgName:${fullTokenOptions.orgName} tokenGeneratorEnv:${tokenGeneratorEnv})`);
 }
 
 export function getEnduserTokenFromGenerator(tokenOptions = null) {
-  let fullTokenOptions = extend({}, defaultTokenOptions, tokenOptions);
+  let fullTokenOptions = extend({}, defaultTokenOptionsForEndUser, tokenOptions);
   const url = `http://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=${tokenGeneratorEnv}&scopes=${encodeURIComponent(fullTokenOptions.scopes)}&pid=${fullTokenOptions.ssn}&ttl=${tokenTtl}`;
   return fetchToken(url, fullTokenOptions, `end user (ssn:${fullTokenOptions.ssn}, tokenGeneratorEnv:${tokenGeneratorEnv})`);
 }
 
 export function getEndUserTokens(count, tokenOptions = null) {
-  let fullTokenOptions = extend({}, defaultTokenOptions, tokenOptions);
+  let fullTokenOptions = extend({}, defaultTokenOptionsForEndUser, tokenOptions);
   const url = `http://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env=${tokenGeneratorEnv}&scopes=${encodeURIComponent(fullTokenOptions.scopes)}&bulkCount=${count}&ttl=${tokenTtl}`;
   tokenRequestOptions.timeout = 600000;
   let response = http.get(url, tokenRequestOptions);
@@ -79,11 +84,11 @@ export function getEndUserTokens(count, tokenOptions = null) {
 }
 
 export function getDefaultEnduserOrgNo() {
-  return defaultTokenOptions.orgNo;
+  return defaultTokenOptionsForEndUser.orgNo;
 }
 
 export function getDefaultEnduserSsn() {
-  return defaultTokenOptions.ssn;
+  return defaultTokenOptionsForEndUser.ssn;
 }
 
 export function getDefaultServiceOwnerOrgNo() {


### PR DESCRIPTION
## Description

This adds a per-endpoint-policy validation to the user type validation middleware, ensuring that each endpoint cannot be accessed unless the correct user type for that endpoint is authenticated.

Changes include an update to the e2e tests, which conflated the claims (in particular scopes) for service owner and end user tokens. Now this is properly separated to closer mimic the actual maskinporten/id-porten tokens. 

## Related Issue(s)

- #2538 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
