### PR TITLE
fix(infra): enable Active Directory and password authentication for PostgreSQL server

### DIFF
--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -214,6 +214,10 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
     dataEncryption: {
       type: 'SystemManaged'
     }
+    authConfig: {
+      activeDirectoryAuth: 'Enabled'
+      passwordAuth: 'Enabled'
+    }
     replicationRole: 'Primary'
     network: {
       delegatedSubnetResourceId: subnetId


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
EntraId has been enabled (clickops?) for our DB servers, but is not enabled initially for brand new Postgres servers created by IaC.

Deployment of a brand new postgres database server via our IaC currently fails with the following error:

```❯ Deployment failed: Error: Request failed. CorrelationId: e69a481d-b30f-455d-b05d-b3176a33d4ea                                                                                                                                                                                                                                                                            
Error: {                                                                                                                                                                                                                                                                                                                                                                   
  "code": "DeploymentFailed",                                                                                                                                                                                                                                                                                                                                              
  "target": "/subscriptions/***/resourceGroups/dp-be-test-rg/providers/Microsoft.Resources/deployments/dp-be-test-1.106.2-d8de2d3-pgmigration",                                                                                                                                                                                                                            
  "message": "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",                                                                                                                                                                                   
  "details": [                                                                                                                                                                                                                                                                                                                                                             
    {                                                                                                                                                                                                                                                                                                                                                                      
      "code": "ResourceDeploymentFailure",                                                                                                                                                                                                                                                                                                                                 
      "target": "/subscriptions/***/resourceGroups/dp-be-test-rg/providers/Microsoft.Resources/deployments/postgresqlMigrationTarget",                                                                                                                                                                                                                                     
      "message": "The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.",                                                                                                                                                                                                                                 
      "details": [                                                                                                                                                                                                                                                                                                                                                         
        {                                                                                                                                                                                                                                                                                                                                                                  
          "code": "DeploymentFailed",                                                                                                                                                                                                                                                                                                                                      
          "target": "/subscriptions/***/resourceGroups/dp-be-test-rg/providers/Microsoft.Resources/deployments/postgresqlMigrationTarget",                                                                                                                                                                                                                                 
          "message": "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",                                                                                                                                                                           
          "details": [                                                                                                                                                                                                                                                                                                                                                     
            {                                                                                                                                                                                                                                                                                                                                                              
              "code": "ResourceDeploymentFailure",                                                                                                                                                                                                                                                                                                                         
              "target": "/subscriptions/***/resourceGroups/dp-be-test-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/dp-be-test-postgres2-i7se3jtjey3lo/administrators/84805870-1289-4375-9ff7-37cf82fb1419",                                                                                                                                                      
              "message": "The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.",                                                                                                                                                                                                                         
              "details": [                                                                                                                                                                                                                                                                                                                                                 
                {                                                                                                                                                                                                                                                                                                                                                          
                  "code": "AadAuthPrincipalCreationFailed",                                                                                                                                                                                                                                                                                                                
                  "message": "Failed to create Microsoft Entra principal. Reason: 'Microsoft Entra authentication isn't enabled in server 'dp-be-test-postgres2-i7se3jtjey3lo', in resource group 'dp-be-test-rg', in subscription with identifier '***'.'."                                                                                                               
                }                                                                                                                                                                                                                                                                                                                                                          
              ]                                                                                                                                                                                                                                                                                                                                                            
            }                                                                                                                                                                                                                                                                                                                                                              
          ]                                                                                                                                                                                                                                                                                                                                                                
        }                                                                                                                                                                                                                                                                                                                                                                  
      ]                                                                                                                                                                                                                                                                                                                                                                    
    }                                                                                                                                                                                                                                                                                                                                                                      
  ]                                                                                                                                                                                                                                                                                                                                                                        
}                                                                                                                                                                                                                                                                                                                                                                          
Error: Create failed
```
<!--- Describe your changes in detail -->

## Related Issue(s)

- #3507

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
