### PR TITLE
chore(infra): enable migration target deployment for prod

### DIFF
--- a/.github/workflows/workflow-deploy-infra.yml
+++ b/.github/workflows/workflow-deploy-infra.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Dryrun Deploy PostgreSQL migration target (${{ inputs.environment }})
         uses: azure/bicep-deploy@4d5dc29bf04d05546dd5df9c665c54b9c5213207 # v2.2.0
-        if: ${{ inputs.environment == 'test' || inputs.environment == 'prod' }}
+        if: ${{ inputs.dryRun && (inputs.environment == 'test' || inputs.environment == 'prod') }}
         id: deploy-migration-target-dry-run
         env:
           # parameters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable the PostgreSQL migration target deployment for prod by adding `inputs.environment == 'prod'` to the two workflow conditions (dryrun and deploy steps) in `workflow-deploy-infra.yml`. This follows the post-deployment instructions from #3639.

## Related Issue(s)

- #3658