### PR TITLE
trivial(infra): set yt01 workload profile minimumCount to 3

### DIFF
--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -81,7 +81,7 @@ param workloadProfiles = [
   {
     name: 'Dedicated-D8'
     workloadProfileType: 'D8'
-    minimumCount: 0
+    minimumCount: 3
     maximumCount: 10
   }
 ]


### PR DESCRIPTION
## Description

Set the Dedicated-D8 workload profile `minimumCount` from 0 to 3 in the yt01 Bicep parameters. The scale-on workflow sets `min-nodes=3` via az CLI, but subsequent Bicep deploys reset it to 0, undoing the scale-up. This aligns the Bicep definition with the desired running state.

Scale-off still explicitly sets `min-nodes=0` via az CLI, so shutdown is unaffected.

## Related Issue(s)

- #3679

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)