### PR TITLE
fix(ci): ensure we checkout the proper ref when publishing nuget package

### DIFF
--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -112,6 +112,7 @@ jobs:
       version: ${{ inputs.version }}
       path: 'src/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj'
       source: 'https://api.nuget.org/v3/index.json'
+      ref: "refs/tags/v${{ inputs.version }}"
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 

--- a/.github/workflows/workflow-publish-nuget.yml
+++ b/.github/workflows/workflow-publish-nuget.yml
@@ -15,6 +15,11 @@ on:
         description: "Nuget Source"
         required: true
         type: string
+      ref:
+        description: "The branch or tag ref to publish. Using default checkout ref if not provided."
+        required: false
+        default: ${{ github.ref }}
+        type: string
     secrets:
       NUGET_API_KEY:
         required: true
@@ -34,6 +39,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up .NET
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

When running ci-cd-production.yaml it used `main` as a ref. This would result in that the package had `main` as a base instead of the actual tag to be deployed. 

## Related Issue(s)

- #N/A
