### PR TITLE
chore: adjust otel trace sampler ratio

### DIFF
--- a/.azure/applications/graphql/prod.bicepparam
+++ b/.azure/applications/graphql/prod.bicepparam
@@ -14,7 +14,7 @@ param resources = {
     memory: '4Gi'
 }
 
-param otelTraceSamplerRatio = '0.2'
+param otelTraceSamplerRatio = '0.05'
 
 // Use dedicated workload profile
 param workloadProfileName = 'Dedicated-D8'

--- a/.azure/applications/graphql/staging.bicepparam
+++ b/.azure/applications/graphql/staging.bicepparam
@@ -8,7 +8,7 @@ param whitelistedIPs = [
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/graphql/yt01.bicepparam
+++ b/.azure/applications/graphql/yt01.bicepparam
@@ -12,7 +12,7 @@ param resources = {
     memory: '4Gi'
 }
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // Use dedicated workload profile
 param workloadProfileName = 'Dedicated-D8'

--- a/.azure/applications/service/prod.bicepparam
+++ b/.azure/applications/service/prod.bicepparam
@@ -15,7 +15,7 @@ param resources = {
     memory: '4Gi'
 }
 
-param otelTraceSamplerRatio = '0.2'
+param otelTraceSamplerRatio = '0.05'
 
 // secrets
 param appInsightConnectionString = readEnvironmentVariable('AZURE_APP_INSIGHTS_CONNECTION_STRING')

--- a/.azure/applications/service/staging.bicepparam
+++ b/.azure/applications/service/staging.bicepparam
@@ -9,7 +9,7 @@ param appConfigurationName = readEnvironmentVariable('AZURE_APP_CONFIGURATION_NA
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')
 param serviceBusNamespaceName = readEnvironmentVariable('AZURE_SERVICE_BUS_NAMESPACE_NAME')
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // secrets
 param appInsightConnectionString = readEnvironmentVariable('AZURE_APP_INSIGHTS_CONNECTION_STRING')

--- a/.azure/applications/service/yt01.bicepparam
+++ b/.azure/applications/service/yt01.bicepparam
@@ -13,7 +13,7 @@ param resources = {
     memory: '4Gi'
 }
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // secrets
 param appInsightConnectionString = readEnvironmentVariable('AZURE_APP_INSIGHTS_CONNECTION_STRING')

--- a/.azure/applications/web-api-eu/prod.bicepparam
+++ b/.azure/applications/web-api-eu/prod.bicepparam
@@ -14,7 +14,7 @@ param resources = {
     memory: '4Gi'
 }
 
-param otelTraceSamplerRatio = '0.2'
+param otelTraceSamplerRatio = '0.05'
 
 // Use dedicated workload profile
 param workloadProfileName = 'Dedicated-D8'

--- a/.azure/applications/web-api-eu/staging.bicepparam
+++ b/.azure/applications/web-api-eu/staging.bicepparam
@@ -8,7 +8,7 @@ param whitelistedIPs = [
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/web-api-eu/yt01.bicepparam
+++ b/.azure/applications/web-api-eu/yt01.bicepparam
@@ -12,7 +12,7 @@ param resources = {
     memory: '4Gi'
 }
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // Use dedicated workload profile
 param workloadProfileName = 'Dedicated-D8'

--- a/.azure/applications/web-api-so/prod.bicepparam
+++ b/.azure/applications/web-api-so/prod.bicepparam
@@ -14,7 +14,7 @@ param resources = {
     memory: '4Gi'
 }
 
-param otelTraceSamplerRatio = '0.2'
+param otelTraceSamplerRatio = '0.05'
 
 // Use dedicated workload profile
 param workloadProfileName = 'Dedicated-D8'

--- a/.azure/applications/web-api-so/staging.bicepparam
+++ b/.azure/applications/web-api-so/staging.bicepparam
@@ -13,7 +13,7 @@ param resources = {
     memory: '2Gi'
 }
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/web-api-so/yt01.bicepparam
+++ b/.azure/applications/web-api-so/yt01.bicepparam
@@ -12,7 +12,7 @@ param resources = {
     memory: '4Gi'
 }
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // Use dedicated workload profile
 param workloadProfileName = 'Dedicated-D8'


### PR DESCRIPTION
## Summary
- set non-test otelTraceSamplerRatio to 0.05 across all apps/environments
- keep test environment ratio at 1

## Testing
- not run (config-only change)