### PR TITLE
chore(postgresql): remove parameter logging

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -71,14 +71,12 @@ param appInsightsSku AppInsightsSku
 import { Sku as PostgresSku } from '../modules/postgreSql/create.bicep'
 import { StorageConfiguration as PostgresStorageConfig } from '../modules/postgreSql/create.bicep'
 import { HighAvailabilityConfiguration as PostgresHighAvailabilityConfig } from '../modules/postgreSql/create.bicep'
-import { ParameterLoggingConfiguration as PostgresParameterLoggingConfig } from '../modules/postgreSql/create.bicep'
 
 param postgresConfiguration {
   sku: PostgresSku
   storage: PostgresStorageConfig
   enableIndexTuning: bool
   enableQueryPerformanceInsight: bool
-  parameterLogging: PostgresParameterLoggingConfig
   highAvailability: PostgresHighAvailabilityConfig?
   backupRetentionDays: int
   availabilityZone: string
@@ -237,7 +235,6 @@ module postgresql '../modules/postgreSql/create.bicep' = {
     appInsightWorkspaceName: appInsights.outputs.appInsightsWorkspaceName
     enableIndexTuning: postgresConfiguration.enableIndexTuning
     enableQueryPerformanceInsight: postgresConfiguration.enableQueryPerformanceInsight
-    parameterLogging: postgresConfiguration.parameterLogging
     subnetId: vnet.outputs.postgresqlSubnetId
     vnetId: vnet.outputs.virtualNetworkId
     highAvailability: postgresConfiguration.?highAvailability

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -54,9 +54,6 @@ param postgresConfiguration = {
   // Enabling index tuning will practically also enable query performance insight
   enableIndexTuning: true
   enableQueryPerformanceInsight: false
-  parameterLogging: {
-    enabled: false
-  }
   backupRetentionDays: 32
   availabilityZone: '3'
   enableBackupVault: true

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -40,9 +40,6 @@ param postgresConfiguration = {
   // Enabling index tuning will practically also enable query performance insight
   enableIndexTuning: false
   enableQueryPerformanceInsight: true
-  parameterLogging: {
-    enabled: false
-  }
   backupRetentionDays: 7
   availabilityZone: '1'
   enableBackupVault: false

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -42,10 +42,6 @@ param postgresConfiguration = {
   // Enabling index tuning will practically also enable query performance insight
   enableIndexTuning: true
   enableQueryPerformanceInsight: true
-  parameterLogging: {
-    enabled: true
-    logMinDurationStatementMs: 5000
-  }
   backupRetentionDays: 7
   availabilityZone: '1'
   enableBackupVault: false

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -54,17 +54,6 @@ param enableQueryPerformanceInsight bool
 @description('Enable index tuning')
 param enableIndexTuning bool
 
-@export()
-type ParameterLoggingConfiguration = {
-  @description('Enable parameter logging for queries')
-  enabled: bool
-  @description('Minimum query duration in milliseconds to log. Defaults to 5000ms (5 seconds). Set to 0 to log all queries.')
-  logMinDurationStatementMs: int?
-}
-
-@description('Parameter logging configuration. Logs query parameters for slow queries which can be useful for debugging but increases log volume.')
-param parameterLogging ParameterLoggingConfiguration
-
 @description('The name of the Application Insights workspace')
 param appInsightWorkspaceName string
 
@@ -272,37 +261,6 @@ resource index_tuning_mode 'Microsoft.DBforPostgreSQL/flexibleServers/configurat
     source: 'user-override'
   }
   dependsOn: [pg_qs_query_capture_mode]
-}
-
-// Parameter logging configuration (independent of Query Store)
-resource log_min_duration_statement 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = if (parameterLogging.enabled) {
-  parent: postgres
-  name: 'log_min_duration_statement'
-  properties: {
-    value: string(parameterLogging.?logMinDurationStatementMs ?? 5000)
-    source: 'user-override'
-  }
-  dependsOn: [idle_transactions_timeout]
-}
-
-resource log_statement 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = if (parameterLogging.enabled) {
-  parent: postgres
-  name: 'log_statement'
-  properties: {
-    value: 'none'  // Only log queries that exceed log_min_duration_statement
-    source: 'user-override'
-  }
-  dependsOn: [log_min_duration_statement]
-}
-
-resource log_duration 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = if (parameterLogging.enabled) {
-  parent: postgres
-  name: 'log_duration'
-  properties: {
-    value: 'on'  // Log duration of completed statements
-    source: 'user-override'
-  }
-  dependsOn: [log_statement]
 }
 
 resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

We are not using parameter logging in postgresql as we have enabled this in code. This setting also causes some race condition when updating server params, so removing it. 

## Related Issue(s)

- #N/A