### PR TITLE
chore(api): Increase max request size to cater for huge A3 instances

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Constants.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Constants.cs
@@ -7,7 +7,7 @@ internal static class Constants
     internal const string ETag = "Etag";
     internal const string Authorization = "Authorization";
     internal const string CurrentTokenIssuer = "CurrentIssuer";
-    internal const int MaxRequestBodySize = 2_000_000;
+    internal const int MaxRequestBodySizeInBytes = 2_000_000;
 
     internal static class SwaggerSummary
     {

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Extensions/ErrorResponseBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Extensions/ErrorResponseBuilderExtensions.cs
@@ -35,7 +35,7 @@ internal static class ErrorResponseBuilderExtensions
         {
             StatusCodes.Status413PayloadTooLarge => new ProblemDetails
             {
-                Title = $"Payload too large. The maximum allowed size is {Constants.MaxRequestBodySize} bytes.",
+                Title = $"Payload too large. The maximum allowed size is {Constants.MaxRequestBodySizeInBytes} bytes.",
                 Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.11",
                 Status = statusCode,
                 Instance = ctx.Request.Path,

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -58,7 +58,7 @@ static void BuildAndRun(string[] args)
 
     builder.WebHost.ConfigureKestrel(kestrelOptions =>
     {
-        kestrelOptions.Limits.MaxRequestBodySize = Constants.MaxRequestBodySize;
+        kestrelOptions.Limits.MaxRequestBodySize = Constants.MaxRequestBodySizeInBytes;
     });
 
     builder.Configuration


### PR DESCRIPTION
Fix for some instances of dialogs having a very large number of attachments