### PR TITLE
fix(api): Validate authorization attribute

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/FluentValidation/FluentValidationStringExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/FluentValidation/FluentValidationStringExtensions.cs
@@ -1,9 +1,10 @@
-﻿using FluentValidation;
+﻿using System.Text.RegularExpressions;
+using FluentValidation;
 using HtmlAgilityPack;
 
 namespace Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
 
-internal static class FluentValidationStringExtensions
+internal static partial class FluentValidationStringExtensions
 {
     private static readonly string[] AllowedTags = ["p", "a", "br", "em", "strong", "ul", "ol", "li"];
     private static readonly string ContainsValidHtmlError =
@@ -39,6 +40,21 @@ internal static class FluentValidationStringExtensions
         return ruleBuilder
             .Must(x => x is null || x.HtmlAgilityPackCheck())
             .WithMessage(ContainsValidHtmlError);
+    }
+
+    [GeneratedRegex(
+        "^(?:urn:altinn:(?:app|resource|subresource):)?[a-z][a-z0-9_-]*$",
+        RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex ValidAuthorizationAttributeRegex();
+
+    public static IRuleBuilderOptions<T, string?> IsValidAuthorizationAttribute<T>(
+        this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .Must(value => value is null || ValidAuthorizationAttributeRegex().IsMatch(value))
+            .WithMessage("'{PropertyName}' must be on format 'urn:altinn:app:{app-name}' or " +
+                         "'urn:altinn:resource:{resource-name}' or 'urn:altinn:subresource:{subresource-name}' " +
+                         "or {subresource-name} with valid names.");
     }
 
     private static bool HtmlAgilityPackCheck(this string html)

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogApiActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogApiActionDtoValidator.cs
@@ -18,7 +18,8 @@ internal sealed class CreateDialogDialogApiActionDtoValidator : AbstractValidato
             .MaximumLength(Constants.DefaultMaxStringLength);
 
         RuleFor(x => x.AuthorizationAttribute)
-            .MaximumLength(Constants.DefaultMaxStringLength);
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .IsValidAuthorizationAttribute();
 
         RuleFor(x => x.Name)
             .MaximumLength(Constants.DefaultMaxStringLength);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogGuiActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogGuiActionDtoValidator.cs
@@ -25,7 +25,8 @@ internal sealed class CreateDialogDialogGuiActionDtoValidator : AbstractValidato
             .MaximumLength(Constants.DefaultMaxUriLength);
 
         RuleFor(x => x.AuthorizationAttribute)
-            .MaximumLength(Constants.DefaultMaxStringLength);
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .IsValidAuthorizationAttribute();
 
         RuleFor(x => x.Priority)
             .IsInEnum();

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogTransmissionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogTransmissionDtoValidator.cs
@@ -40,7 +40,8 @@ internal sealed class CreateDialogDialogTransmissionDtoValidator : AbstractValid
             .SetValidator(actorValidator);
 
         RuleFor(x => x.AuthorizationAttribute)
-            .MaximumLength(Constants.DefaultMaxStringLength);
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .IsValidAuthorizationAttribute();
 
         RuleFor(x => x.Attachments)
             .UniqueBy(x => x.Id);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogApiActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogApiActionDtoValidator.cs
@@ -14,7 +14,8 @@ internal sealed class UpdateDialogDialogApiActionDtoValidator : AbstractValidato
             .MaximumLength(Constants.DefaultMaxStringLength);
 
         RuleFor(x => x.AuthorizationAttribute)
-            .MaximumLength(Constants.DefaultMaxStringLength);
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .IsValidAuthorizationAttribute();
 
         RuleFor(x => x.Name)
             .MaximumLength(Constants.DefaultMaxStringLength);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogGuiActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogGuiActionDtoValidator.cs
@@ -21,7 +21,8 @@ internal sealed class UpdateDialogDialogGuiActionDtoValidator : AbstractValidato
             .MaximumLength(Constants.DefaultMaxUriLength);
 
         RuleFor(x => x.AuthorizationAttribute)
-            .MaximumLength(Constants.DefaultMaxStringLength);
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .IsValidAuthorizationAttribute();
 
         RuleFor(x => x.Priority)
             .IsInEnum();

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogTransmissionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogTransmissionDtoValidator.cs
@@ -40,7 +40,8 @@ internal sealed class UpdateDialogDialogTransmissionDtoValidator : AbstractValid
             .SetValidator(actorValidator);
 
         RuleFor(x => x.AuthorizationAttribute)
-            .MaximumLength(Constants.DefaultMaxStringLength);
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .IsValidAuthorizationAttribute();
 
         RuleFor(x => x.Attachments)
             .UniqueBy(x => x.Id);


### PR DESCRIPTION
## Description

This adds validation to authorization attribute values to avoid runtime errors with XACML requests containing invalid attribute values

## Related Issue(s)

- #2644 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

