### PR TITLE
fix: logging override for party/service tuples

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.json
@@ -11,8 +11,8 @@
         "Microsoft.AspNetCore": "Warning",
         "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "Fatal",
 
-        // This enables logging of parties/service tuples counts being fed into authorization
-        "Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearchRepository": "Information"
+        // This enables logging of parties/service tuples counts being fed into the search SQL query
+        "Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearch": "Information"
       }
     }
   },

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
@@ -13,8 +13,8 @@
         "Microsoft.EntityFrameworkCore": "Fatal",
         "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "Fatal",
 
-        // This enables logging of parties/service tuples counts being fed into authorization
-        "Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearchRepository": "Information",
+        // This enables logging of parties/service tuples counts being fed into the search SQL query
+        "Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearch": "Information",
 
         // WARNING! This is critical to cost management tracking and should not be disabled.
         "Digdir.Domain.Dialogporten.Application.Common.Behaviours.FeatureMetric.LoggingFeatureMetricDeliveryContext": "Information"


### PR DESCRIPTION
## Description
#3493 introduced a namespace change that disabled PartiesAndServices-logging. This fixes it.

## Related Issue(s)

- n/a

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
