### PR TITLE
feat(dialoglookup): Add title to EU DTO

### DIFF
--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -276,6 +276,7 @@ type DialogLookup {
   dialogId: UUID!
   instanceRef: String!
   party: String!
+  title: [Localization!]!
   serviceResource: DialogLookupServiceResource!
   serviceOwner: DialogLookupServiceOwner!
   authorizationEvidence: DialogLookupAuthorizationEvidence!

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -505,6 +505,13 @@
           },
           "serviceResource": {
             "$ref": "#/components/schemas/V1CommonIdentifierLookup_IdentifierLookupServiceResource"
+          },
+          "title": {
+            "items": {
+              "$ref": "#/components/schemas/V1CommonLocalizations_Localization"
+            },
+            "nullable": true,
+            "type": "array"
           }
         },
         "type": "object"

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/IdentifierLookup/IdentifierLookupAuthorizationResolver.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/IdentifierLookup/IdentifierLookupAuthorizationResolver.cs
@@ -14,23 +14,19 @@ internal sealed class IdentifierLookupAuthorizationResolver : IIdentifierLookupA
 {
     private readonly IUser _user;
     private readonly IAltinnAuthorization _altinnAuthorization;
-    private readonly IServiceResourceMinimumAuthenticationLevelResolver _serviceResourceMinimumAuthenticationLevelResolver;
     private readonly IDialogDbContext _db;
 
     public IdentifierLookupAuthorizationResolver(
         IUser user,
         IAltinnAuthorization altinnAuthorization,
-        IServiceResourceMinimumAuthenticationLevelResolver serviceResourceMinimumAuthenticationLevelResolver,
         IDialogDbContext db)
     {
         ArgumentNullException.ThrowIfNull(user);
         ArgumentNullException.ThrowIfNull(altinnAuthorization);
-        ArgumentNullException.ThrowIfNull(serviceResourceMinimumAuthenticationLevelResolver);
         ArgumentNullException.ThrowIfNull(db);
 
         _user = user;
         _altinnAuthorization = altinnAuthorization;
-        _serviceResourceMinimumAuthenticationLevelResolver = serviceResourceMinimumAuthenticationLevelResolver;
         _db = db;
     }
 
@@ -41,18 +37,11 @@ internal sealed class IdentifierLookupAuthorizationResolver : IIdentifierLookupA
         InstanceRef responseInstanceRef,
         CancellationToken cancellationToken)
     {
-        var minimumAuthenticationLevel = await _serviceResourceMinimumAuthenticationLevelResolver
-            .GetMinimumAuthenticationLevel(dialogData.ServiceResource, cancellationToken);
         var currentAuthenticationLevel = _user.GetPrincipal().GetAuthenticationLevel();
-        if (currentAuthenticationLevel < minimumAuthenticationLevel)
-        {
-            return CreateUnauthorizedResolution(currentAuthenticationLevel);
-        }
-
         var partyIdentifier = _user.GetPrincipal().GetEndUserPartyIdentifier();
         if (partyIdentifier is null)
         {
-            return CreateUnauthorizedResolution(currentAuthenticationLevel);
+            return CreateUnauthorizedResolution();
         }
 
         var authorizedParties = await _altinnAuthorization.GetAuthorizedPartiesForLookup(
@@ -65,7 +54,7 @@ internal sealed class IdentifierLookupAuthorizationResolver : IIdentifierLookupA
 
         if (matchingAuthorizedParty is null)
         {
-            return CreateUnauthorizedResolution(currentAuthenticationLevel);
+            return CreateUnauthorizedResolution();
         }
 
         var authorizedSubjects = matchingAuthorizedParty.AuthorizedRolesAndAccessPackages
@@ -142,13 +131,10 @@ internal sealed class IdentifierLookupAuthorizationResolver : IIdentifierLookupA
             });
     }
 
-    private static IdentifierLookupAuthorizationResolution CreateUnauthorizedResolution(int currentAuthenticationLevel) =>
+    private static IdentifierLookupAuthorizationResolution CreateUnauthorizedResolution() =>
         new(
             false,
-            new IdentifierLookupAuthorizationEvidenceDto
-            {
-                CurrentAuthenticationLevel = currentAuthenticationLevel
-            });
+            new IdentifierLookupAuthorizationEvidenceDto());
 
     private static IdentifierLookupGrantType? ResolveGrantType(string subject)
     {

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/IdentifierLookup/IdentifierLookupDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/IdentifierLookup/IdentifierLookupDto.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.IdentifierLookup;
@@ -9,6 +10,7 @@ public abstract class IdentifierLookupDto
     public required string Party { get; set; }
     public required IdentifierLookupServiceResourceDto ServiceResource { get; set; }
     public required IdentifierLookupServiceOwnerDto ServiceOwner { get; set; }
+    public List<LocalizationDto> Title { get; set; } = [];
 }
 
 public sealed class IdentifierLookupServiceResourceDto
@@ -33,6 +35,6 @@ public sealed class EndUserIdentifierLookupDto : IdentifierLookupDto
 
 public sealed class ServiceOwnerIdentifierLookupDto : IdentifierLookupDto
 {
-    public List<LocalizationDto> Title { get; set; } = [];
+    [JsonPropertyOrder(100)] // Make sure we get placed after "Title"
     public List<LocalizationDto>? NonSensitiveTitle { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/IdentifierLookup/IdentifierLookupTitleResolver.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/IdentifierLookup/IdentifierLookupTitleResolver.cs
@@ -1,0 +1,25 @@
+using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.IdentifierLookup;
+
+internal static class IdentifierLookupTitleResolver
+{
+    public static List<LocalizationDto> ResolveEndUserTitle(
+        IdentifierLookupDialogData dialogData,
+        int currentAuthenticationLevel,
+        int minimumAuthenticationLevel) =>
+        ToLocalizations(
+            currentAuthenticationLevel < minimumAuthenticationLevel && dialogData.NonSensitiveTitle is not null
+                ? dialogData.NonSensitiveTitle
+                : dialogData.Title);
+
+    public static List<LocalizationDto> ToLocalizations(IEnumerable<ResourceLocalization> localizations) =>
+        localizations
+            .Select(x => new LocalizationDto
+            {
+                LanguageCode = x.LanguageCode,
+                Value = x.Value
+            })
+            .ToList();
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogLookup/Queries/Get/GetDialogLookupQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/DialogLookup/Queries/Get/GetDialogLookupQuery.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Digdir.Domain.Dialogporten.Application.Common.Behaviours.FeatureMetric;
 using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.IdentifierLookup;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using FluentValidation.Results;
@@ -93,6 +94,12 @@ internal sealed class GetDialogLookupQueryHandler : IRequestHandler<GetDialogLoo
             request.AcceptedLanguages,
             cancellationToken);
 
+        var title = IdentifierLookupTitleResolver.ResolveEndUserTitle(
+            dialogData,
+            authorization.Evidence.CurrentAuthenticationLevel,
+            serviceResource.MinimumAuthenticationLevel);
+        title.PruneLocalizations(request.AcceptedLanguages);
+
         return new EndUserIdentifierLookupDto
         {
             DialogId = dialogData.DialogId,
@@ -100,6 +107,7 @@ internal sealed class GetDialogLookupQueryHandler : IRequestHandler<GetDialogLoo
             Party = dialogData.Party,
             ServiceResource = serviceResource,
             ServiceOwner = serviceOwner,
+            Title = title,
             AuthorizationEvidence = authorization.Evidence
         };
     }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogLookup/Queries/Get/GetDialogLookupQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/DialogLookup/Queries/Get/GetDialogLookupQuery.cs
@@ -96,12 +96,12 @@ internal sealed class GetDialogLookupQueryHandler : IRequestHandler<GetDialogLoo
             request.AcceptedLanguages,
             cancellationToken);
 
-        var title = ToLocalizations(dialogData.Title);
+        var title = IdentifierLookupTitleResolver.ToLocalizations(dialogData.Title);
         title.PruneLocalizations(request.AcceptedLanguages);
 
         var nonSensitiveTitle = dialogData.NonSensitiveTitle is null
             ? null
-            : ToLocalizations(dialogData.NonSensitiveTitle);
+            : IdentifierLookupTitleResolver.ToLocalizations(dialogData.NonSensitiveTitle);
         nonSensitiveTitle?.PruneLocalizations(request.AcceptedLanguages);
 
         return new ServiceOwnerIdentifierLookupDto
@@ -115,13 +115,4 @@ internal sealed class GetDialogLookupQueryHandler : IRequestHandler<GetDialogLoo
             NonSensitiveTitle = nonSensitiveTitle
         };
     }
-
-    private static List<LocalizationDto> ToLocalizations(IEnumerable<ResourceLocalization> localizations) =>
-        localizations
-            .Select(x => new LocalizationDto
-            {
-                LanguageCode = x.LanguageCode,
-                Value = x.Value
-            })
-            .ToList();
 }

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogLookup/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogLookup/ObjectTypes.cs
@@ -34,6 +34,7 @@ public sealed class DialogLookup
     public Guid DialogId { get; set; }
     public string InstanceRef { get; set; } = null!;
     public string Party { get; set; } = null!;
+    public List<Localization> Title { get; set; } = [];
 
     public DialogLookupServiceResource ServiceResource { get; set; } = null!;
     public DialogLookupServiceOwner ServiceOwner { get; set; } = null!;

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/DialogLookup/Queries/Get/GetDialogLookupTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/DialogLookup/Queries/Get/GetDialogLookupTests.cs
@@ -1,8 +1,11 @@
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common.ApplicationFlow;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.Common.Extensions;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -155,21 +158,163 @@ public class GetDialogLookupTests(DialogApplication application) : ApplicationCo
             .ExecuteAndAssert<Digdir.Domain.Dialogporten.Application.Common.ReturnTypes.Forbidden>(_ => { });
 
     [Fact]
-    public Task Get_Should_Return_Forbidden_When_EndUser_Auth_Level_Is_Too_Low()
+    public Task Get_Should_Return_NonSensitiveTitle_As_Title_When_EndUser_Auth_Level_Is_Too_Low()
     {
+        var party = Party;
         const string serviceResource = "urn:altinn:resource:test-service-auth-level-too-low";
 
         return FlowBuilder.For(Application)
+            .ConfigureAltinnAuthorization(altinnAuthorization =>
+                ConfigureLookupAccessViaResourceDelegation(altinnAuthorization, party, serviceResource))
             .AsIntegrationTestUser(x => x.WithClaim(
                 ClaimsPrincipalExtensions.IdportenAuthLevelClaim,
                 Digdir.Domain.Dialogporten.Application.Common.Authorization.Constants.IdportenLoaSubstantial))
-            .CreateSimpleDialog((x, _) => x.Dto.ServiceResource = serviceResource)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.Party = party;
+                x.Dto.ServiceResource = serviceResource;
+                x.Dto.Content!.Title.Value =
+                [
+                    new LocalizationDto { LanguageCode = "nb", Value = "Gradert tittel" }
+                ];
+                x.Dto.Content.NonSensitiveTitle = new ContentValueDto
+                {
+                    Value =
+                    [
+                        new LocalizationDto { LanguageCode = "nb", Value = "Ugradert tittel" }
+                    ]
+                };
+            })
             .Do(async (_, ctx) => await SeedMinimumAuthenticationLevel(ctx, serviceResource, minimumAuthenticationLevel: 4))
             .SendCommand((_, ctx) => new GetDialogLookupQuery
             {
                 InstanceRef = $"urn:altinn:dialog-id:{ctx.GetDialogId()}"
             })
-            .ExecuteAndAssert<Digdir.Domain.Dialogporten.Application.Common.ReturnTypes.Forbidden>(_ => { });
+            .ExecuteAndAssert<EndUserIdentifierLookupDto>(result =>
+            {
+                result.Title.Should().ContainSingle();
+                result.Title[0].Value.Should().Be("Ugradert tittel");
+                result.AuthorizationEvidence.CurrentAuthenticationLevel.Should().Be(3);
+            });
+    }
+
+    [Fact]
+    public Task Get_Should_Fall_Back_To_Title_When_EndUser_Auth_Level_Is_Too_Low_And_NonSensitiveTitle_Is_Not_Set()
+    {
+        var party = Party;
+        const string serviceResource = "urn:altinn:resource:test-service-auth-level-title-fallback";
+
+        return FlowBuilder.For(Application)
+            .ConfigureAltinnAuthorization(altinnAuthorization =>
+                ConfigureLookupAccessViaResourceDelegation(altinnAuthorization, party, serviceResource))
+            .AsIntegrationTestUser(x => x.WithClaim(
+                ClaimsPrincipalExtensions.IdportenAuthLevelClaim,
+                Digdir.Domain.Dialogporten.Application.Common.Authorization.Constants.IdportenLoaSubstantial))
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.Party = party;
+                x.Dto.ServiceResource = serviceResource;
+                x.Dto.Content!.Title.Value =
+                [
+                    new LocalizationDto { LanguageCode = "nb", Value = "Gradert tittel" }
+                ];
+                x.Dto.Content.NonSensitiveTitle = null;
+            })
+            .Do(async (_, ctx) => await SeedMinimumAuthenticationLevel(ctx, serviceResource, minimumAuthenticationLevel: 4))
+            .SendCommand((_, ctx) => new GetDialogLookupQuery
+            {
+                InstanceRef = $"urn:altinn:dialog-id:{ctx.GetDialogId()}"
+            })
+            .ExecuteAndAssert<EndUserIdentifierLookupDto>(result =>
+            {
+                result.Title.Should().ContainSingle();
+                result.Title[0].Value.Should().Be("Gradert tittel");
+            });
+    }
+
+    [Fact]
+    public Task Get_Should_Return_Title_When_EndUser_Auth_Level_Is_Sufficient_Even_If_NonSensitiveTitle_Is_Set()
+    {
+        var party = Party;
+        const string serviceResource = "urn:altinn:resource:test-service-auth-level-sufficient";
+
+        return FlowBuilder.For(Application)
+            .ConfigureAltinnAuthorization(altinnAuthorization =>
+                ConfigureLookupAccessViaResourceDelegation(altinnAuthorization, party, serviceResource))
+            .AsIntegrationTestUser(x => x.WithClaim(
+                ClaimsPrincipalExtensions.IdportenAuthLevelClaim,
+                Digdir.Domain.Dialogporten.Application.Common.Authorization.Constants.IdportenLoaHigh))
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.Party = party;
+                x.Dto.ServiceResource = serviceResource;
+                x.Dto.Content!.Title.Value =
+                [
+                    new LocalizationDto { LanguageCode = "nb", Value = "Gradert tittel" }
+                ];
+                x.Dto.Content.NonSensitiveTitle = new ContentValueDto
+                {
+                    Value =
+                    [
+                        new LocalizationDto { LanguageCode = "nb", Value = "Ugradert tittel" }
+                    ]
+                };
+            })
+            .Do(async (_, ctx) => await SeedMinimumAuthenticationLevel(ctx, serviceResource, minimumAuthenticationLevel: 4))
+            .SendCommand((_, ctx) => new GetDialogLookupQuery
+            {
+                InstanceRef = $"urn:altinn:dialog-id:{ctx.GetDialogId()}"
+            })
+            .ExecuteAndAssert<EndUserIdentifierLookupDto>(result =>
+            {
+                result.Title.Should().ContainSingle();
+                result.Title[0].Value.Should().Be("Gradert tittel");
+                result.AuthorizationEvidence.CurrentAuthenticationLevel.Should().Be(4);
+            });
+    }
+
+    [Fact]
+    public Task Get_Should_Prune_Selected_Title_When_AcceptLanguage_Is_Set()
+    {
+        var party = Party;
+        const string serviceResource = "urn:altinn:resource:test-service-title-pruning";
+
+        return FlowBuilder.For(Application)
+            .ConfigureAltinnAuthorization(altinnAuthorization =>
+                ConfigureLookupAccessViaResourceDelegation(altinnAuthorization, party, serviceResource))
+            .AsIntegrationTestUser(x => x.WithClaim(
+                ClaimsPrincipalExtensions.IdportenAuthLevelClaim,
+                Digdir.Domain.Dialogporten.Application.Common.Authorization.Constants.IdportenLoaSubstantial))
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.Party = party;
+                x.Dto.ServiceResource = serviceResource;
+                x.Dto.Content!.Title.Value =
+                [
+                    new LocalizationDto { LanguageCode = "nb", Value = "Gradert tittel" },
+                    new LocalizationDto { LanguageCode = "en", Value = "Sensitive title" }
+                ];
+                x.Dto.Content.NonSensitiveTitle = new ContentValueDto
+                {
+                    Value =
+                    [
+                        new LocalizationDto { LanguageCode = "nb", Value = "Ugradert tittel" },
+                        new LocalizationDto { LanguageCode = "en", Value = "Non-sensitive title" }
+                    ]
+                };
+            })
+            .Do(async (_, ctx) => await SeedMinimumAuthenticationLevel(ctx, serviceResource, minimumAuthenticationLevel: 4))
+            .SendCommand((_, ctx) => new GetDialogLookupQuery
+            {
+                InstanceRef = $"urn:altinn:dialog-id:{ctx.GetDialogId()}",
+                AcceptedLanguages = [new AcceptedLanguage("en", 100)]
+            })
+            .ExecuteAndAssert<EndUserIdentifierLookupDto>(result =>
+            {
+                result.Title.Should().ContainSingle();
+                result.Title[0].LanguageCode.Should().Be("en");
+                result.Title[0].Value.Should().Be("Non-sensitive title");
+            });
     }
 
     [Fact]
@@ -496,5 +641,31 @@ public class GetDialogLookupTests(DialogApplication application) : ApplicationCo
         });
 
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static void ConfigureLookupAccessViaResourceDelegation(
+        IAltinnAuthorization altinnAuthorization,
+        string party,
+        string serviceResource)
+    {
+        altinnAuthorization.GetAuthorizedPartiesForLookup(
+                null!,
+                Arg.Any<List<string>>(),
+                Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(new AuthorizedPartiesResult
+            {
+                AuthorizedParties =
+                [
+                    new AuthorizedParty
+                    {
+                        Party = party,
+                        PartyUuid = Guid.NewGuid(),
+                        Name = "Party",
+                        AuthorizedRolesAndAccessPackages = [],
+                        AuthorizedResources = [serviceResource],
+                        AuthorizedInstances = []
+                    }
+                ]
+            });
     }
 }

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/Features/DialogLookup/DialogLookupTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/Features/DialogLookup/DialogLookupTests.cs
@@ -60,6 +60,7 @@ public class DialogLookupTests(GraphQlE2EFixture fixture) : E2ETestBase<GraphQlE
         lookup.DialogId.Should().Be(dialogId);
         lookup.InstanceRef.Should().Be(instanceRef.ToLowerInvariant());
         lookup.Party.Should().NotBeEmpty().And.Be(party);
+        lookup.Title.Should().NotBeNull().And.NotBeEmpty();
         lookup.ServiceResource.Id.Should().NotBeNullOrWhiteSpace();
         lookup.ServiceOwner.Code.Should().NotBeNullOrWhiteSpace();
     }

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/GetDialogLookup.graphql
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/GetDialogLookup.graphql
@@ -4,6 +4,10 @@ query GetDialogLookup($instanceRef: String!) {
       dialogId
       instanceRef
       party
+      title {
+        languageCode
+        value
+      }
       serviceResource {
         id
       }

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EndUser/DialogLookup/Queries/Get/GetDialogLookupTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EndUser/DialogLookup/Queries/Get/GetDialogLookupTests.cs
@@ -64,5 +64,6 @@ public class GetDialogLookupTests(WebApiE2EFixture fixture) : E2ETestBase<WebApi
         lookup.ServiceResource.Id.Should().NotBeNullOrWhiteSpace();
         lookup.ServiceResource.MinimumAuthenticationLevel.Should().Be(2);
         lookup.ServiceOwner.Code.Should().NotBeNullOrWhiteSpace();
+        lookup.Title.Should().NotBeNull().And.NotBeEmpty();
     }
 }

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EnduserRefitterInterface.cs
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EnduserRefitterInterface.cs
@@ -1176,6 +1176,9 @@ namespace Digdir.Domain.Dialogporten.WebAPI.E2E.Tests.Features.V1
         [JsonPropertyName("serviceResource")]
         public V1CommonIdentifierLookup_IdentifierLookupServiceResource ServiceResource { get; set; }
 
+        [JsonPropertyName("title")]
+        public ICollection<V1CommonLocalizations_Localization> Title { get; set; }
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))")]


### PR DESCRIPTION
## Description

This adds title (which may be populated with nonSensitiveTitle data) to the EU dialog lookup DTO. Consequently, this also removes the 403 if currentauthenticationlevel < minimumauthenticationlevel handling (mirroring dialog search behaviour)

## Related Issue(s)

- #3709

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 
