### PR TITLE
fix(ci): use valid Azure names for storage account and rbac roles

### DIFF
--- a/.azure/applications/aggregate-cost-metrics-job/main.bicep
+++ b/.azure/applications/aggregate-cost-metrics-job/main.bicep
@@ -86,7 +86,7 @@ resource storageContainer 'Microsoft.Storage/storageAccounts/blobServices/contai
 }
 
 module storageBlobDataContributorRole '../../modules/storageAccount/addBlobDataContributorRole.bicep' = {
-  name: 'storageBlobDataContributorRole-${name}'
+  name: 'storageContributorRole-${name}'
   params: {
     storageAccountName: storageAccount.outputs.storageAccountName
     principalIds: [managedIdentity.properties.principalId]
@@ -94,7 +94,7 @@ module storageBlobDataContributorRole '../../modules/storageAccount/addBlobDataC
 }
 
 module appInsightsMonitoringReaderRole '../../modules/applicationInsights/addMonitoringReaderRole.bicep' = {
-  name: 'appInsightsMonitoringReaderRole-${name}'
+  name: 'appInsightsReaderRole-${name}'
   params: {
     appInsightsName: appInsightsName
     principalIds: [managedIdentity.properties.principalId]

--- a/.azure/modules/storageAccount/main.bicep
+++ b/.azure/modules/storageAccount/main.bicep
@@ -19,7 +19,7 @@ param enableHierarchicalNamespace bool = false
 @description('The access tier for the storage account')
 param accessTier 'Hot' | 'Cool' = 'Hot'
 
-var storageAccountName = take('${namePrefix}storage${uniqueString(resourceGroup().id)}', 24)
+var storageAccountName = take('${toLower(replace(namePrefix, '-', ''))}storage${uniqueString(resourceGroup().id)}', 24)
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   name: storageAccountName


### PR DESCRIPTION
## Related Issue(s)

- #2377 