### PR TITLE
chore(infra): Use flags and party filter against authorizedparties

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -22,7 +22,7 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.Authorization;
 internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
 {
     private const string AuthorizeUrl = "authorization/api/v1/authorize";
-    private const string AuthorizedPartiesUrl = "/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true";
+    private const string AuthorizedPartiesBaseUrl = "/accessmanagement/api/v1/resourceowner/authorizedparties";
 
     private readonly HttpClient _httpClient;
     private readonly IFusionCache _pdpCache;
@@ -97,6 +97,14 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
     {
         var authorizedPartiesRequest = new AuthorizedPartiesRequest(authenticatedParty);
 
+        return await GetAuthorizedPartiesInternal(authorizedPartiesRequest, flatten, cancellationToken);
+    }
+
+    private async Task<AuthorizedPartiesResult> GetAuthorizedPartiesInternal(
+        AuthorizedPartiesRequest authorizedPartiesRequest,
+        bool flatten,
+        CancellationToken cancellationToken)
+    {
         AuthorizedPartiesResult authorizedParties;
         using (_logger.TimeOperation(nameof(GetAuthorizedParties)))
         {
@@ -221,7 +229,18 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
     private async Task<DialogSearchAuthorizationResult> PerformDialogSearchAuthorization(DialogSearchAuthorizationRequest request, CancellationToken cancellationToken)
     {
         var partyIdentifier = request.Claims.GetEndUserPartyIdentifier() ?? throw new UnreachableException();
-        var authorizedParties = await GetAuthorizedParties(partyIdentifier, flatten: true, cancellationToken: cancellationToken);
+        var authorizedPartiesRequest = new AuthorizedPartiesRequest(
+            partyIdentifier,
+            includeAccessPackages: true,
+            includeRoles: true,
+            includeResources: true,
+            includeInstances: true,
+            partyFilter: CreatePartyFilters(request.ConstraintParties));
+
+        var authorizedParties = await GetAuthorizedPartiesInternal(
+            authorizedPartiesRequest,
+            flatten: true,
+            cancellationToken);
 
         var result = await AuthorizationHelper.ResolveDialogSearchAuthorization(
             authorizedParties,
@@ -257,6 +276,41 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
             },
             token: cancellationToken);
 
+    private static List<AuthorizedPartyFilter> CreatePartyFilters(List<string> constraintParties)
+    {
+        if (constraintParties.Count == 0)
+        {
+            return [];
+        }
+
+        var filters = new List<AuthorizedPartyFilter>(constraintParties.Count);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var party in constraintParties)
+        {
+            if (string.IsNullOrWhiteSpace(party)
+                || !PartyIdentifier.TryParse(party.AsSpan(), out var identifier))
+            {
+                continue;
+            }
+
+            var type = identifier.Prefix();
+            var filterKey = $"{type}:{identifier.Id}";
+            if (!seen.Add(filterKey))
+            {
+                continue;
+            }
+
+            filters.Add(new AuthorizedPartyFilter
+            {
+                Type = type,
+                Value = identifier.Id
+            });
+        }
+
+        return filters;
+    }
+
     private async Task<DialogDetailsAuthorizationResult> PerformDialogDetailsAuthorization(
         DialogDetailsAuthorizationRequest request, CancellationToken cancellationToken)
     {
@@ -287,7 +341,16 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
     private async Task<List<AuthorizedPartiesResultDto>?> SendAuthorizedPartiesRequest(
         AuthorizedPartiesRequest authorizedPartiesRequest, CancellationToken cancellationToken) =>
         await SendRequest<List<AuthorizedPartiesResultDto>>(
-            AuthorizedPartiesUrl, authorizedPartiesRequest, cancellationToken);
+            BuildAuthorizedPartiesUrl(authorizedPartiesRequest), authorizedPartiesRequest, cancellationToken);
+
+    private static string BuildAuthorizedPartiesUrl(AuthorizedPartiesRequest request)
+    {
+        return $"{AuthorizedPartiesBaseUrl}?includeAltinn2=true" +
+               $"&includeAccessPackages={(request.IncludeAccessPackages ? "true" : "false")}" +
+               $"&includeRoles={(request.IncludeRoles ? "true" : "false")}" +
+               $"&includeResources={(request.IncludeResources ? "true" : "false")}" +
+               $"&includeInstances={(request.IncludeInstances ? "true" : "false")}";
+    }
 
     private async Task<T?> SendRequest<T>(string url, object request, CancellationToken cancellationToken)
     {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesRequest.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesRequest.cs
@@ -1,24 +1,70 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json.Serialization;
 using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
 
 namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.Authorization;
 
-internal sealed class AuthorizedPartiesRequest(IPartyIdentifier partyIdentifier)
+internal sealed class AuthorizedPartiesRequest(
+    IPartyIdentifier partyIdentifier,
+    bool includeAccessPackages = false,
+    bool includeRoles = false,
+    bool includeResources = false,
+    bool includeInstances = false,
+    IEnumerable<AuthorizedPartyFilter>? partyFilter = null)
 {
-    public string Type { get; init; } = partyIdentifier.Prefix();
-    public string Value { get; init; } = partyIdentifier.Id;
+    public string Type { get; } = partyIdentifier.Prefix();
+    public string Value { get; } = partyIdentifier.Id;
+
+    [JsonPropertyName("partyFilter")]
+    public List<AuthorizedPartyFilter> PartyFilter { get; } =
+        partyFilter?.Select(filter => new AuthorizedPartyFilter
+        {
+            Type = filter.Type,
+            Value = filter.Value
+        }).ToList() ?? [];
+
+    [JsonIgnore]
+    public bool IncludeAccessPackages { get; } = includeAccessPackages;
+
+    [JsonIgnore]
+    public bool IncludeRoles { get; } = includeRoles;
+
+    [JsonIgnore]
+    public bool IncludeResources { get; } = includeResources;
+
+    [JsonIgnore]
+    public bool IncludeInstances { get; } = includeInstances;
 }
 
 internal static class AuthorizedPartiesRequestExtensions
 {
     public static string GenerateCacheKey(this AuthorizedPartiesRequest request)
     {
-        var rawKey = $"{request.Type}:{request.Value}";
+        var optionsKey =
+            $"{BoolToChar(request.IncludeAccessPackages)}{BoolToChar(request.IncludeRoles)}" +
+            $"{BoolToChar(request.IncludeResources)}{BoolToChar(request.IncludeInstances)}";
+
+        var partyFilterKey = request.PartyFilter.Count == 0
+            ? string.Empty
+            : string.Join(";", request.PartyFilter
+                .OrderBy(filter => filter.Type, StringComparer.Ordinal)
+                .ThenBy(filter => filter.Value, StringComparer.Ordinal)
+                .Select(filter => $"{filter.Type}:{filter.Value}"));
+
+        var rawKey = $"{request.Type}:{request.Value}|{optionsKey}|{partyFilterKey}";
 
         var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(rawKey));
         var hashString = BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
 
         return $"auth:parties:{hashString}";
     }
+
+    private static char BoolToChar(bool value) => value ? '1' : '0';
+}
+
+internal sealed class AuthorizedPartyFilter
+{
+    public required string Type { get; init; }
+    public required string Value { get; init; }
 }

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/AuthorizedPartiesRequestTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/AuthorizedPartiesRequestTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
+using Digdir.Domain.Dialogporten.Infrastructure.Altinn.Authorization;
+using Xunit;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests;
+
+public class AuthorizedPartiesRequestTests
+{
+    [Fact]
+    public void GenerateCacheKey_ShouldChange_WhenIncludeFlagsDiffer()
+    {
+        var identifier = new TestPartyIdentifier();
+
+        var defaultKey = new AuthorizedPartiesRequest(identifier).GenerateCacheKey();
+        var includeResourcesKey = new AuthorizedPartiesRequest(identifier, includeResources: true).GenerateCacheKey();
+
+        Assert.NotEqual(defaultKey, includeResourcesKey);
+    }
+
+    [Fact]
+    public void GenerateCacheKey_ShouldChange_WhenPartyFilterDiffers()
+    {
+        var identifier = new TestPartyIdentifier();
+        var partyFilter = new List<AuthorizedPartyFilter>
+        {
+            new()
+            {
+                Type = TestPartyIdentifier.Prefix,
+                Value = "789"
+            }
+        };
+
+        var defaultKey = new AuthorizedPartiesRequest(identifier).GenerateCacheKey();
+        var filterKey = new AuthorizedPartiesRequest(identifier, partyFilter: partyFilter).GenerateCacheKey();
+
+        Assert.NotEqual(defaultKey, filterKey);
+    }
+
+    private sealed class TestPartyIdentifier : IPartyIdentifier
+    {
+        public TestPartyIdentifier(string id = "123")
+        {
+            Id = id;
+            FullId = PrefixWithSeparator + id;
+        }
+
+        public string FullId { get; }
+        public string Id { get; }
+        public static string Prefix => "urn:altinn:test";
+        public static string PrefixWithSeparator => Prefix + PartyIdentifier.Separator;
+
+        public static bool TryParse(ReadOnlySpan<char> value, [NotNullWhen(true)] out IPartyIdentifier? identifier)
+        {
+            identifier = new TestPartyIdentifier(value.ToString());
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Description

This utilizes new flags in resourceowner/authorizedparties to not include information about authorized roles/packages/resources/instances when just proxying authorized party. In addition, when a party filter is included, this is passed to authorizedparties when performing requests related to list authorizations

## Related Issue(s)

- n/a

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
