### PR TITLE
chore(janitor): Integrate environment Key Vault and add secret handing for cost metrics job to match existing jobs

### DIFF
--- a/.azure/applications/aggregate-cost-metrics-job/prod.bicepparam
+++ b/.azure/applications/aggregate-cost-metrics-job/prod.bicepparam
@@ -11,3 +11,4 @@ param storageContainerName = 'costmetrics'
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')
 param appInsightConnectionString = readEnvironmentVariable('AZURE_APP_INSIGHTS_CONNECTION_STRING')
 param azureSubscriptionId = readEnvironmentVariable('AZURE_SUBSCRIPTION_ID')
+param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/aggregate-cost-metrics-job/staging.bicepparam
+++ b/.azure/applications/aggregate-cost-metrics-job/staging.bicepparam
@@ -11,4 +11,5 @@ param storageContainerName = 'costmetrics'
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')
 param appInsightConnectionString = readEnvironmentVariable('AZURE_APP_INSIGHTS_CONNECTION_STRING')
 param azureSubscriptionId = readEnvironmentVariable('AZURE_SUBSCRIPTION_ID')
+param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')
 


### PR DESCRIPTION
While Redis isn't used by the cost metrics job itself, the Janitor application requires the Redis connection string in its configuration to prevent startup errors.

## Related Issue(s)

- #2377
