### PR TITLE
chore(infra): update PostgreSQL SKU to Standard_E8ads_v5 in staging migration parameters

### DIFF
--- a/.azure/infrastructure/postgresql-migration-target.staging.bicepparam
+++ b/.azure/infrastructure/postgresql-migration-target.staging.bicepparam
@@ -14,7 +14,7 @@ param postgresConfiguration = {
   serverNameStem: 'postgres2'
   version: '18'
   sku: {
-    name: 'Standard_D8ads_v5'
+    name: 'Standard_E8ads_v5'
     tier: 'MemoryOptimized'
   }
   storage: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  - Fix `Standard_D8ads_v5` → `Standard_E8ads_v5` in staging migration target bicepparam                                                                                                                                                                           
                                                                                                                                                                                                                                                                   
  D-series SKUs are GeneralPurpose only and incompatible with the MemoryOptimized tier required for PremiumV2_LRS storage.  

## Related Issue(s)

- #3638

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
