### PR TITLE
trivial(ci): disallow backticks in PR titles

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,11 +4,11 @@
     "color": "EEEEEE"
   },
   "CHECKS": {
-    "regexp": "^(feat|fix|docs|test|ci|chore|trivial)!?(\\(.*\\))?!?:.*"
+    "regexp": "^(?!.*`)(feat|fix|docs|test|ci|chore|trivial)!?(\\(.*\\))?!?:.*"
   },
   "MESSAGES": {
     "success": "PR title is valid",
     "failure": "PR title is invalid",
-    "notice": "PR Title needs to pass regex '^(feat|fix|docs|test|ci|chore|trivial)!?(\\(.*\\))?!?:.*"
+    "notice": "PR Title needs to pass regex '^(?!.*`)(feat|fix|docs|test|ci|chore|trivial)!?(\\(.*\\))?!?:.*'"
   }
 }


### PR DESCRIPTION
They cause the sending of Slack messages to fail, backticks initiate a command substitution in .sh

```
### Miscellaneous Chores
* **janitor:** Update cost metrics aggregation to use `IHostEnvironment`, remove deployment to test ([#2911](https://github.com/Altinn/dialogporten/issues/2911)) ([2ef77d9](https://github.com/Altinn/dialogporten/commit/2ef77d93b5b3283786da5ab5c265619964400008))
```
Example: https://github.com/Altinn/dialogporten/actions/runs/18711732351/job/53361918045#step:6:39