### PR TITLE
chore: Disable Npsql serilog override

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.prod.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.prod.json
@@ -1,12 +1,4 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Override": {
-        "Npgsql": "Information",
-        "Npgsql.Internal": "Information"
-      }
-    }
-  },
   "Infrastructure": {
     "EnableSqlStatementLogging": true,
     "EnableSqlParametersLogging": false,


### PR DESCRIPTION
## Description

This disables ingestion of Npsql query texts to AppTraces via Serilog / ILogger, keeping the OTEL telemetry instrumentation providing the same information into AppDependencies

## Related Issue(s)

- n/a

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
