### PR TITLE
trivial: Document workaround for ´dotnet build´ failing in container on Mac M4

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ brew install docker-compose
 
 5. Check that `Docker Compatibility mode` is enabled, see the bottom left corner
 
-6. Enable privileged [testcontainers-dotnet](https://github.com/testcontainers/testcontainers-dotnet/issues/876#issuecomment-1930397928)  
+6. If you have an M4 processor, check that the Podman Machine uses `LibKRun` not `Apple Hypervisor`. 
+   Otherwise, recreate the Podman Machine and change the setting.
+   Note: This is a workaround for `dotnet build` crashing inside containers on M4.
+
+7. Enable privileged [testcontainers-dotnet](https://github.com/testcontainers/testcontainers-dotnet/issues/876#issuecomment-1930397928)  
 `echo "ryuk.container.privileged = true" >> $HOME/.testcontainers.properties`
 
 ### Windows 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
