### PR TITLE
chore(deps): Top-level dependency for AsyncKeyedLock

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Digdir.Domain.Dialogporten.Infrastructure.csproj
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Digdir.Domain.Dialogporten.Infrastructure.csproj
@@ -1,17 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.2.1"/>
+        <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.2.1" />
+        <PackageReference Include="AsyncKeyedLock" Version="7.1.8" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Include="EntityFrameworkCore.Exceptions.PostgreSQL" Version="8.1.3" />
         <PackageReference Include="HotChocolate.Subscriptions.Redis" Version="15.1.11" />
         <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="8.5.7" />
         <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.5.7" />
         <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.11" />
-        <PackageReference Include="Altinn.Authorization.ABAC" Version="0.1.1"/>
+        <PackageReference Include="Altinn.Authorization.ABAC" Version="0.1.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.11" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.11" />
-        <PackageReference Include="Npgsql" Version="9.0.4"/>
+        <PackageReference Include="Npgsql" Version="9.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.11">
             <PrivateAssets>all</PrivateAssets>
@@ -21,26 +22,26 @@
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.11" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.11" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
-        <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1"/>
+        <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="ZiggyCreatures.FusionCache.Locking.AsyncKeyed" Version="2.4.0" />
-        <PackageReference Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" Version="2.4.0"/>
-        <PackageReference Include="ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack" Version="2.4.0"/>
+        <PackageReference Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" Version="2.4.0" />
+        <PackageReference Include="ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack" Version="2.4.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Digdir.Domain.Dialogporten.Application\Digdir.Domain.Dialogporten.Application.csproj"/>
-        <ProjectReference Include="..\Digdir.Library.Entity.EntityFrameworkCore\Digdir.Library.Entity.EntityFrameworkCore.csproj"/>
+        <ProjectReference Include="..\Digdir.Domain.Dialogporten.Application\Digdir.Domain.Dialogporten.Application.csproj" />
+        <ProjectReference Include="..\Digdir.Library.Entity.EntityFrameworkCore\Digdir.Library.Entity.EntityFrameworkCore.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Digdir.Domain.Dialogporten.Application.Integration.Tests"/>
-        <InternalsVisibleTo Include="Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests"/>
-        <InternalsVisibleTo Include="Digdir.Domain.Dialogporten.GraphQL"/>
+        <InternalsVisibleTo Include="Digdir.Domain.Dialogporten.Application.Integration.Tests" />
+        <InternalsVisibleTo Include="Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests" />
+        <InternalsVisibleTo Include="Digdir.Domain.Dialogporten.GraphQL" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="DynamicProxyGenAssembly2"/>
-        <InternalsVisibleTo Include="Digdir.Domain.Dialogporten.Architecture.Tests"/>
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+        <InternalsVisibleTo Include="Digdir.Domain.Dialogporten.Architecture.Tests" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Description

Currently, AsyncKeyedLock is used transitively via a FusionCache adapter but it is not the latest version so it would be wise to have it at the top level to take advantage of performance benefits.

## Related Issue(s)

N/A

## Verification

- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [N/A] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [N/A] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
