### PR TITLE
chore: add optional public network access for redis

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -96,9 +96,11 @@ param serviceBusSku ServiceBusSku
 param serviceBusVnetEnabled bool = true
 
 import { Sku as RedisSku } from '../modules/redis/main.bicep'
-param redisSku RedisSku
-@minLength(1)
-param redisVersion string
+param redisConfiguration {
+  version: string
+  sku: RedisSku
+  publicNetworkAccess: bool?
+}
 
 var secrets = {
   dialogportenPgAdminPassword: dialogportenPgAdminPassword
@@ -263,8 +265,9 @@ module redis '../modules/redis/main.bicep' = {
     namePrefix: namePrefix
     location: location
     environmentKeyVaultName: environmentKeyVault.outputs.name
-    sku: redisSku
-    version: redisVersion
+    sku: redisConfiguration.sku
+    version: redisConfiguration.version
+    publicNetworkAccess: redisConfiguration.?publicNetworkAccess ?? false
     subnetId: vnet.outputs.redisSubnetId
     vnetId: vnet.outputs.virtualNetworkId
     tags: tags

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -267,7 +267,7 @@ module redis '../modules/redis/main.bicep' = {
     environmentKeyVaultName: environmentKeyVault.outputs.name
     sku: redisConfiguration.sku
     version: redisConfiguration.version
-    publicNetworkAccess: redisConfiguration.?publicNetworkAccess ?? false
+    publicNetworkAccess: redisConfiguration.publicNetworkAccess ?? false
     subnetId: vnet.outputs.redisSubnetId
     vnetId: vnet.outputs.virtualNetworkId
     tags: tags

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -4,7 +4,14 @@ param environment = 'prod'
 param location = 'norwayeast'
 param keyVaultSourceKeys = json(readEnvironmentVariable('AZURE_KEY_VAULT_SOURCE_KEYS'))
 
-param redisVersion = '6.0'
+param redisConfiguration = {
+  version: '6.0'
+  sku: {
+    name: 'Standard'
+    family: 'C'
+    capacity: 1
+  }
+}
 
 param containerAppEnvZoneRedundancyEnabled = true
 
@@ -62,12 +69,6 @@ param postgresConfiguration = {
 }
 
 param deployerPrincipalName = 'GitHub: altinn/dialogporten - Prod'
-
-param redisSku = {
-  name: 'Standard'
-  family: 'C'
-  capacity: 1
-}
 
 param serviceBusSku = {
   name: 'Premium'

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -4,7 +4,14 @@ param environment = 'staging'
 param location = 'norwayeast'
 param keyVaultSourceKeys = json(readEnvironmentVariable('AZURE_KEY_VAULT_SOURCE_KEYS'))
 
-param redisVersion = '6.0'
+param redisConfiguration = {
+  version: '6.0'
+  sku: {
+    name: 'Basic'
+    family: 'C'
+    capacity: 1
+  }
+}
 
 param containerAppEnvZoneRedundancyEnabled = true
 
@@ -51,12 +58,6 @@ param postgresConfiguration = {
 }
 
 param deployerPrincipalName = 'GitHub: altinn/dialogporten - Prod'
-
-param redisSku = {
-  name: 'Basic'
-  family: 'C'
-  capacity: 1
-}
 
 param serviceBusSku = {
   name: 'Premium'

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -4,7 +4,15 @@ param environment = 'test'
 param location = 'norwayeast'
 param keyVaultSourceKeys = json(readEnvironmentVariable('AZURE_KEY_VAULT_SOURCE_KEYS'))
 
-param redisVersion = '6.0'
+param redisConfiguration = {
+  version: '6.0'
+  sku: {
+    name: 'Basic'
+    family: 'C'
+    capacity: 1
+  }
+  publicNetworkAccess: true
+}
 
 param containerAppEnvZoneRedundancyEnabled = false
 
@@ -48,12 +56,6 @@ param postgresConfiguration = {
 }
 
 param deployerPrincipalName = 'GitHub: altinn/dialogporten - Dev'
-
-param redisSku = {
-  name: 'Basic'
-  family: 'C'
-  capacity: 1
-}
 
 param serviceBusSku = {
   name: 'Standard'

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -6,7 +6,14 @@ param keyVaultSourceKeys = json(readEnvironmentVariable('AZURE_KEY_VAULT_SOURCE_
 
 param appInsightsPurgeDataOn30Days = true
 
-param redisVersion = '6.0'
+param redisConfiguration = {
+  version: '6.0'
+  sku: {
+    name: 'Basic'
+    family: 'C'
+    capacity: 1
+  }
+}
 
 param containerAppEnvZoneRedundancyEnabled = false
 
@@ -50,12 +57,6 @@ param postgresConfiguration = {
 }
 
 param deployerPrincipalName = 'GitHub: altinn/dialogporten - Dev'
-
-param redisSku = {
-  name: 'Basic'
-  family: 'C'
-  capacity: 1
-}
 
 param serviceBusSku = {
   name: 'Standard'

--- a/.azure/modules/redis/main.bicep
+++ b/.azure/modules/redis/main.bicep
@@ -36,6 +36,9 @@ type Sku = {
 @description('The SKU of the Redis instance')
 param sku Sku
 
+@description('Whether to enable public network access')
+param publicNetworkAccess bool = false
+
 var redisNameMaxLength = 63
 var redisName = uniqueResourceName('${namePrefix}-redis', redisNameMaxLength)
 
@@ -54,7 +57,7 @@ resource redis 'Microsoft.Cache/Redis@2024-11-01' = {
       'maxmemory-policy': 'allkeys-lru'
     }
     redisVersion: version
-    publicNetworkAccess: 'Disabled'
+    publicNetworkAccess: publicNetworkAccess ? 'Enabled' : 'Disabled'
   }
   tags: tags
 }


### PR DESCRIPTION
## Description

- Consolidates `redisSku` and `redisVersion` parameters into a unified `redisConfiguration` object for cleaner configuration management
- Adds optional `publicNetworkAccess` parameter that defaults to `false` for security
- Enables public network access only for the `test` environment to support integration testing and external connectivity
- Updates all environment parameter files (`prod`, `staging`, `test`, `yt01`) to use the new configuration structure
- Maintains backward compatibility with existing SKU and version values across all environments