### PR TITLE
test(e2e): refactor dialog search tests

### DIFF
--- a/tests/k6/tests/serviceowner/dialogSearch.js
+++ b/tests/k6/tests/serviceowner/dialogSearch.js
@@ -188,13 +188,13 @@ export default function () {
         });
 
         // Update single dialog
-        let penultimateDialogId = dialogIds[0];
-        let penultimateDialog = dialogToInsert();
-        penultimateDialog.id = penultimateDialogId;
-        setProcess(penultimateDialog, "urn:test:process:1");
-        setTitle(penultimateDialog, titleForUpdatedItem);
+        let firstDialogId = dialogIds[0];
+        let firstDialog = dialogToInsert();
+        firstDialog.id = firstDialogId;
+        setProcess(firstDialog, "urn:test:process:1");
+        setTitle(firstDialog, titleForUpdatedItem);
 
-        let post = putSO("dialogs/" + penultimateDialogId, penultimateDialog);
+        let post = putSO("dialogs/" + firstDialogId, firstDialog);
         expectStatusFor(post).to.equal(204);
 
         // Assert


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Made E2E tests in DialogSearch.js not dependent on different tests to run before/after it
## Related Issue(s)

- #2587 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
