### PR TITLE
fix(auth): Increase FailSafeMaxDuration for RR data

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -116,6 +116,7 @@ public static class InfrastructureExtensions
         .ConfigureFusionCache(nameof(Altinn.ResourceRegistry), new()
         {
             Duration = TimeSpan.FromMinutes(20),
+            FailSafeMaxDuration = TimeSpan.FromHours(26),
             // The resource list is several megabytes and might take a while to process
             FactoryHardTimeout = TimeSpan.FromSeconds(10)
         })


### PR DESCRIPTION
RR data is not very volatile, upping the use of stale data to improve resillience of RR downtime.