### PR TITLE
ci: still run dotnet e2e tests when k6 fails

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -147,7 +147,7 @@ jobs:
 
   run-graphql-e2e-tests:
     name: "Run GraphQL E2E tests"
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
+    if: ${{ always() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
     needs: [ run-e2e-tests, check-for-changes ]
     uses: ./.github/workflows/workflow-run-graphql-e2e-tests.yml
     secrets:
@@ -158,7 +158,7 @@ jobs:
 
   run-webapi-e2e-tests:
     name: "Run WebAPI E2E tests"
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
+    if: ${{ always() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
     needs: [ run-graphql-e2e-tests, check-for-changes ]
     uses: ./.github/workflows/workflow-run-webapi-e2e-tests.yml
     secrets:

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -144,7 +144,7 @@ jobs:
 
   run-graphql-e2e-tests:
     name: "Run GraphQL E2E tests"
-    if: ${{ always() && !failure() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
+    if: ${{ always() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
     needs: [ run-e2e-tests, check-for-changes ]
     uses: ./.github/workflows/workflow-run-graphql-e2e-tests.yml
     secrets:
@@ -156,7 +156,7 @@ jobs:
 
   run-webapi-e2e-tests:
     name: "Run WebAPI E2E tests"
-    if: ${{ always() && !failure() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
+    if: ${{ always() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
     needs: [ run-graphql-e2e-tests, check-for-changes ]
     uses: ./.github/workflows/workflow-run-webapi-e2e-tests.yml
     secrets:

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -115,7 +115,7 @@ jobs:
 
   run-graphql-e2e-tests:
     name: "Run GraphQL E2E tests"
-    if: ${{ always() && !failure() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
+    if: ${{ always() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
     needs: [ run-e2e-tests, check-for-changes ]
     uses: ./.github/workflows/workflow-run-graphql-e2e-tests.yml
     secrets:
@@ -127,7 +127,7 @@ jobs:
 
   run-webapi-e2e-tests:
     name: "Run WebAPI E2E tests"
-    if: ${{ always() && !failure() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
+    if: ${{ always() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
     needs: [ run-graphql-e2e-tests, check-for-changes ]
     uses: ./.github/workflows/workflow-run-webapi-e2e-tests.yml
     secrets:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- #3346 
- #3203 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
