### PR TITLE
fix(DialogSearch): Fix json parsing of search query

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearchRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearchRepository.cs
@@ -160,9 +160,9 @@ internal sealed class DialogSearchRepository(DialogDbContext dbContext, ILogger<
                 $"""
                  raw_permissions AS (
                     SELECT p.party, s.service
-                    FROM jsonb_to_recordset({JsonSerializer.Serialize(partiesAndServices)}::jsonb) AS x(parties text[], services text[])
-                    CROSS JOIN LATERAL unnest(x.services) AS s(service)
-                    CROSS JOIN LATERAL unnest(x.parties) AS p(party)
+                    FROM jsonb_to_recordset({JsonSerializer.Serialize(partiesAndServices)}::jsonb) AS x("Parties" text[], "Services" text[])
+                    CROSS JOIN LATERAL unnest(x."Services") AS s(service)
+                    CROSS JOIN LATERAL unnest(x."Parties") AS p(party)
                  )
                  ,party_permission_map AS (
                      SELECT party

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/DialogApplication.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/DialogApplication.cs
@@ -172,6 +172,10 @@ public class DialogApplication : IAsyncLifetime
             .Value
             .Returns(new ApplicationSettings
             {
+                FeatureToggle = new FeatureToggle
+                {
+                    UseOptimizedEndUserDialogSearch = true
+                },
                 Dialogporten = new DialogportenSettings
                 {
                     BaseUri = new Uri("https://integration.test"),


### PR DESCRIPTION
The introduction of the PartiesAndServices record changed the jsion property casing of the query input, confusing postgres. This PR fixes the parsing error. 

In addition this PR switches all tests over to using the new enduser search by flipping the feature flag in the test suite.