### PR TITLE
trivial: add .omc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -412,5 +412,8 @@ CLAUDE.md
 .claude
 .claude_settings.json
 
+# Oh My Claude Code related files
+.omc
+
 # Auto Claude data directory, *security and *status files
 .auto-claude*


### PR DESCRIPTION
## Summary
- Adds `.omc` (Oh My Claude Code) directory to `.gitignore` alongside other agent tool directories (`.claude`, `.codex`, `.agents`)

## Test plan
- [ ] Verify `.omc` directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)