### PR TITLE
chore(logging): Don't treat empty party list as error if party filter is supplied

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -215,9 +215,12 @@ internal sealed class AltinnAuthorizationClient : IAltinnAuthorization
         CancellationToken cancellationToken)
     {
         var authorizedPartiesDto = await SendAuthorizedPartiesRequest(authorizedPartiesRequest, cancellationToken);
-        // System users might have no rights whatsoever, which is not an error condition
-        // Other user types (persons, SI users) will always be able to represent themselves as a minimum
-        if (authorizedPartiesDto is null || (authorizedPartiesDto.Count == 0 && authorizedPartiesRequest.Type != SystemUserIdentifier.Prefix))
+        // System users might have no rights whatsoever, which is not an error condition. Other user types (persons, SI users)
+        // will always be able to represent themselves as a minimum, unless a party filter is supplied
+        if (authorizedPartiesDto is null || (
+                authorizedPartiesDto.Count == 0
+                && authorizedPartiesRequest.Type != SystemUserIdentifier.Prefix
+                && authorizedPartiesRequest.PartyFilter.Count == 0))
         {
             _logger.LogWarning("Empty authorized parties for party T={Type} V={Value}", authorizedPartiesRequest.Type, authorizedPartiesRequest.Value);
             throw new UpstreamServiceException("access-management returned no authorized parties, missing Altinn profile?");


### PR DESCRIPTION
## Description
This stops treating empty party list as error if a party filter is supplied

## Related Issue(s)

- n/a

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
