### PR TITLE
chore: Add application validation for transmission counts to prevent overflow

### DIFF
--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Transmissions/Commands/CreateTransmissionTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Transmissions/Commands/CreateTransmissionTests.cs
@@ -7,9 +7,11 @@ using AwesomeAssertions;
 using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.CreateTransmission;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.Common.Extensions;
-using Digdir.Domain.Dialogporten.Domain.Common;
 using Digdir.Library.Entity.Abstractions.Features.Identifiable;
 using TransmissionAttachmentDto = Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.CreateTransmission.TransmissionAttachmentDto;
+using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+using Constants = Digdir.Domain.Dialogporten.Domain.Common.Constants;
 
 namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.ServiceOwner.Transmissions.Commands;
 
@@ -69,4 +71,24 @@ public class CreateTransmissionTests : ApplicationCollectionFixture
                     attachment.Name = new string('a', Constants.DefaultMaxStringLength + 1)))
             .ExecuteAndAssert<ValidationError>(result =>
                 result.ShouldHaveErrorWithText(nameof(TransmissionAttachmentDto.Name)));
+
+    [Fact]
+    public Task Cannot_Create_More_Than_ShortMaxValue_Transmissions() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog()
+            .AssertResult<CreateDialogSuccess>()
+            .Modify((_, ctx) =>
+            {
+                using var scope = Application.GetServiceProvider().CreateScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<DialogDbContext>();
+                var dialogEntity = dbContext.Dialogs
+                    .Single(x => x.Id == ctx.GetDialogId());
+                dialogEntity.FromServiceOwnerTransmissionsCount = short.MaxValue - 1;
+                dbContext.SaveChanges();
+            })
+            .CreateTransmission((_, _) => { })
+            .AssertResult<CreateTransmissionSuccess>()
+            .CreateTransmission((_, _) => { })
+            .ExecuteAndAssert<DomainError>(x =>
+                x.ShouldHaveErrorWithText($"cannot exceed {short.MaxValue}"));
 }


### PR DESCRIPTION
In DialogTransmissionAppender.Append, transmission counts was cast to short when updating FromPartyTransmissionsCount and FromServiceOwnerTransmissionsCount:

Now a error is added to the domainContext and all errors are returned to the caller at the end of the request.

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/3165

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

Automatic test is written, but is skipped because it takes too long time 