### PR TITLE
trivial(infra): Remove invalid comma-separated --status from gh run list

### DIFF
--- a/.github/workflows/workflow-scale-yt01-down.yml
+++ b/.github/workflows/workflow-scale-yt01-down.yml
@@ -89,7 +89,6 @@ jobs:
             --repo "$REPOSITORY" \
             --workflow "dispatch-purge-e2e-test-data.yml" \
             --event workflow_dispatch \
-            --status in_progress,queued,pending \
             --limit 1 \
             --json databaseId \
             --jq '.[0].databaseId')


### PR DESCRIPTION
gh run list --status only accepts a single value, not comma-separated. The --event workflow_dispatch + --limit 1 filters are sufficient to find the correct run.
