### PR TITLE
chore(infra): refine yt01 scaling strategy

### DIFF
--- a/.azure/applications/graphql/yt01.bicepparam
+++ b/.azure/applications/graphql/yt01.bicepparam
@@ -14,19 +14,11 @@ param resources = {
 
 param otelTraceSamplerRatio = '0.05'
 
-// Scale to zero when idle, use HTTP scaling to wake on traffic
+// Scale-off workflows override to 0 via az CLI.
 param scale = {
-  minReplicas: 0
+  minReplicas: 1
   maxReplicas: 10
   rules: [
-    {
-      name: 'http-rule'
-      http: {
-        metadata: {
-          concurrentRequests: '100'
-        }
-      }
-    }
     {
       name: 'cpu'
       custom: {

--- a/.azure/applications/service/yt01.bicepparam
+++ b/.azure/applications/service/yt01.bicepparam
@@ -15,8 +15,8 @@ param resources = {
 
 param otelTraceSamplerRatio = '0.05'
 
-// Scale to zero when idle (manual restart needed to wake, no HTTP ingress)
-param minReplicas = 0
+// Scale-off workflows override to 0 via az CLI.
+param minReplicas = 1
 
 // secrets
 param appInsightConnectionString = readEnvironmentVariable('AZURE_APP_INSIGHTS_CONNECTION_STRING')

--- a/.azure/applications/web-api-eu/yt01.bicepparam
+++ b/.azure/applications/web-api-eu/yt01.bicepparam
@@ -14,19 +14,11 @@ param resources = {
 
 param otelTraceSamplerRatio = '0.05'
 
-// Scale to zero when idle, use HTTP scaling to wake on traffic
+// Scale-off workflows override to 0 via az CLI.
 param scale = {
-  minReplicas: 0
+  minReplicas: 1
   maxReplicas: 20
   rules: [
-    {
-      name: 'http-rule'
-      http: {
-        metadata: {
-          concurrentRequests: '100'
-        }
-      }
-    }
     {
       name: 'cpu'
       custom: {

--- a/.azure/applications/web-api-so/yt01.bicepparam
+++ b/.azure/applications/web-api-so/yt01.bicepparam
@@ -14,19 +14,11 @@ param resources = {
 
 param otelTraceSamplerRatio = '0.05'
 
-// Scale to zero when idle, use HTTP scaling to wake on traffic
+// Scale-off workflows override to 0 via az CLI.
 param scale = {
-  minReplicas: 0
+  minReplicas: 1
   maxReplicas: 10
   rules: [
-    {
-      name: 'http-rule'
-      http: {
-        metadata: {
-          concurrentRequests: '100'
-        }
-      }
-    }
     {
       name: 'cpu'
       custom: {

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -1,10 +1,14 @@
-﻿# Deploys the created release to yt01
+﻿# Deploys a release to yt01. Triggered manually or from the scale-on workflow.
 name: CI/CD YT01
-run-name: CI/CD YT01 ${{ github.event.client_payload.version && format('({0})', github.event.client_payload.version) || '' }}
+run-name: CI/CD YT01 ${{ inputs.version && format('({0})', inputs.version) || '(latest)' }}
 
 on:
-  repository_dispatch:
-    types: [release_created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deploy (e.g. 1.23.4). Leave empty to auto-detect latest release."
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -16,6 +20,28 @@ permissions:
   pull-requests: write
 
 jobs:
+  resolve-version:
+    name: Resolve deploy version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Resolve version
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$INPUT_VERSION" ]]; then
+            echo "Using provided version: $INPUT_VERSION"
+            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            VERSION=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q '.tagName' | sed 's/^v//')
+            echo "Auto-detected latest release: $VERSION"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
   get-versions-from-github:
     name: Get Latest Deployed Version Info from GitHub
     uses: ./.github/workflows/workflow-get-latest-deployed-version-info-from-github.yml
@@ -35,7 +61,7 @@ jobs:
   deploy-infra:
     name: Deploy infra to yt01
     if: ${{ needs.check-for-changes.outputs.hasInfraChanges == 'true' }}
-    needs: [check-for-changes]
+    needs: [check-for-changes, resolve-version]
     uses: ./.github/workflows/workflow-deploy-infra.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -48,24 +74,24 @@ jobs:
     with:
       environment: yt01
       region: norwayeast
-      version: ${{ github.event.client_payload.version }}
-      ref: "refs/tags/v${{ github.event.client_payload.version }}"
+      version: ${{ needs.resolve-version.outputs.version }}
+      ref: "refs/tags/v${{ needs.resolve-version.outputs.version }}"
 
   store-infra-version:
     name: Store Latest Deployed Infra Version as GitHub Variable
-    needs: [deploy-infra]
+    needs: [deploy-infra, resolve-version]
     if: ${{ needs.deploy-infra.result == 'success' }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_INFRA_VERSION
-      variable_value: ${{ github.event.client_payload.version }}
+      variable_value: ${{ needs.resolve-version.outputs.version }}
       environment: yt01
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
 
   deploy-apps:
     name: Deploy apps to yt01
-    needs: [check-for-changes, deploy-infra]
+    needs: [check-for-changes, deploy-infra, resolve-version]
     if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
     uses: ./.github/workflows/workflow-deploy-apps.yml
     secrets:
@@ -81,27 +107,27 @@ jobs:
       AZURE_SERVICE_BUS_NAMESPACE_NAME: ${{ secrets.AZURE_SERVICE_BUS_NAMESPACE_NAME }}
     with:
       environment: yt01
-      version: ${{ github.event.client_payload.version }}
+      version: ${{ needs.resolve-version.outputs.version }}
       runMigration: false # DB may be off due to scale-to-zero, run migrations manually
-      ref: "refs/tags/v${{ github.event.client_payload.version }}"
+      ref: "refs/tags/v${{ needs.resolve-version.outputs.version }}"
 
   tag-issues-with-environment:
     name: Tag deployed PRs and issues for yt01
-    needs: [ deploy-apps, deploy-infra ]
+    needs: [ deploy-apps, deploy-infra, resolve-version ]
     if: ${{ always() && !failure() && !cancelled() && (needs.deploy-apps.outputs.deployment_executed == 'true' || needs.deploy-infra.outputs.deployment_executed == 'true') }}
     uses: ./.github/workflows/workflow-tag-issues-with-environment.yml
     with:
       environment-label: yt01
-      version: ${{ github.event.client_payload.version }}
+      version: ${{ needs.resolve-version.outputs.version }}
 
   store-apps-version:
     name: Store Latest Deployed Apps Version as GitHub Variable
-    needs: [deploy-apps]
+    needs: [deploy-apps, resolve-version]
     if: ${{ always() && !failure() && needs.deploy-apps.outputs.deployment_executed == 'true' }}
     uses: ./.github/workflows/workflow-store-github-env-variable.yml
     with:
       variable_name: LATEST_DEPLOYED_APPS_VERSION
-      variable_value: ${{ github.event.client_payload.version }}
+      variable_value: ${{ needs.resolve-version.outputs.version }}
       environment: yt01
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
@@ -110,7 +136,7 @@ jobs:
     name: "Run K6 functional end-to-end tests"
     # we want the end-to-end tests to be dependent on deployment of infrastructure and apps, but if infrastructure is skipped, we still want to run the tests
     if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
-    needs: [deploy-apps, check-for-changes]
+    needs: [deploy-apps, check-for-changes, resolve-version]
     uses: ./.github/workflows/workflow-run-k6-tests.yml
     secrets:
       TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKEN_GENERATOR_USERNAME }}
@@ -119,7 +145,7 @@ jobs:
       environment: yt01
       apiVersion: v1
       testSuitePath: tests/k6/suites/all-single-pass.js
-      ref: "refs/tags/v${{ github.event.client_payload.version }}"
+      ref: "refs/tags/v${{ needs.resolve-version.outputs.version }}"
     permissions:
       checks: write
       pull-requests: write
@@ -127,31 +153,31 @@ jobs:
   run-graphql-e2e-tests:
     name: "Run GraphQL E2E tests"
     if: ${{ always() && !failure() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
-    needs: [ run-e2e-tests, check-for-changes ]
+    needs: [ run-e2e-tests, check-for-changes, resolve-version ]
     uses: ./.github/workflows/workflow-run-graphql-e2e-tests.yml
     secrets:
       TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKEN_GENERATOR_USERNAME }}
       TOKEN_GENERATOR_PASSWORD: ${{ secrets.TOKEN_GENERATOR_PASSWORD }}
     with:
       environment: yt01
-      ref: "refs/tags/v${{ github.event.client_payload.version }}"
+      ref: "refs/tags/v${{ needs.resolve-version.outputs.version }}"
 
   run-webapi-e2e-tests:
     name: "Run WebAPI E2E tests"
     if: ${{ always() && !failure() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true') }}
-    needs: [ run-e2e-tests, check-for-changes ]
+    needs: [ run-e2e-tests, check-for-changes, resolve-version ]
     uses: ./.github/workflows/workflow-run-webapi-e2e-tests.yml
     secrets:
       TOKEN_GENERATOR_USERNAME: ${{ secrets.TOKEN_GENERATOR_USERNAME }}
       TOKEN_GENERATOR_PASSWORD: ${{ secrets.TOKEN_GENERATOR_PASSWORD }}
     with:
       environment: yt01
-      ref: "refs/tags/v${{ github.event.client_payload.version }}"
+      ref: "refs/tags/v${{ needs.resolve-version.outputs.version }}"
 
   run-performance-tests:
     name: "Run K6 performance tests"
     if: ${{ always() && !failure() && !cancelled() }}
-    needs: [run-e2e-tests]
+    needs: [run-e2e-tests, resolve-version]
     uses: ./.github/workflows/workflow-run-k6-performance.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -176,7 +202,7 @@ jobs:
       breakpoint: false
       abortOnFail: false
       numberOfEndUsers: 200
-      ref: "refs/tags/v${{ github.event.client_payload.version }}"
+      ref: "refs/tags/v${{ needs.resolve-version.outputs.version }}"
     permissions:
       checks: write
       pull-requests: write
@@ -204,10 +230,10 @@ jobs:
     name: Send deployment to Swarmia
     if: ${{ always() && !failure() && !cancelled() }}
     uses: ./.github/workflows/workflow-swarmia-deployment.yml
-    needs: [ deploy-infra, deploy-apps ]
+    needs: [ deploy-infra, deploy-apps, resolve-version ]
     with:
       app-name: dialogporten
       environment: 'yt01'
-      version: ${{ github.event.client_payload.version }}
+      version: ${{ needs.resolve-version.outputs.version }}
     secrets:
       token: ${{ secrets.SWARMIA_DEPLOYMENTS_AUTHORIZATION }}

--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -10,6 +10,11 @@ on:
         options:
           - 'on'
           - 'off'
+      deploy:
+        description: "Deploy latest version when scaling on (checks if newer version is available)"
+        required: false
+        type: boolean
+        default: true
       postpone_until:
         description: "Postpone scheduled shutdown until this datetime (ISO 8601, e.g. 2026-03-01T20:00:00+01:00). Only used with 'on'."
         required: false
@@ -96,6 +101,21 @@ jobs:
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 
+      - name: Scale workload profile up
+        if: inputs.state == 'on'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          az containerapp env workload-profile update \
+            --name "dp-be-yt01-cae" \
+            --resource-group "$RESOURCE_GROUP" \
+            --workload-profile-name "Dedicated-D8" \
+            --min-nodes 3 \
+            --max-nodes 10
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
       - name: Enable availability test
         if: inputs.state == 'on'
         shell: bash
@@ -109,35 +129,90 @@ jobs:
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 
-      - name: Restart service container app
+      - name: Set minReplicas=1 for all apps
         if: inputs.state == 'on'
         shell: bash
         run: |
           set -euo pipefail
 
-          # The service app has no HTTP trigger so it needs an explicit restart
-          # to reattach its Service Bus consumer after scale-to-zero.
-          # HTTP apps (webapi-so, webapi-eu, graphql) will scale up on first request.
-          APP="dp-be-yt01-service"
+          APPS=(
+            "dp-be-yt01-webapi-eu-ca"
+            "dp-be-yt01-webapi-so-ca"
+            "dp-be-yt01-graphql-ca"
+            "dp-be-yt01-service"
+          )
 
-          echo "Finding latest revision for $APP..."
-          REVISION=$(az containerapp revision list \
-            --name "$APP" \
-            --resource-group "$RESOURCE_GROUP" \
-            --query "sort_by([?properties.active==\`true\`], &properties.createdTime)[-1].name" \
-            -o tsv)
-
-          if [[ -n "$REVISION" ]]; then
-            echo "Restarting revision $REVISION..."
-            az containerapp revision restart \
+          for APP in "${APPS[@]}"; do
+            echo "Setting minReplicas=1 for $APP..."
+            az containerapp update \
               --name "$APP" \
               --resource-group "$RESOURCE_GROUP" \
-              --revision "$REVISION"
-          else
-            echo "No active revision found for $APP"
-          fi
+              --min-replicas 1
+          done
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
+      - name: Resume scheduled Container App Jobs
+        if: inputs.state == 'on'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG_KEY="scaleOffOriginalCron"
+
+          mapfile -t JOBS < <(az containerapp job list \
+            -g "$RESOURCE_GROUP" \
+            --query "[?properties.configuration.triggerType=='Schedule'].name" \
+            -o tsv)
+
+          if [[ ${#JOBS[@]} -eq 0 ]]; then
+            echo "No scheduled Container App Jobs found."
+            exit 0
+          fi
+
+          for JOB in "${JOBS[@]}"; do
+            SAVED_CRON=$(az containerapp job show \
+              -g "$RESOURCE_GROUP" -n "$JOB" \
+              --query "tags.\"${TAG_KEY}\"" -o tsv 2>/dev/null || true)
+
+            if [[ -z "$SAVED_CRON" || "$SAVED_CRON" == "None" ]]; then
+              echo "[$JOB] skipped: no saved cron tag"
+              continue
+            fi
+
+            az containerapp job update \
+              -g "$RESOURCE_GROUP" -n "$JOB" \
+              --cron-expression "$SAVED_CRON" --only-show-errors >/dev/null
+            echo "[$JOB] resumed (cron=$SAVED_CRON)"
+          done
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
+      - name: Deploy latest version
+        if: inputs.state == 'on' && inputs.deploy == true
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          LATEST_VERSION=$(gh release view --repo "$REPOSITORY" --json tagName -q '.tagName' | sed 's/^v//')
+          echo "Latest release version: $LATEST_VERSION"
+
+          DEPLOYED_VERSION=$(gh variable get LATEST_DEPLOYED_APPS_VERSION \
+            --env yt01 \
+            --repo "$REPOSITORY" 2>/dev/null || echo "")
+          echo "Currently deployed version: ${DEPLOYED_VERSION:-unknown}"
+
+          if [[ "$LATEST_VERSION" != "$DEPLOYED_VERSION" ]]; then
+            echo "Newer version available. Triggering deploy of $LATEST_VERSION..."
+            gh workflow run ci-cd-yt01.yml \
+              --repo "$REPOSITORY" \
+              -f version="$LATEST_VERSION"
+          else
+            echo "Already on latest version ($DEPLOYED_VERSION). Skipping deploy."
+          fi
 
       # === SCALE OFF ===
       - name: Disable public network access for container app environment
@@ -185,6 +260,95 @@ jobs:
             --name "dp-be-yt01-dialogporten-health-test" \
             --resource-group "$RESOURCE_GROUP" \
             --enabled false
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
+      - name: Pause scheduled Container App Jobs
+        if: inputs.state == 'off'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG_KEY="scaleOffOriginalCron"
+          PAUSE_CRON="0 0 1 1 *"
+
+          mapfile -t JOBS < <(az containerapp job list \
+            -g "$RESOURCE_GROUP" \
+            --query "[?properties.configuration.triggerType=='Schedule'].name" \
+            -o tsv)
+
+          if [[ ${#JOBS[@]} -eq 0 ]]; then
+            echo "No scheduled Container App Jobs found."
+            exit 0
+          fi
+
+          for JOB in "${JOBS[@]}"; do
+            CURRENT_CRON=$(az containerapp job show \
+              -g "$RESOURCE_GROUP" -n "$JOB" \
+              --query "properties.configuration.scheduleTriggerConfig.cronExpression" \
+              -o tsv)
+
+            if [[ -z "$CURRENT_CRON" || "$CURRENT_CRON" == "None" ]]; then
+              echo "[$JOB] skipped: empty cron expression"
+              continue
+            fi
+
+            SAVED_CRON=$(az containerapp job show \
+              -g "$RESOURCE_GROUP" -n "$JOB" \
+              --query "tags.\"${TAG_KEY}\"" -o tsv 2>/dev/null || true)
+
+            if [[ -z "$SAVED_CRON" || "$SAVED_CRON" == "None" ]]; then
+              JOB_ID=$(az containerapp job show -g "$RESOURCE_GROUP" -n "$JOB" --query id -o tsv)
+              az tag update --resource-id "$JOB_ID" \
+                --operation Merge --tags "${TAG_KEY}=${CURRENT_CRON}" \
+                --only-show-errors >/dev/null
+            fi
+
+            az containerapp job update \
+              -g "$RESOURCE_GROUP" -n "$JOB" \
+              --cron-expression "$PAUSE_CRON" --only-show-errors >/dev/null
+            az containerapp job stop \
+              -g "$RESOURCE_GROUP" -n "$JOB" --only-show-errors >/dev/null || true
+            echo "[$JOB] paused (cron=$CURRENT_CRON -> $PAUSE_CRON)"
+          done
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
+      - name: Set minReplicas=0 for all apps
+        if: inputs.state == 'off'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          APPS=(
+            "dp-be-yt01-webapi-eu-ca"
+            "dp-be-yt01-webapi-so-ca"
+            "dp-be-yt01-graphql-ca"
+            "dp-be-yt01-service"
+          )
+
+          for APP in "${APPS[@]}"; do
+            echo "Setting minReplicas=0 for $APP..."
+            az containerapp update \
+              --name "$APP" \
+              --resource-group "$RESOURCE_GROUP" \
+              --min-replicas 0
+          done
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
+      - name: Scale workload profile down
+        if: inputs.state == 'off'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          az containerapp env workload-profile update \
+            --name "dp-be-yt01-cae" \
+            --resource-group "$RESOURCE_GROUP" \
+            --workload-profile-name "Dedicated-D8" \
+            --min-nodes 0 \
+            --max-nodes 10
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 

--- a/.github/workflows/dispatch-scale-yt01-scheduled.yml
+++ b/.github/workflows/dispatch-scale-yt01-scheduled.yml
@@ -120,6 +120,95 @@ jobs:
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 
+      - name: Pause scheduled Container App Jobs
+        if: steps.check-postpone.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG_KEY="scaleOffOriginalCron"
+          PAUSE_CRON="0 0 1 1 *"
+
+          mapfile -t JOBS < <(az containerapp job list \
+            -g "$RESOURCE_GROUP" \
+            --query "[?properties.configuration.triggerType=='Schedule'].name" \
+            -o tsv)
+
+          if [[ ${#JOBS[@]} -eq 0 ]]; then
+            echo "No scheduled Container App Jobs found."
+            exit 0
+          fi
+
+          for JOB in "${JOBS[@]}"; do
+            CURRENT_CRON=$(az containerapp job show \
+              -g "$RESOURCE_GROUP" -n "$JOB" \
+              --query "properties.configuration.scheduleTriggerConfig.cronExpression" \
+              -o tsv)
+
+            if [[ -z "$CURRENT_CRON" || "$CURRENT_CRON" == "None" ]]; then
+              echo "[$JOB] skipped: empty cron expression"
+              continue
+            fi
+
+            SAVED_CRON=$(az containerapp job show \
+              -g "$RESOURCE_GROUP" -n "$JOB" \
+              --query "tags.\"${TAG_KEY}\"" -o tsv 2>/dev/null || true)
+
+            if [[ -z "$SAVED_CRON" || "$SAVED_CRON" == "None" ]]; then
+              JOB_ID=$(az containerapp job show -g "$RESOURCE_GROUP" -n "$JOB" --query id -o tsv)
+              az tag update --resource-id "$JOB_ID" \
+                --operation Merge --tags "${TAG_KEY}=${CURRENT_CRON}" \
+                --only-show-errors >/dev/null
+            fi
+
+            az containerapp job update \
+              -g "$RESOURCE_GROUP" -n "$JOB" \
+              --cron-expression "$PAUSE_CRON" --only-show-errors >/dev/null
+            az containerapp job stop \
+              -g "$RESOURCE_GROUP" -n "$JOB" --only-show-errors >/dev/null || true
+            echo "[$JOB] paused (cron=$CURRENT_CRON -> $PAUSE_CRON)"
+          done
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
+      - name: Set minReplicas=0 for all apps
+        if: steps.check-postpone.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          APPS=(
+            "dp-be-yt01-webapi-eu-ca"
+            "dp-be-yt01-webapi-so-ca"
+            "dp-be-yt01-graphql-ca"
+            "dp-be-yt01-service"
+          )
+
+          for APP in "${APPS[@]}"; do
+            echo "Setting minReplicas=0 for $APP..."
+            az containerapp update \
+              --name "$APP" \
+              --resource-group "$RESOURCE_GROUP" \
+              --min-replicas 0
+          done
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
+      - name: Scale workload profile down
+        if: steps.check-postpone.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          az containerapp env workload-profile update \
+            --name "dp-be-yt01-cae" \
+            --resource-group "$RESOURCE_GROUP" \
+            --workload-profile-name "Dedicated-D8" \
+            --min-nodes 0 \
+            --max-nodes 10
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
       - name: Logout from Azure
-        if: ${{ always() }}
+        if: ${{ always() && steps.check-postpone.outputs.skip != 'true' }}
         run: az logout


### PR DESCRIPTION
## Description

Refines the yt01 environment scaling approach. Instead of relying on Container Apps runtime scale-to-zero with HTTP wake-up rules, the bicep config now sets `minReplicas: 1` and the scale-on/off workflows manage replicas explicitly via `az containerapp update`. Key changes:

- **Bicep params**: `minReplicas` set to 1, HTTP scaling rules removed (CPU/memory rules retained)
- **CI/CD workflow**: Trigger changed from `repository_dispatch` to `workflow_dispatch` with a `resolve-version` job that auto-detects the latest release when no version is provided
- **Manual scale workflow**: Added workload profile scaling (Dedicated-D8), explicit `minReplicas` toggling for all apps, optional deploy-on-scale-on that triggers CI/CD if a newer version exists, and pause/resume of scheduled Container App Jobs using tag-based cron preservation
- **Scheduled shutdown**: Added `minReplicas=0`, workload profile scale-down, scheduled job pausing, and fixed `az logout` error when shutdown is postponed

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)