### PR TITLE
feat: Added minimum length of 3 character for dialog idempotentKey

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDtoValidator.cs
@@ -40,6 +40,7 @@ internal sealed class CreateDialogDtoValidator : AbstractValidator<CreateDialogD
                 x.UpdatedAt.HasValue && x.UpdatedAt != default(DateTimeOffset));
 
         RuleFor(x => x.IdempotentKey)
+            .MinimumLength(Constants.MinIdempotentKeyLength)
             .MaximumLength(Constants.MaxIdempotentKeyLength);
 
         RuleFor(x => x.ServiceResource)

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/UniqueConstraintTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/UniqueConstraintTests.cs
@@ -102,6 +102,30 @@ public class UniqueConstraintTests : ApplicationCollectionFixture
     }
 
     [Fact]
+    public Task Cannot_Exceed_Dialog_IdempotentKey_Max_Length_When_Creating_Dialog() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog(x => x
+                .Dto.IdempotentKey = "Random string which is longer than maximum allowed idempotentKey length")
+            .ExecuteAndAssert<ValidationError>(x =>
+            {
+                var err = x.Errors.Single();
+                err.ErrorCode.Should().Be("MaximumLengthValidator");
+                err.ErrorMessage.Should().Contain(nameof(CreateDialogDto.IdempotentKey));
+            });
+
+    [Fact]
+    public Task Cannot_Go_Below_The_Dialog_IdempotentKey_Min_Length_When_Creating_Dialog() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog(x => x
+                    .Dto.IdempotentKey = "be")
+            .ExecuteAndAssert<ValidationError>(x =>
+            {
+                var err = x.Errors.Single();
+                err.ErrorCode.Should().Be("MinimumLengthValidator");
+                err.ErrorMessage.Should().Contain(nameof(CreateDialogDto.IdempotentKey));
+            });
+
+    [Fact]
     public async Task Cannot_Use_Duplicate_Transmission_IdempotentKey_When_Creating_Dialog()
     {
         var idempotentKey1 = NewUuidV7().ToString();


### PR DESCRIPTION
Add check on minimum dialog idempotentKey length

## Description
Only support idempotentKeys between 3 and 36 including both limits

Before this is merged, we need to check DB if someone have made keys below 3 characters

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/3349

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
