### PR TITLE
chore(llm): Disable CodeRabbit docstring check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,6 +12,9 @@ reviews:
   poem: false
   collapse_walkthrough: true
   sequence_diagrams: false
+  finishing_touches:
+    docstrings:
+      enabled: false
   labeling_instructions: []
   path_filters: ["!**/Migrations/**/*Designer.cs", "!**/Migrations/DialogDbContextModelSnapshot.cs"]
   path_instructions: []


### PR DESCRIPTION
## Description

This disables the docstring check in CodeRabbit as it currently represents more noise than signal.

## Related Issue(s)

- n/a

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
