### PR TITLE
fix: Filtering of exceptions already handled

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/UnitOfWork.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/UnitOfWork.cs
@@ -144,18 +144,11 @@ internal sealed class UnitOfWork : IUnitOfWork, IAsyncDisposable, IDisposable
                 ? new ConcurrencyError()
                 : new Conflict("", "The request conflicted with a concurrent operation. Please try again.");
         }
-        catch (UniqueConstraintException ex) when
-            (ex.InnerException?.Data["Detail"] is string message &&
-            ex.InnerException.Data["TableName"] is string tableName)
+        catch (Exception ex) when (ex is UniqueConstraintException or ReferenceConstraintException &&
+                                   ex.InnerException?.Data["Detail"] is string message &&
+                                   ex.InnerException.Data["TableName"] is string tableName)
         {
             _domainContext.AddError(tableName, message.Replace('"', '\''));
-        }
-        catch (ReferenceConstraintException)
-        {
-            // A request triggers loading of exising data, but before it's saved,
-            // another request removes it — causing the save attempt to fail.
-            // On a retry, the client will get a "proper" error message
-            return new Conflict("", "The request conflicted with a concurrent operation. Please try again.");
         }
         catch (Exception ex) when (IsSerializationFailure(ex))
         {

--- a/src/Digdir.Library.Utils.AspNet/Constants.cs
+++ b/src/Digdir.Library.Utils.AspNet/Constants.cs
@@ -10,7 +10,7 @@ public static class Constants
     public const string DbQueryParameters = "db.query.parameters";
     public const string DbStatement = "db.statement";
     public const string OtelStatusCode = "otel.status_code";
-    public const string OtelStatusDescription = "otel.status_description";
+    public const string DbStatusCode = "db.response.status_code";
 
     public const string FusionCache = "ZiggyCreatures";
     public const string AspNetCore = "Microsoft.AspNetCore";

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogActivityTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogActivityTests.cs
@@ -246,7 +246,7 @@ public class CreateDialogActivityTests(DialogApplication application) : Applicat
                     Description = []
                 }
             )
-            .ExecuteAndAssert<Conflict>();
+            .ExecuteAndAssert<DomainError>();
     }
 
     [Fact]


### PR DESCRIPTION
## Description
Exceptions with id 23503 and 23505 is reported as errors.
These are already handled and should not make noise in our alerts channel

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/3388

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
