### PR TITLE
fix: fix string formatting for order conditions

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
@@ -104,19 +104,19 @@ internal static class PostgresFormattableStringBuilderExtensions
         orderPart.Direction switch
         {
             OrderDirection.Asc when orderPart.Type.IsNullableType() && orderPart.Value is not null
-                => builder.Append($""" {orderPart.Key} IS NULL OR "{orderPart.Key}" > '{orderPart.Value}'"""),
+                => builder.Append((string)$""" "{orderPart.Key}" IS NULL OR "{orderPart.Key}" > """).Append($"{orderPart.Value}"),
             OrderDirection.Desc when orderPart.Type.IsNullableType() && orderPart.Value is null
-                => builder.Append($""" {orderPart.Key} IS NOT NULL"""),
+                => builder.Append((string)$""" "{orderPart.Key}" IS NOT NULL"""),
 
-            OrderDirection.Asc => builder.Append($""" {orderPart.Key} > '{orderPart.Value}'"""),
-            OrderDirection.Desc => builder.Append($""" {orderPart.Key} < '{orderPart.Value}'"""),
+            OrderDirection.Asc => builder.Append((string)$""" "{orderPart.Key}" > """).Append($"{orderPart.Value}"),
+            OrderDirection.Desc => builder.Append((string)$""" "{orderPart.Key}" < """).Append($"{orderPart.Value}"),
             _ => throw new InvalidOperationException()
         };
 
     private static PostgresFormattableStringBuilder CreateEqualsPart(this PostgresFormattableStringBuilder builder, OrderPart x) =>
         x.Value is not null
-            ? builder.Append($""" {x.Key} = '{x.Value}'""")
-            : builder.Append($""" {x.Key} IS NULL""");
+            ? builder.Append((string)$""" "{x.Key}" = """).Append($"{x.Value}")
+            : builder.Append((string)$""" "{x.Key}" IS NULL""");
 
     private sealed record OrderPart(OrderDirection Direction, Type Type, string Key, object? Value);
 


### PR DESCRIPTION
Koden slik den står nå vil sende inn kolonne-navnet som en string, og legge på for mange fnutter rundt verdien som skal sjekkes opp mot ved paginering. Denne PRen vil gjøre paginering om fra
`AND ( 'CreatedAt < ''2019-08-10T08:39:44.0000000+00:00'' OR ( 'Id' < ''016c7aae-ff00-7db9-a9d7-42c37dfb5775'' AND 'CreatedAt' = ''2019-08-10T08:39:44.0000000+00:00'')) `
til
`AND ( "CreatedAt" < '2019-08-10T08:39:44.0000000+00:00' OR ( "Id" < '016c7aae-ff00-7db9-a9d7-42c37dfb5775' AND "CreatedAt" = '2019-08-10T08:39:44.0000000+00:00')) `