### PR TITLE
chore(infra): deploy PostgreSQL migration target in infra workflow

### DIFF
--- a/.github/workflows/workflow-deploy-infra.yml
+++ b/.github/workflows/workflow-deploy-infra.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Dryrun Deploy PostgreSQL migration target (${{ inputs.environment }})
         uses: azure/bicep-deploy@4d5dc29bf04d05546dd5df9c665c54b9c5213207 # v2.2.0
-        if: ${{ inputs.dryRun && inputs.environment != 'staging' && inputs.environment != 'prod' && hashFiles(format('.azure/infrastructure/postgresql-migration-target.{0}.bicepparam', inputs.environment)) != '' }}
+        if: ${{ inputs.dryRun && inputs.environment != 'staging' && inputs.environment != 'prod' }}
         id: deploy-migration-target-dry-run
         env:
           # secrets
@@ -157,7 +157,7 @@ jobs:
 
       - name: Deploy PostgreSQL migration target (${{ inputs.environment }})
         uses: azure/bicep-deploy@4d5dc29bf04d05546dd5df9c665c54b9c5213207 # v2.2.0
-        if: ${{ !inputs.dryRun && inputs.environment != 'staging' && inputs.environment != 'prod' && hashFiles(format('.azure/infrastructure/postgresql-migration-target.{0}.bicepparam', inputs.environment)) != '' }}
+        if: ${{ !inputs.dryRun && inputs.environment != 'staging' && inputs.environment != 'prod' }}
         id: deploy-migration-target
         env:
           # secrets


### PR DESCRIPTION
## Summary
- Add dry-run deployment for `.azure/infrastructure/postgresql-migration-target.bicep` in `workflow-deploy-infra.yml`.
- Add actual deployment for the same migration target template in non-dry-run mode.
- Only deploy for test and yt01

## Test plan
- [x] Verified workflow YAML diff for expected dry-run and deploy steps.
- [x] Confirmed new steps reuse existing secrets and Azure subscription input wiring.
- [ ] Run GitHub Actions workflow in dry-run mode for `test`/`yt01`.
- [ ] Run GitHub Actions workflow deploy mode for `test`/`yt01` when ready.

Made with [Cursor](https://cursor.com)