### PR TITLE
fix: Add missing checks to CreateActivityCommand

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/DialogUnopenedContent.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/DialogUnopenedContent.cs
@@ -8,11 +8,14 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common;
 
 public static class DialogUnopenedContent
 {
+    public static bool IsRelevantTransmissionType(DialogTransmissionType.Values transmissionType) =>
+        transmissionType is not (DialogTransmissionType.Values.Correction or DialogTransmissionType.Values.Submission);
+
     public static bool HasUnopenedContent(DialogEntity dialog, ServiceResourceInformation? serviceResourceInformation)
     {
         // Checks if transmissions of all types except Correction or Submission have any activities with TransmissionOpened
         var transmissions = dialog.Transmissions
-            .Where(transmission => transmission.TypeId is not (DialogTransmissionType.Values.Correction or DialogTransmissionType.Values.Submission));
+            .Where(transmission => IsRelevantTransmissionType(transmission.TypeId));
 
         if (transmissions
             .Any(transmission =>
@@ -26,7 +29,6 @@ public static class DialogUnopenedContent
             dialog.Activities.All(a => a.TypeId != DialogActivityType.Values.CorrespondenceOpened);
     }
 
-    public static bool IsOpened(DialogTransmission transmission) => transmission.TypeId
-        is not (DialogTransmissionType.Values.Correction or DialogTransmissionType.Values.Submission)
+    public static bool IsOpened(DialogTransmission transmission) => IsRelevantTransmissionType(transmission.TypeId)
         && transmission.Activities.Any(x => x.TypeId == DialogActivityType.Values.TransmissionOpened);
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogCommand.cs
@@ -124,8 +124,8 @@ internal sealed class CreateDialogCommandHandler : IRequestHandler<CreateDialogC
         CreateDialogEndUserContext(request, dialog);
         CreateDialogServiceOwnerContext(request, dialog);
 
-        var activityTypes = dialog.Activities
-            .Select(x => x.TypeId)
+        var activityTypes = request.Dto.Activities
+            .Select(x => x.Type)
             .Distinct();
 
         if (!ActivityTypeAuthorization.UsingAllowedActivityTypes(activityTypes, _user, out var errorMessage))

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateActivity/CreateActivityCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateActivity/CreateActivityCommand.cs
@@ -6,14 +6,20 @@ using Digdir.Domain.Dialogporten.Application.Common.Behaviours.FeatureMetric;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.SystemLabelAdder;
+using Digdir.Domain.Dialogporten.Domain.Common;
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 using Digdir.Library.Entity.Abstractions.Features.Identifiable;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using OneOf;
+using ResourceRegistryConstants = Digdir.Domain.Dialogporten.Application.Common.ResourceRegistry.Constants;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.CreateActivity;
 
@@ -49,6 +55,7 @@ internal sealed class CreateActivityCommandHandler : IRequestHandler<CreateActiv
     private readonly IDomainContext _domainContext;
     private readonly IDialogDbContext _db;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IUser _user;
     private readonly IUserResourceRegistry _userResourceRegistry;
     private readonly IServiceResourceAuthorizer _serviceResourceAuthorizer;
     private readonly IMapper _mapper;
@@ -58,6 +65,7 @@ internal sealed class CreateActivityCommandHandler : IRequestHandler<CreateActiv
         IDomainContext domainContext,
         IUnitOfWork unitOfWork,
         IDialogDbContext db,
+        IUser user,
         IUserResourceRegistry userResourceRegistry,
         IServiceResourceAuthorizer serviceResourceAuthorizer,
         IMapper mapper,
@@ -66,6 +74,7 @@ internal sealed class CreateActivityCommandHandler : IRequestHandler<CreateActiv
         _domainContext = domainContext;
         _unitOfWork = unitOfWork;
         _db = db;
+        _user = user;
         _userResourceRegistry = userResourceRegistry;
         _mapper = mapper;
         _systemLabelAdder = systemLabelAdder;
@@ -93,6 +102,21 @@ internal sealed class CreateActivityCommandHandler : IRequestHandler<CreateActiv
         var newActivity = _mapper.Map<DialogActivity>(request.Activity);
         newActivity.Id = newActivity.EnsureId();
         newActivity.DialogId = dialog.Id;
+
+        var activityTypeForbidden = ValidateActivityTypeAuthorization(newActivity);
+        if (activityTypeForbidden is not null)
+        {
+            return activityTypeForbidden;
+        }
+
+        var transmissionRelationError =
+            await ValidateActivityTransmissionRelationAsync(dialog.Id, newActivity, cancellationToken);
+        if (transmissionRelationError is not null)
+        {
+            return transmissionRelationError;
+        }
+
+        await UpdateHasUnopenedContentAsync(dialog, newActivity, cancellationToken);
 
         _db.DialogActivities.Add(newActivity);
 
@@ -134,5 +158,134 @@ internal sealed class CreateActivityCommandHandler : IRequestHandler<CreateActiv
             .IgnoreQueryFilters()
             .WhereIf(!isAdmin, x => x.Org == org)
             .FirstOrDefaultAsync(x => x.Id == dialogId, cancellationToken);
+    }
+
+    private Forbidden? ValidateActivityTypeAuthorization(DialogActivity newActivity)
+    {
+        IEnumerable<DialogActivityType.Values> activityTypes = [newActivity.TypeId];
+
+        if (!ActivityTypeAuthorization.UsingAllowedActivityTypes(activityTypes, _user, out var errorMessage))
+        {
+            return new Forbidden(errorMessage);
+        }
+
+        return null;
+    }
+
+    private async Task<DomainError?> ValidateActivityTransmissionRelationAsync(Guid dialogId, DialogActivity newActivity,
+        CancellationToken cancellationToken)
+    {
+        if (newActivity.TransmissionId is not { } transmissionId)
+        {
+            return null;
+        }
+
+        var transmissionExists = await _db.DialogTransmissions
+            .Where(x => x.DialogId == dialogId)
+            .AnyAsync(x => x.Id == transmissionId, cancellationToken);
+
+        if (transmissionExists)
+        {
+            return null;
+        }
+
+        return new DomainError(new DomainFailure(
+            $"{nameof(CreateActivityCommand.Activity)}.{nameof(CreateActivityDto.TransmissionId)}",
+            $"Invalid '{nameof(DialogActivity.TransmissionId)}', entity '{nameof(DialogTransmission)}' with the following key(s) does not exist: ({transmissionId}) in '{nameof(DialogEntity.Transmissions)}'"));
+    }
+
+    private async Task UpdateHasUnopenedContentAsync(DialogEntity dialog, DialogActivity newActivity,
+        CancellationToken cancellationToken)
+    {
+        if (!dialog.HasUnopenedContent)
+        {
+            return;
+        }
+
+        if (newActivity.TypeId == DialogActivityType.Values.TransmissionOpened)
+        {
+            await UpdateHasUnopenedContentForTransmissionOpenedAsync(dialog, newActivity, cancellationToken);
+            return;
+        }
+
+        if (newActivity.TypeId == DialogActivityType.Values.CorrespondenceOpened)
+        {
+            await UpdateHasUnopenedContentForCorrespondenceOpenedAsync(dialog.Id, dialog, cancellationToken);
+        }
+    }
+
+    private async Task UpdateHasUnopenedContentForTransmissionOpenedAsync(DialogEntity dialog, DialogActivity newActivity,
+        CancellationToken cancellationToken)
+    {
+        if (newActivity.TransmissionId is not { } transmissionId)
+        {
+            return;
+        }
+
+        var transmissionType = await _db.DialogTransmissions
+            .Where(x => x.DialogId == dialog.Id && x.Id == transmissionId)
+            .Select(x => (DialogTransmissionType.Values?)x.TypeId)
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (transmissionType is not { } type || !DialogUnopenedContent.IsRelevantTransmissionType(type))
+        {
+            return;
+        }
+
+        var hasOtherUnopenedRelevantTransmissions =
+            await HasUnopenedRelevantTransmissionsAsync(dialog.Id, transmissionId, cancellationToken);
+
+        if (hasOtherUnopenedRelevantTransmissions)
+        {
+            return;
+        }
+
+        if (dialog.ServiceResourceType == ResourceRegistryConstants.CorrespondenceService)
+        {
+            var hasCorrespondenceOpened = await _db.DialogActivities
+                .Where(x => x.DialogId == dialog.Id)
+                .AnyAsync(x => x.TypeId == DialogActivityType.Values.CorrespondenceOpened, cancellationToken);
+
+            if (!hasCorrespondenceOpened)
+            {
+                return;
+            }
+        }
+
+        dialog.HasUnopenedContent = false;
+    }
+
+    private async Task UpdateHasUnopenedContentForCorrespondenceOpenedAsync(Guid dialogId, DialogEntity dialog,
+        CancellationToken cancellationToken)
+    {
+        if (dialog.ServiceResourceType != ResourceRegistryConstants.CorrespondenceService)
+        {
+            return;
+        }
+
+        var hasUnopenedRelevantTransmissions =
+            await HasUnopenedRelevantTransmissionsAsync(dialogId, transmissionIdToExclude: null, cancellationToken);
+
+        if (!hasUnopenedRelevantTransmissions)
+        {
+            dialog.HasUnopenedContent = false;
+        }
+    }
+
+    private Task<bool> HasUnopenedRelevantTransmissionsAsync(Guid dialogId, Guid? transmissionIdToExclude,
+        CancellationToken cancellationToken)
+    {
+        var query = _db.DialogTransmissions
+            .Where(x => x.DialogId == dialogId)
+            .Where(x => x.TypeId != DialogTransmissionType.Values.Correction &&
+                x.TypeId != DialogTransmissionType.Values.Submission);
+
+        if (transmissionIdToExclude is { } transmissionId)
+        {
+            query = query.Where(x => x.Id != transmissionId);
+        }
+
+        return query.AnyAsync(x => x.Activities
+            .All(a => a.TypeId != DialogActivityType.Values.TransmissionOpened), cancellationToken);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogCommand.cs
@@ -125,8 +125,8 @@ internal sealed class UpdateDialogCommandHandler : IRequestHandler<UpdateDialogC
 
         AppendActivity(dialog, request.Dto);
 
-        var activityTypes = dialog.Activities
-            .Select(x => x.TypeId)
+        var activityTypes = request.Dto.Activities
+            .Select(x => x.Type)
             .Distinct();
 
         if (!ActivityTypeAuthorization.UsingAllowedActivityTypes(activityTypes, _user, out var errorMessage))

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Activities/ActivityAuthorizationTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Activities/ActivityAuthorizationTests.cs
@@ -2,6 +2,7 @@ using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Create;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.CreateActivity;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Update;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common.ApplicationFlow;
@@ -94,4 +95,87 @@ public class ActivityAuthorizationTests : ApplicationCollectionFixture
                 });
             })
             .ExecuteAndAssert<UpdateDialogSuccess>();
+
+    [Fact]
+    public Task Can_Update_NonCorrespondence_Activity_Without_Scope_When_Dialog_Already_Has_Correspondence_Activity() =>
+        FlowBuilder.For(Application)
+            .AsCorrespondenceUser()
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.Activities
+                    .Add(DialogGenerator.GenerateFakeDialogActivity(
+                        type: DialogActivityType.Values.CorrespondenceOpened));
+            })
+            .AssertResult<CreateDialogSuccess>()
+            .AsIntegrationTestUser()
+            .UpdateDialog(x =>
+            {
+                x.Dto.Activities.Add(new()
+                {
+                    Type = DialogActivityType.Values.DialogCreated,
+                    PerformedBy = new ActorDto { ActorType = ActorType.Values.ServiceOwner }
+                });
+            })
+            .ExecuteAndAssert<UpdateDialogSuccess>();
+
+    [Fact]
+    public Task Cannot_Create_Correspondence_Activity_With_CreateActivity_Without_Required_Scope() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog()
+            .CreateActivity((command, _) => command.Activity = new CreateActivityDto
+            {
+                CreatedAt = new DateTimeOffset(2001, 1, 1, 1, 1, 1, TimeSpan.Zero),
+                Type = DialogActivityType.Values.CorrespondenceOpened,
+                PerformedBy = new ActorDto
+                {
+                    ActorType = ActorType.Values.ServiceOwner
+                },
+                Description = []
+            })
+            .ExecuteAndAssert<Forbidden>(x =>
+            {
+                x.Reasons.Should().ContainSingle(reason => reason.Contains(AuthorizationScope.CorrespondenceScope));
+                x.Reasons.Should().ContainSingle(reason => reason.Contains(nameof(DialogActivityType.Values.CorrespondenceOpened)));
+            });
+
+    [Fact]
+    public Task Can_Create_Correspondence_Activity_With_CreateActivity_With_Required_Scope() =>
+        FlowBuilder.For(Application)
+            .AsCorrespondenceUser()
+            .CreateSimpleDialog()
+            .CreateActivity((command, _) => command.Activity = new CreateActivityDto
+            {
+                CreatedAt = new DateTimeOffset(2001, 1, 1, 1, 1, 1, TimeSpan.Zero),
+                Type = DialogActivityType.Values.CorrespondenceOpened,
+                PerformedBy = new ActorDto
+                {
+                    ActorType = ActorType.Values.ServiceOwner
+                },
+                Description = []
+            })
+            .ExecuteAndAssert<CreateActivitySuccess>();
+
+    [Fact]
+    public Task Can_Create_NonCorrespondence_Activity_Without_Scope_When_Dialog_Already_Has_Correspondence_Activity() =>
+        FlowBuilder.For(Application)
+            .AsCorrespondenceUser()
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.Activities
+                    .Add(DialogGenerator.GenerateFakeDialogActivity(
+                        type: DialogActivityType.Values.CorrespondenceOpened));
+            })
+            .AssertResult<CreateDialogSuccess>()
+            .AsIntegrationTestUser()
+            .CreateActivity((command, _) => command.Activity = new CreateActivityDto
+            {
+                CreatedAt = new DateTimeOffset(2001, 1, 1, 1, 1, 1, TimeSpan.Zero),
+                Type = DialogActivityType.Values.DialogCreated,
+                PerformedBy = new ActorDto
+                {
+                    ActorType = ActorType.Values.ServiceOwner
+                },
+                Description = []
+            })
+            .ExecuteAndAssert<CreateActivitySuccess>();
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogActivityTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/CreateDialogActivityTests.cs
@@ -8,6 +8,7 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Co
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common.ApplicationFlow;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.Common.Extensions;
 using Digdir.Domain.Dialogporten.Domain;
 using Digdir.Domain.Dialogporten.Domain.Actors;
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
@@ -227,6 +228,7 @@ public class CreateDialogActivityTests(DialogApplication application) : Applicat
     [Fact]
     public Task Can_Not_Create_Activity_On_Unknown_TransmissionId()
     {
+        var transmissionId = Guid.Parse("019c27dc-76d0-7269-a8e1-b30fc5a53aec");
         return FlowBuilder.For(Application)
             .CreateSimpleDialog()
             .CreateActivity(
@@ -236,7 +238,7 @@ public class CreateDialogActivityTests(DialogApplication application) : Applicat
                     CreatedAt = new DateTimeOffset(2001, 1, 1, 1, 1, 1, TimeSpan.Zero),
                     ExtendedType = null,
                     Type = DialogActivityType.Values.TransmissionOpened,
-                    TransmissionId = Guid.Parse("019c27dc-76d0-7269-a8e1-b30fc5a53aec"),
+                    TransmissionId = transmissionId,
                     PerformedBy = new ActorDto
                     {
                         ActorType = ActorType.Values.PartyRepresentative,
@@ -246,7 +248,79 @@ public class CreateDialogActivityTests(DialogApplication application) : Applicat
                     Description = []
                 }
             )
-            .ExecuteAndAssert<DomainError>();
+            .ExecuteAndAssert<DomainError>(x =>
+            {
+                x.ShouldHaveErrorWithPropertyNameText(nameof(CreateActivityDto.TransmissionId));
+                x.ShouldHaveErrorWithText("does not exist");
+                x.ShouldHaveErrorWithText(transmissionId.ToString());
+            });
+    }
+
+    [Fact]
+    public Task Can_Not_Create_Activity_On_TransmissionId_Belonging_To_Another_Dialog()
+    {
+        var transmissionId = Guid.Parse("019c0f25-9759-70c5-8d9d-f03f336a0b6f");
+        return FlowBuilder.For(Application)
+            .CreateComplexDialog((x, _) => x.Dto.Transmissions =
+            [
+                new TransmissionDto
+                {
+                    Id = transmissionId,
+                    CreatedAt = new DateTimeOffset(2001, 1, 1, 1, 1, 1, TimeSpan.Zero),
+                    AuthorizationAttribute = null,
+                    ExtendedType = null,
+                    ExternalReference = null,
+                    RelatedTransmissionId = null,
+                    Type = DialogTransmissionType.Values.Information,
+                    Sender = new ActorDto
+                    {
+                        ActorType = ActorType.Values.PartyRepresentative,
+                        ActorName = null,
+                        ActorId = "urn:altinn:person:legacy-selfidentified:Per"
+                    },
+                    Content = new TransmissionContentDto
+                    {
+                        Title = new ContentValueDto
+                        {
+                            Value =
+                            [
+                                new LocalizationDto
+                                {
+                                    Value = "title",
+                                    LanguageCode = "nb"
+                                }
+                            ],
+                            MediaType = MediaTypes.PlainText
+                        },
+                        Summary = null,
+                        ContentReference = null
+                    }
+                }
+            ])
+            .CreateSimpleDialog()
+            .CreateActivity(
+                (c, _) => c.Activity = new CreateActivityDto
+                {
+                    Id = Guid.Parse("019c27e4-b9be-7f48-b652-fa7aa5df094a"),
+                    CreatedAt = new DateTimeOffset(2001, 1, 1, 1, 1, 1, TimeSpan.Zero),
+                    ExtendedType = null,
+                    Type = DialogActivityType.Values.TransmissionOpened,
+                    TransmissionId = transmissionId,
+                    PerformedBy = new ActorDto
+                    {
+                        ActorType = ActorType.Values.PartyRepresentative,
+                        ActorName = null,
+                        ActorId = "urn:altinn:person:legacy-selfidentified:Leif"
+                    },
+                    Description = []
+                }
+            )
+            .ExecuteAndAssert<DomainError>(x =>
+            {
+                x.ShouldHaveErrorWithPropertyNameText(nameof(CreateActivityDto.TransmissionId));
+                x.ShouldHaveErrorWithText("does not exist");
+                x.ShouldHaveErrorWithText(transmissionId.ToString());
+            });
     }
 
     [Fact]
@@ -311,6 +385,35 @@ public class CreateDialogActivityTests(DialogApplication application) : Applicat
                 }
             )
             .ExecuteAndAssert<CreateActivitySuccess>();
+    }
+
+    [Fact]
+    public Task Create_Activity_Updates_HasUnopenedContent_When_Last_Transmission_Is_Opened()
+    {
+        var transmissionId = Guid.CreateVersion7();
+        return FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) => x.AddTransmission(transmissionDto =>
+            {
+                transmissionDto.Id = transmissionId;
+                transmissionDto.Type = DialogTransmissionType.Values.Information;
+            }))
+            .CreateActivity((c, _) => c.Activity = new CreateActivityDto
+            {
+                CreatedAt = new DateTimeOffset(2001, 1, 1, 1, 1, 1, TimeSpan.Zero),
+                Type = DialogActivityType.Values.TransmissionOpened,
+                TransmissionId = transmissionId,
+                PerformedBy = new ActorDto
+                {
+                    ActorType = ActorType.Values.ServiceOwner
+                },
+                Description = []
+            })
+            .GetServiceOwnerDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                x.HasUnopenedContent.Should().BeFalse();
+                x.Transmissions.First().IsOpened.Should().BeTrue();
+            });
     }
 
     [Theory, ClassData(typeof(CreateInvalidActivityTestData))]


### PR DESCRIPTION
## Description

This adds missing checks to the new CreateActivityCommand to have parity with CreateDialogCommand/UpdateDialogCommand. This includes:

- Checking if authorized to add correspondence activities 
- Checking transmissionId relation
- Checking if hasUnopenedContent should be updated

NOTE! the correspondence scope check has been changed to no longer consider already persisted activities, which was unintented in the first place. 

## Related Issue(s)

- #3590 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 
