### PR TITLE
trivial(infra): extract yt01 scale-down to reusable workflow

### DIFF
--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -370,4 +370,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    secrets: inherit
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_RESOURCE_GROUP_NAME: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+      RELEASE_VERSION_STORAGE_PAT: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}

--- a/.github/workflows/dispatch-scale-yt01-scheduled.yml
+++ b/.github/workflows/dispatch-scale-yt01-scheduled.yml
@@ -53,4 +53,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    secrets: inherit
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_RESOURCE_GROUP_NAME: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+      RELEASE_VERSION_STORAGE_PAT: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}

--- a/.github/workflows/workflow-scale-yt01-down.yml
+++ b/.github/workflows/workflow-scale-yt01-down.yml
@@ -1,7 +1,18 @@
 name: Scale YT01 Down
 
 on:
-  workflow_call: {}
+  workflow_call:
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+      AZURE_RESOURCE_GROUP_NAME:
+        required: true
+      RELEASE_VERSION_STORAGE_PAT:
+        required: true
 
 jobs:
   scale-down:


### PR DESCRIPTION
## Description

Extracts all yt01 scale-off steps into a reusable `workflow_call` workflow (`workflow-scale-yt01-down.yml`), eliminating duplication between the manual and scheduled shutdown workflows. Removes `workflow_dispatch` from the scheduled workflow to prevent bypassing postpone variable cleanup. Adds an E2E test data purge step that runs while the API is still accessible, before network access and revisions are disabled.

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)