### PR TITLE
fix(infra): Use new register endpoint for name lookups

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/ApplicationSettings.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/ApplicationSettings.cs
@@ -14,6 +14,7 @@ public sealed class ApplicationSettings
 public sealed class FeatureToggle
 {
     public bool UseOptimizedEndUserDialogSearch { get; init; }
+    public bool UseCorrectNamingConventionForParties { get; init; }
 }
 
 public sealed class DialogportenSettings


### PR DESCRIPTION
## Description

This utilizes the new endpoint in register for party name lookups.

## Related Issue(s)

- n/a

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
