### PR TITLE
Add system user support for parties, add system user claims

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using System.Security.Claims;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
@@ -16,9 +15,7 @@ public static class ClaimsPrincipalExtensions
 {
     private const string ConsumerClaim = "consumer";
     private const string SupplierClaim = "supplier";
-    private const string AuthorityClaim = "authority";
     private const string AuthorityValue = "iso6523-actorid-upis";
-    private const string IdClaim = "ID";
     private const char IdDelimiter = ':';
     private const string IdPrefix = "0192";
     private const string AltinnClaimPrefix = "urn:altinn:";
@@ -37,15 +34,15 @@ public static class ClaimsPrincipalExtensions
         return value is not null;
     }
 
-    public static bool TryGetOrganizationNumber(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? orgNumber)
-        => claimsPrincipal.FindFirst(ConsumerClaim).TryGetOrganizationNumber(out orgNumber);
+    public static bool TryGetConsumerOrgNumber(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? orgNumber)
+        => claimsPrincipal.FindFirst(ConsumerClaim).TryGetConsumerOrgNumber(out orgNumber);
 
     public static bool HasScope(this ClaimsPrincipal claimsPrincipal, string scope) =>
         claimsPrincipal.TryGetClaimValue(ScopeClaim, out var scopes) &&
         scopes.Split(ScopeClaimSeparator).Contains(scope);
 
     public static bool TryGetSupplierOrgNumber(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? orgNumber)
-        => claimsPrincipal.FindFirst(SupplierClaim).TryGetOrganizationNumber(out orgNumber);
+        => claimsPrincipal.FindFirst(SupplierClaim).TryGetConsumerOrgNumber(out orgNumber);
 
     public static bool TryGetPid(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? pid)
         => claimsPrincipal.FindFirst(PidClaim).TryGetPid(out pid);
@@ -64,55 +61,6 @@ public static class ClaimsPrincipalExtensions
         }
 
         return pid is not null;
-    }
-
-    // https://docs.altinn.studio/authentication/systemauthentication/
-    private sealed class SystemUserAuthorizationDetails
-    {
-        [JsonPropertyName("type")]
-        public string? Type { get; set; }
-
-        [JsonPropertyName("systemuser_id")]
-        public string[]? SystemUserIds { get; set; }
-    }
-
-    private static bool TryGetAuthorizationDetailsClaimValue(this ClaimsPrincipal claimsPrincipal,
-        [NotNullWhen(true)] out SystemUserAuthorizationDetails[]? authorizationDetails)
-    {
-        authorizationDetails = null;
-
-        if (!claimsPrincipal.TryGetClaimValue(AuthorizationDetailsClaim, out var authDetailsJson))
-        {
-            return false;
-        }
-
-        JsonNode? authDetailsJsonNode;
-        try
-        {
-            authDetailsJsonNode = JsonNode.Parse(authDetailsJson);
-            if (authDetailsJsonNode is null)
-            {
-                return false;
-            }
-        }
-        catch (JsonException)
-        {
-            // If the JSON is malformed, we cannot parse it, so we return false
-            return false;
-        }
-
-        // If a claim is an array, but contains only one element, it will be deserialized as a single object by dotnet
-        if (authDetailsJsonNode.GetValueKind() is JsonValueKind.Array)
-        {
-            authorizationDetails = JsonSerializer.Deserialize<SystemUserAuthorizationDetails[]>(authDetailsJson);
-        }
-        else
-        {
-            var systemUserAuthorizationDetails = JsonSerializer.Deserialize<SystemUserAuthorizationDetails>(authDetailsJson);
-            authorizationDetails = [systemUserAuthorizationDetails!];
-        }
-
-        return authorizationDetails is not null;
     }
 
     public static bool TryGetSystemUserId(this Claim claim,
@@ -150,7 +98,28 @@ public static class ClaimsPrincipalExtensions
         return systemUserId is not null;
     }
 
-    public static bool TryGetOrganizationNumber(this Claim? consumerClaim, [NotNullWhen(true)] out string? orgNumber)
+    public static bool TryGetSystemUserOrgNumber(this ClaimsPrincipal claimsPrincipal,
+        [NotNullWhen(true)] out string? orgNumber)
+    {
+        orgNumber = null;
+
+        if (!claimsPrincipal.TryGetAuthorizationDetailsClaimValue(out var authorizationDetails))
+        {
+            return false;
+        }
+
+        if (authorizationDetails.Length == 0)
+        {
+            return false;
+        }
+
+        var systemUserDetails = authorizationDetails.FirstOrDefault(x => x.Type == AuthorizationDetailsType);
+
+        return systemUserDetails?.SystemUserOrg is not null
+               && TryGetOrganizationNumberFromConsumerOrganization(systemUserDetails.SystemUserOrg, out orgNumber);
+    }
+
+    public static bool TryGetConsumerOrgNumber(this Claim? consumerClaim, [NotNullWhen(true)] out string? orgNumber)
     {
         orgNumber = null;
         if (consumerClaim is null || consumerClaim.Type != ConsumerClaim)
@@ -158,31 +127,7 @@ public static class ClaimsPrincipalExtensions
             return false;
         }
 
-        var consumerClaimJson = JsonSerializer.Deserialize<Dictionary<string, string>>(consumerClaim.Value);
-
-        if (consumerClaimJson is null)
-        {
-            return false;
-        }
-
-        if (!consumerClaimJson.TryGetValue(AuthorityClaim, out var authority) ||
-            !string.Equals(authority, AuthorityValue, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (!consumerClaimJson.TryGetValue(IdClaim, out var id))
-        {
-            return false;
-        }
-
-        orgNumber = id.Split(IdDelimiter) switch
-        {
-            [IdPrefix, var on] => NorwegianOrganizationIdentifier.IsValid(on) ? on : null,
-            _ => null
-        };
-
-        return orgNumber is not null;
+        return TryGetOrganizationNumberFromConsumerOrganization(JsonSerializer.Deserialize<ConsumerOrganization>(consumerClaim.Value), out orgNumber);
     }
 
     public static int GetAuthenticationLevel(this ClaimsPrincipal claimsPrincipal)
@@ -253,7 +198,7 @@ public static class ClaimsPrincipalExtensions
         }
 
         if (claimsPrincipal.HasScope(AuthorizationScope.ServiceProvider) &&
-            claimsPrincipal.TryGetOrganizationNumber(out externalId))
+            claimsPrincipal.TryGetConsumerOrgNumber(out externalId))
         {
             return (UserIdType.ServiceOwner, externalId);
         }
@@ -281,9 +226,86 @@ public static class ClaimsPrincipalExtensions
         };
     }
 
-    internal static bool TryGetOrganizationNumber(this IUser user, [NotNullWhen(true)] out string? orgNumber) =>
-        user.GetPrincipal().TryGetOrganizationNumber(out orgNumber);
+    private static bool TryGetAuthorizationDetailsClaimValue(this ClaimsPrincipal claimsPrincipal,
+        [NotNullWhen(true)] out SystemUserAuthorizationDetails[]? authorizationDetails)
+    {
+        authorizationDetails = null;
 
-    internal static bool TryGetPid(this IUser user, [NotNullWhen(true)] out string? pid) =>
-        user.GetPrincipal().TryGetPid(out pid);
+        if (!claimsPrincipal.TryGetClaimValue(AuthorizationDetailsClaim, out var authDetailsJson))
+        {
+            return false;
+        }
+
+        JsonNode? authDetailsJsonNode;
+        try
+        {
+            authDetailsJsonNode = JsonNode.Parse(authDetailsJson);
+            if (authDetailsJsonNode is null)
+            {
+                return false;
+            }
+        }
+        catch (JsonException)
+        {
+            // If the JSON is malformed, we cannot parse it, so we return false
+            return false;
+        }
+
+        // If a claim is an array, but contains only one element, it will be deserialized as a single object by dotnet
+        if (authDetailsJsonNode.GetValueKind() is JsonValueKind.Array)
+        {
+            authorizationDetails = JsonSerializer.Deserialize<SystemUserAuthorizationDetails[]>(authDetailsJson);
+        }
+        else
+        {
+            var systemUserAuthorizationDetails = JsonSerializer.Deserialize<SystemUserAuthorizationDetails>(authDetailsJson);
+            authorizationDetails = [systemUserAuthorizationDetails!];
+        }
+
+        return authorizationDetails is not null;
+    }
+
+    private static bool TryGetOrganizationNumberFromConsumerOrganization(ConsumerOrganization? consumerOrganization, [NotNullWhen(true)] out string? orgNumber)
+    {
+        orgNumber = null;
+
+        if (consumerOrganization is null)
+        {
+            return false;
+        }
+
+        if (!consumerOrganization.Authority.Equals(AuthorityValue, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        orgNumber = consumerOrganization.Id.Split(IdDelimiter) switch
+        {
+            [IdPrefix, var on] => NorwegianOrganizationIdentifier.IsValid(on) ? on : null,
+            _ => null
+        };
+
+        return orgNumber is not null;
+    }
+
+    // https://docs.altinn.studio/authentication/systemauthentication/
+    private sealed class SystemUserAuthorizationDetails
+    {
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        [JsonPropertyName("systemuser_id")]
+        public string[]? SystemUserIds { get; set; }
+
+        [JsonPropertyName("systemuser_org")]
+        public ConsumerOrganization SystemUserOrg { get; set; } = new();
+    }
+
+    private sealed class ConsumerOrganization
+    {
+        [JsonPropertyName("authority")]
+        public string Authority { get; set; } = null!;
+        [JsonPropertyName("ID")]
+        public string Id { get; set; } = null!;
+    }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IDialogTokenGenerator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IDialogTokenGenerator.cs
@@ -5,6 +5,7 @@ using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Parties;
+using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Digdir.Domain.Dialogporten.Application.Common;
@@ -41,30 +42,48 @@ internal sealed class DialogTokenGenerator : IDialogTokenGenerator
         _compactJwsGenerator = compactJwsGenerator ?? throw new ArgumentNullException(nameof(compactJwsGenerator));
     }
 
-    public string GetDialogToken(DialogEntity dialog, DialogDetailsAuthorizationResult authorizationResult, string issuerVersion)
+    public string GetDialogToken(DialogEntity dialog, DialogDetailsAuthorizationResult authorizationResult,
+        string issuerVersion)
     {
         var claimsPrincipal = _user.GetPrincipal();
         var now = _clock.UtcNowOffset.ToUnixTimeSeconds();
+        var endUserPartyIdentifier = claimsPrincipal.GetEndUserPartyIdentifier()!;
 
-        var claims = new Dictionary<string, object?>
+        var claims = new Dictionary<string, object?>(15)
         {
-            { DialogTokenClaimTypes.JwtId, Guid.NewGuid() },
-            { DialogTokenClaimTypes.AuthenticatedParty, GetAuthenticatedParty() },
-            { DialogTokenClaimTypes.AuthenticationLevel, claimsPrincipal.GetAuthenticationLevel() },
-            { DialogTokenClaimTypes.DialogParty, dialog.Party },
-            { DialogTokenClaimTypes.ServiceResource, dialog.ServiceResource },
-            { DialogTokenClaimTypes.DialogId, dialog.Id },
-            { DialogTokenClaimTypes.Actions, GetAuthorizedActions(authorizationResult) },
-            { DialogTokenClaimTypes.Issuer, _applicationSettings.Dialogporten.BaseUri.AbsoluteUri.TrimEnd('/') + issuerVersion },
-            { DialogTokenClaimTypes.IssuedAt, now },
-            { DialogTokenClaimTypes.NotBefore, now },
-            { DialogTokenClaimTypes.Expires, now + (long)_tokenLifetime.TotalSeconds }
+            [DialogTokenClaimTypes.JwtId] = Guid.NewGuid()
         };
 
+        // If we have authenticated a system user, we want the consumer organization number as the authenticated party
+        // and adding the system user identifier as a separate claim along with the system user's organization.
+        if (endUserPartyIdentifier is SystemUserIdentifier
+            && claimsPrincipal.TryGetConsumerOrgNumber(out var consumerOrgNumber)
+            && claimsPrincipal.TryGetSystemUserOrgNumber(out var systemUserOrgNumber))
+        {
+            claims[DialogTokenClaimTypes.AuthenticatedParty] = NorwegianOrganizationIdentifier.PrefixWithSeparator + consumerOrgNumber;
+            claims[DialogTokenClaimTypes.SystemUserId] = endUserPartyIdentifier.FullId;
+            claims[DialogTokenClaimTypes.SystemUserOrg] = NorwegianOrganizationIdentifier.PrefixWithSeparator + systemUserOrgNumber;
+        }
+        else
+        {
+            claims[DialogTokenClaimTypes.AuthenticatedParty] = endUserPartyIdentifier.FullId;
+        }
+
+        // If we have a supplier organization number from Maskinporten delegation ("supplier"), add it as a separate claim.
         if (claimsPrincipal.TryGetSupplierOrgNumber(out var supplierOrgNumber))
         {
-            claims.Add(DialogTokenClaimTypes.SupplierParty, NorwegianOrganizationIdentifier.PrefixWithSeparator + supplierOrgNumber);
+            claims[DialogTokenClaimTypes.SupplierParty] = NorwegianOrganizationIdentifier.PrefixWithSeparator + supplierOrgNumber;
         }
+
+        claims[DialogTokenClaimTypes.AuthenticationLevel] = claimsPrincipal.GetAuthenticationLevel();
+        claims[DialogTokenClaimTypes.DialogParty] = dialog.Party;
+        claims[DialogTokenClaimTypes.ServiceResource] = dialog.ServiceResource;
+        claims[DialogTokenClaimTypes.DialogId] = dialog.Id;
+        claims[DialogTokenClaimTypes.Actions] = GetAuthorizedActions(authorizationResult);
+        claims[DialogTokenClaimTypes.Issuer] = _applicationSettings.Dialogporten.BaseUri.AbsoluteUri.TrimEnd('/') + issuerVersion;
+        claims[DialogTokenClaimTypes.IssuedAt] = now;
+        claims[DialogTokenClaimTypes.NotBefore] = now;
+        claims[DialogTokenClaimTypes.Expires] = now + (long)_tokenLifetime.TotalSeconds;
 
         return _compactJwsGenerator.GetCompactJws(claims);
     }
@@ -93,21 +112,6 @@ internal sealed class DialogTokenGenerator : IDialogTokenGenerator
 
         return actions.ToString();
     }
-
-    private string GetAuthenticatedParty()
-    {
-        if (_user.TryGetPid(out var pid))
-        {
-            return NorwegianPersonIdentifier.PrefixWithSeparator + pid;
-        }
-
-        if (_user.TryGetOrganizationNumber(out var orgNumber))
-        {
-            return NorwegianOrganizationIdentifier.PrefixWithSeparator + orgNumber;
-        }
-
-        throw new InvalidOperationException("User must have either pid or org number");
-    }
 }
 
 public static class DialogTokenClaimTypes
@@ -121,6 +125,8 @@ public static class DialogTokenClaimTypes
     public const string AuthenticatedParty = "c";
     public const string DialogParty = "p";
     public const string SupplierParty = "u";
+    public const string SystemUserId = "y";
+    public const string SystemUserOrg = "o";
     public const string ServiceResource = "s";
     public const string DialogId = "i";
     public const string Actions = "a";

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IUserOrganizationRegistry.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IUserOrganizationRegistry.cs
@@ -22,7 +22,7 @@ public sealed class UserOrganizationRegistry : IUserOrganizationRegistry
 
     public async Task<string?> GetCurrentUserOrgShortName(CancellationToken cancellationToken)
     {
-        if (!_user.TryGetOrganizationNumber(out var orgNumber))
+        if (!_user.GetPrincipal().TryGetConsumerOrgNumber(out var orgNumber))
         {
             return null;
         }

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IUserParties.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IUserParties.cs
@@ -21,10 +21,11 @@ public sealed class UserParties : IUserParties
         _altinnAuthorization = altinnAuthorization ?? throw new ArgumentNullException(nameof(altinnAuthorization));
     }
 
-    public Task<AuthorizedPartiesResult> GetUserParties(CancellationToken cancellationToken = default) =>
-        _user.TryGetPid(out var pid) &&
-        NorwegianPersonIdentifier.TryParse(NorwegianPersonIdentifier.PrefixWithSeparator + pid,
-            out var partyIdentifier)
+    public Task<AuthorizedPartiesResult> GetUserParties(CancellationToken cancellationToken = default)
+    {
+        var partyIdentifier = _user.GetPrincipal().GetEndUserPartyIdentifier();
+        return partyIdentifier != null
             ? _altinnAuthorization.GetAuthorizedParties(partyIdentifier, cancellationToken: cancellationToken)
             : Task.FromResult(new AuthorizedPartiesResult());
+    }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IUserResourceRegistry.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IUserResourceRegistry.cs
@@ -33,7 +33,7 @@ internal sealed class UserResourceRegistry : IUserResourceRegistry
 
     public async Task<IReadOnlyCollection<string>> GetCurrentUserResourceIds(CancellationToken cancellationToken)
     {
-        if (!_user.TryGetOrganizationNumber(out var orgNumber))
+        if (!_user.GetPrincipal().TryGetConsumerOrgNumber(out var orgNumber))
         {
             throw new UnreachableException();
         }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
@@ -176,7 +176,7 @@ internal sealed class CreateDialogCommandHandler : IRequestHandler<CreateDialogC
 
     private void AddSystemLabel(DialogEntity dialog, SystemLabel.Values labelToAdd)
     {
-        if (!_user.TryGetOrganizationNumber(out var organizationNumber))
+        if (!_user.GetPrincipal().TryGetConsumerOrgNumber(out var organizationNumber))
         {
             _domainContext.AddError(new DomainFailure(nameof(organizationNumber), "Cannot find organization number for current user."));
             return;

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
@@ -187,7 +187,7 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
 
     private void AddSystemLabel(DialogEntity dialog, SystemLabel.Values labelToAdd)
     {
-        if (!_user.TryGetOrganizationNumber(out var organizationNumber))
+        if (!_user.GetPrincipal().TryGetConsumerOrgNumber(out var organizationNumber))
         {
             _domainContext.AddError(new DomainFailure(nameof(organizationNumber), "Cannot find organization number for current user."));
             return;

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Common/Authorization/AuthorizationPolicyBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Common/Authorization/AuthorizationPolicyBuilderExtensions.cs
@@ -17,5 +17,5 @@ internal static class AuthorizationPolicyBuilderExtensions
                 .Contains(scope)));
 
     public static AuthorizationPolicyBuilder RequireValidConsumerClaim(this AuthorizationPolicyBuilder builder) =>
-        builder.RequireAssertion(ctx => ctx.User.TryGetOrganizationNumber(out _));
+        builder.RequireAssertion(ctx => ctx.User.TryGetConsumerOrgNumber(out _));
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Authorization/AuthorizationPolicyBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Authorization/AuthorizationPolicyBuilderExtensions.cs
@@ -17,5 +17,5 @@ internal static class AuthorizationPolicyBuilderExtensions
                 .Contains(scope)));
 
     public static AuthorizationPolicyBuilder RequireValidConsumerClaim(this AuthorizationPolicyBuilder builder) =>
-        builder.RequireAssertion(ctx => ctx.User.TryGetOrganizationNumber(out _));
+        builder.RequireAssertion(ctx => ctx.User.TryGetConsumerOrgNumber(out _));
 }


### PR DESCRIPTION
## Description

This fixes the parties endpoint for system users, removing the guard that only allowed personal users to get the party list. In addition
* Adds system user id and system user org claims to dialog tokens
* Cleanups in ClaimsPrincipalExtensions and DialogTokenGenerator

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
