### PR TITLE
trivial(infra): use Burstable SKU for AT23 postgres2 migration target

### DIFF
--- a/.azure/infrastructure/postgresql-migration-target.test.bicepparam
+++ b/.azure/infrastructure/postgresql-migration-target.test.bicepparam
@@ -8,20 +8,21 @@ param sourceKeyVaultSubscriptionId = readEnvironmentVariable('AZURE_SOURCE_KEY_V
 param sourceKeyVaultResourceGroup = readEnvironmentVariable('AZURE_SOURCE_KEY_VAULT_RESOURCE_GROUP')
 param sourceKeyVaultName = readEnvironmentVariable('AZURE_SOURCE_KEY_VAULT_NAME')
 
-// After migrations are complete, remove this file and let the current (burstable, SSDv1-tier) server
-// remain the canonical "test"-server.
+// After migration is complete, copy this postgresConfiguration block into test.bicepparam
+// to make postgres2 the canonical server, then remove this file.
+// AT23 stays on Burstable / Premium_LRS (SSDv1) to keep costs down.
 param postgresConfiguration = {
   serverNameStem: 'postgres2'
   version: '18'
   sku: {
-    name: 'Standard_E4ads_v5'
-    tier: 'MemoryOptimized'
+    name: 'Standard_B2s'
+    tier: 'Burstable'
   }
   storage: {
     storageSizeGB: 32
-    type: 'PremiumV2_LRS'
-    iops: 3000
-    throughput: 125
+    autoGrow: 'Enabled'
+    type: 'Premium_LRS'
+    tier: 'P4'
   }
   enableIndexTuning: false
   enableQueryPerformanceInsight: false


### PR DESCRIPTION
## Description

Switch the AT23 postgres2 migration target from MemoryOptimized / PremiumV2_LRS to Burstable / Premium_LRS to match the current test server's SKU and keep costs down. 

## Related Issue(s)

- #3677

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)