### PR TITLE
trivial(infra): make yt01 scale-on steps idempotent and reorder shutdown

### DIFF
--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -72,10 +72,46 @@ jobs:
         run: |
           set -euo pipefail
 
-          az containerapp env update \
+          CURRENT=$(az containerapp env show \
             --name "dp-be-yt01-cae" \
             --resource-group "$RESOURCE_GROUP" \
-            --public-network-access Enabled
+            --query "properties.publicNetworkAccess" -o tsv)
+
+          if [[ "${CURRENT,,}" != "enabled" ]]; then
+            echo "Enabling public network access (currently: $CURRENT)..."
+            az containerapp env update \
+              --name "dp-be-yt01-cae" \
+              --resource-group "$RESOURCE_GROUP" \
+              --public-network-access Enabled
+          else
+            echo "Public network access is already enabled. Skipping."
+          fi
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
+      - name: Scale workload profile up
+        if: inputs.state == 'on'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          CURRENT_MIN=$(az containerapp env workload-profile show \
+            --name "dp-be-yt01-cae" \
+            --resource-group "$RESOURCE_GROUP" \
+            --workload-profile-name "Dedicated-D8" \
+            --query "properties.minimumCount" -o tsv)
+
+          if [[ "$CURRENT_MIN" -ne 3 ]]; then
+            echo "Scaling workload profile up (current min-nodes: $CURRENT_MIN -> 3)..."
+            az containerapp env workload-profile update \
+              --name "dp-be-yt01-cae" \
+              --resource-group "$RESOURCE_GROUP" \
+              --workload-profile-name "Dedicated-D8" \
+              --min-nodes 3 \
+              --max-nodes 10
+          else
+            echo "Workload profile Dedicated-D8 already at min-nodes=3. Skipping."
+          fi
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 
@@ -101,31 +137,26 @@ jobs:
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 
-      - name: Scale workload profile up
-        if: inputs.state == 'on'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          az containerapp env workload-profile update \
-            --name "dp-be-yt01-cae" \
-            --resource-group "$RESOURCE_GROUP" \
-            --workload-profile-name "Dedicated-D8" \
-            --min-nodes 3 \
-            --max-nodes 10
-        env:
-          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
-
       - name: Enable availability test
         if: inputs.state == 'on'
         shell: bash
         run: |
           set -euo pipefail
 
-          az monitor app-insights web-test update \
+          CURRENT=$(az monitor app-insights web-test show \
             --name "dp-be-yt01-dialogporten-health-test" \
             --resource-group "$RESOURCE_GROUP" \
-            --enabled true
+            --query "enabled" -o tsv)
+
+          if [[ "${CURRENT,,}" != "true" ]]; then
+            echo "Enabling availability test (currently: $CURRENT)..."
+            az monitor app-insights web-test update \
+              --name "dp-be-yt01-dialogporten-health-test" \
+              --resource-group "$RESOURCE_GROUP" \
+              --enabled true
+          else
+            echo "Availability test is already enabled. Skipping."
+          fi
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 
@@ -143,11 +174,20 @@ jobs:
           )
 
           for APP in "${APPS[@]}"; do
-            echo "Setting minReplicas=1 for $APP..."
-            az containerapp update \
+            CURRENT=$(az containerapp show \
               --name "$APP" \
               --resource-group "$RESOURCE_GROUP" \
-              --min-replicas 1
+              --query "properties.template.scale.minReplicas" -o tsv)
+
+            if [[ "$CURRENT" -ne 1 ]]; then
+              echo "Setting minReplicas=1 for $APP (currently: $CURRENT)..."
+              az containerapp update \
+                --name "$APP" \
+                --resource-group "$RESOURCE_GROUP" \
+                --min-replicas 1
+            else
+              echo "$APP already at minReplicas=1. Skipping."
+            fi
           done
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
@@ -177,6 +217,16 @@ jobs:
 
             if [[ -z "$SAVED_CRON" || "$SAVED_CRON" == "None" ]]; then
               echo "[$JOB] skipped: no saved cron tag"
+              continue
+            fi
+
+            CURRENT_CRON=$(az containerapp job show \
+              -g "$RESOURCE_GROUP" -n "$JOB" \
+              --query "properties.configuration.scheduleTriggerConfig.cronExpression" \
+              -o tsv)
+
+            if [[ "$CURRENT_CRON" == "$SAVED_CRON" ]]; then
+              echo "[$JOB] already running with correct cron ($CURRENT_CRON). Skipping."
               continue
             fi
 
@@ -225,6 +275,21 @@ jobs:
             --name "dp-be-yt01-cae" \
             --resource-group "$RESOURCE_GROUP" \
             --public-network-access Disabled
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
+      - name: Scale workload profile down
+        if: inputs.state == 'off'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          az containerapp env workload-profile update \
+            --name "dp-be-yt01-cae" \
+            --resource-group "$RESOURCE_GROUP" \
+            --workload-profile-name "Dedicated-D8" \
+            --min-nodes 0 \
+            --max-nodes 10
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 
@@ -334,21 +399,6 @@ jobs:
               --resource-group "$RESOURCE_GROUP" \
               --min-replicas 0
           done
-        env:
-          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
-
-      - name: Scale workload profile down
-        if: inputs.state == 'off'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          az containerapp env workload-profile update \
-            --name "dp-be-yt01-cae" \
-            --resource-group "$RESOURCE_GROUP" \
-            --workload-profile-name "Dedicated-D8" \
-            --min-nodes 0 \
-            --max-nodes 10
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 

--- a/.github/workflows/dispatch-scale-yt01-scheduled.yml
+++ b/.github/workflows/dispatch-scale-yt01-scheduled.yml
@@ -74,6 +74,21 @@ jobs:
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 
+      - name: Scale workload profile down
+        if: steps.check-postpone.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          az containerapp env workload-profile update \
+            --name "dp-be-yt01-cae" \
+            --resource-group "$RESOURCE_GROUP" \
+            --workload-profile-name "Dedicated-D8" \
+            --min-nodes 0 \
+            --max-nodes 10
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+
       - name: Stop PostgreSQL
         if: steps.check-postpone.outputs.skip != 'true'
         shell: bash
@@ -191,21 +206,6 @@ jobs:
               --resource-group "$RESOURCE_GROUP" \
               --min-replicas 0
           done
-        env:
-          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
-
-      - name: Scale workload profile down
-        if: steps.check-postpone.outputs.skip != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          az containerapp env workload-profile update \
-            --name "dp-be-yt01-cae" \
-            --resource-group "$RESOURCE_GROUP" \
-            --workload-profile-name "Dedicated-D8" \
-            --min-nodes 0 \
-            --max-nodes 10
         env:
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 


### PR DESCRIPTION
## Description

Makes scale-on steps in the manual workflow idempotent by checking current state before making changes. This prevents unnecessary CAE updates when running scale-on against an already scaled-on environment (e.g. just to set a postpone date).

Also moves the workload profile scale-down step earlier in both shutdown workflows so it runs in parallel with the PostgreSQL shutdown.

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)