### PR TITLE
trivial: ignore agents and claude configuration folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,5 +402,11 @@ CLAUDE.md
 # Bicep build output (compiled ARM template)
 .azure/infrastructure/main.json
 
-# Codex related files (skills, workflows, etc.)
+# Codex related files (skills, workflows, etc. for codex agents)
 .codex
+
+# Agents related files (used for skills, workflows, etc. for generic agents)
+.agents
+
+# Claude Code related files (used for skills, workflows, etc. for claude agents)
+.claude


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Using https://skills.sh/ to install skills into project. It will install to the agents that is preferred (or all). Using .agents as a symlink to keep a source of truth for configuration. 

## Related Issue(s)

- #N/A
