### PR TITLE
chore(infra): add PostgreSQL migration target for staging and prod

### DIFF
--- a/.azure/infrastructure/postgresql-migration-target.prod.bicepparam
+++ b/.azure/infrastructure/postgresql-migration-target.prod.bicepparam
@@ -1,0 +1,33 @@
+using './postgresql-migration-target.bicep'
+
+param environment = 'prod'
+
+param keyVaultSourceKeys = json(readEnvironmentVariable('AZURE_KEY_VAULT_SOURCE_KEYS'))
+param dialogportenPgAdminPassword = readEnvironmentVariable('PG_ADMIN_PASSWORD')
+param sourceKeyVaultSubscriptionId = readEnvironmentVariable('AZURE_SOURCE_KEY_VAULT_SUBSCRIPTION_ID')
+param sourceKeyVaultResourceGroup = readEnvironmentVariable('AZURE_SOURCE_KEY_VAULT_RESOURCE_GROUP')
+param sourceKeyVaultName = readEnvironmentVariable('AZURE_SOURCE_KEY_VAULT_NAME')
+
+// Copy this into prod.bicepparam replacing the existing postgresConfiguration when migration is complete
+// and remove this file
+param postgresConfiguration = {
+  serverNameStem: 'postgres2'
+  version: '18'
+  sku: {
+    name: 'Standard_E48ads_v5'
+    tier: 'MemoryOptimized'
+  }
+  storage: {
+    storageSizeGB: 10000
+    type: 'PremiumV2_LRS'
+    iops: 24000
+    throughput: 1200
+  }
+  enableIndexTuning: false
+  enableQueryPerformanceInsight: false
+  backupRetentionDays: 32
+  availabilityZone: '3'
+  enableBackupVault: false
+}
+
+param deployerPrincipalName = 'GitHub: altinn/dialogporten - Prod (new postgresql)'

--- a/.azure/infrastructure/postgresql-migration-target.staging.bicepparam
+++ b/.azure/infrastructure/postgresql-migration-target.staging.bicepparam
@@ -1,0 +1,33 @@
+using './postgresql-migration-target.bicep'
+
+param environment = 'staging'
+
+param keyVaultSourceKeys = json(readEnvironmentVariable('AZURE_KEY_VAULT_SOURCE_KEYS'))
+param dialogportenPgAdminPassword = readEnvironmentVariable('PG_ADMIN_PASSWORD')
+param sourceKeyVaultSubscriptionId = readEnvironmentVariable('AZURE_SOURCE_KEY_VAULT_SUBSCRIPTION_ID')
+param sourceKeyVaultResourceGroup = readEnvironmentVariable('AZURE_SOURCE_KEY_VAULT_RESOURCE_GROUP')
+param sourceKeyVaultName = readEnvironmentVariable('AZURE_SOURCE_KEY_VAULT_NAME')
+
+// Copy this into staging.bicepparam replacing the existing postgresConfiguration when migration is complete
+// and remove this file
+param postgresConfiguration = {
+  serverNameStem: 'postgres2'
+  version: '18'
+  sku: {
+    name: 'Standard_D8ads_v5'
+    tier: 'MemoryOptimized'
+  }
+  storage: {
+    storageSizeGB: 256
+    type: 'PremiumV2_LRS'
+    iops: 3000
+    throughput: 125
+  }
+  enableIndexTuning: false
+  enableQueryPerformanceInsight: false
+  backupRetentionDays: 7
+  availabilityZone: '2'
+  enableBackupVault: false
+}
+
+param deployerPrincipalName = 'GitHub: altinn/dialogporten - Staging (new postgresql)'

--- a/.github/workflows/workflow-deploy-infra.yml
+++ b/.github/workflows/workflow-deploy-infra.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Dryrun Deploy PostgreSQL migration target (${{ inputs.environment }})
         uses: azure/bicep-deploy@4d5dc29bf04d05546dd5df9c665c54b9c5213207 # v2.2.0
-        if: ${{ inputs.environment == 'test' }}
+        if: ${{ inputs.environment == 'test' || inputs.environment == 'staging' }}
         id: deploy-migration-target-dry-run
         env:
           # parameters
@@ -162,7 +162,7 @@ jobs:
 
       - name: Deploy PostgreSQL migration target (${{ inputs.environment }})
         uses: azure/bicep-deploy@4d5dc29bf04d05546dd5df9c665c54b9c5213207 # v2.2.0
-        if: ${{ !inputs.dryRun && inputs.environment == 'test' }}
+        if: ${{ !inputs.dryRun && (inputs.environment == 'test' || inputs.environment == 'staging') }}
         id: deploy-migration-target
         env:
           # parameters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  - Add `postgresql-migration-target.staging.bicepparam` (PG18, Standard_D8ads_v5, 256GB PremiumV2_LRS)                                                 
  - Add `postgresql-migration-target.prod.bicepparam` (PG18, Standard_E48ads_v5, 10TB PremiumV2_LRS) — not yet activated in workflow
  - Enable migration target deployment for staging in `workflow-deploy-infra.yml`                                                                       
                                                                                                                                                        
  ## Post-deployment                                                                                                                                    
  - Stop the migration target server to save costs until ready for data migration                                                                       
  - When ready for prod, add `|| inputs.environment == 'prod'` to the two workflow conditions    

## Related Issue(s)

- #3638

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
