### PR TITLE
fix(perf): Denormalize enduser systemlabel

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/ApplicationSettings.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/ApplicationSettings.cs
@@ -15,7 +15,7 @@ public sealed class ApplicationSettings
 
 public sealed class FeatureToggle
 {
-    public bool UseBranchingLogicForDialogSearch { get; init; }
+    public bool UseSystemLabelsMaskForEndUserDialogSearch { get; init; }
     public bool UsePartyResourcePruning { get; init; }
     public bool UseAltinnAutoAuthorizedPartiesQueryParameters { get; init; }
     public bool UseCorrectPersonNameOrdering { get; init; }

--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/DialogEntity.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/DialogEntity.cs
@@ -67,6 +67,11 @@ public sealed class DialogEntity :
     public bool HasUnopenedContent { get; set; }
 
     /// <summary>
+    /// Denormalized bitmask of end-user system labels for search filtering.
+    /// </summary>
+    public short SystemLabelsMask { get; set; }
+
+    /// <summary>
     ///  Indicates whether the dialog can be updated/deleted by the service owner
     /// </summary>
     public bool Frozen { get; set; }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -129,8 +129,8 @@ public static class InfrastructureExtensions
 
             // Transient
             .AddTransient<ISearchStrategySelector<EndUserSearchContext>, DialogEndUserSearchStrategySelector>()
-            .AddTransient<IQueryStrategy<EndUserSearchContext>, PartyDrivenQueryStrategy>()
             .AddTransient<IQueryStrategy<EndUserSearchContext>, ServiceDrivenQueryStrategy>()
+            .AddTransient<IQueryStrategy<EndUserSearchContext>, ServiceDrivenSystemLabelMaskQueryStrategy>()
             .AddTransient<IPartyResourceReferenceRepository, PartyResourceRepository>()
             .AddTransient<IDialogSearchRepository, DialogSearchRepository>()
             .AddTransient<ITransmissionHierarchyRepository, TransmissionHierarchyRepository>()

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Configurations/Dialogs/DialogEntityConfiguration.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Configurations/Dialogs/DialogEntityConfiguration.cs
@@ -60,6 +60,7 @@ internal sealed class DialogEntityConfiguration : IEntityTypeConfiguration<Dialo
         builder.HasIndex(x => new { x.ServiceResource, x.Party, x.ContentUpdatedAt, x.Id })
             .HasDatabaseName("IX_Dialog_ServiceResource_Party_ContentUpdatedAt_Id_NotDeleted")
             .IsDescending(false, false, true, true)
+            .IncludeProperties(x => new { x.StatusId, x.VisibleFrom, x.ExpiresAt, x.IsApiOnly, x.SystemLabelsMask })
             .HasFilter($"\"{nameof(DialogEntity.Deleted)}\" = false");
 
         builder.Property(x => x.Org).UseCollation("C");
@@ -69,5 +70,6 @@ internal sealed class DialogEntityConfiguration : IEntityTypeConfiguration<Dialo
         builder.Property(x => x.IdempotentKey).HasMaxLength(36);
         builder.Property(x => x.ContentUpdatedAt).HasDefaultValueSql("current_timestamp at time zone 'utc'");
         builder.Property(x => x.IsApiOnly).HasDefaultValue(false);
+        builder.Property(x => x.SystemLabelsMask).HasDefaultValue((short)1);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20260331114131_AddDialogSystemLabelsMask.Designer.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20260331114131_AddDialogSystemLabelsMask.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DialogDbContext))]
-    partial class DialogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260331114131_AddDialogSystemLabelsMask")]
+    partial class AddDialogSystemLabelsMask
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20260331114131_AddDialogSystemLabelsMask.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/20260331114131_AddDialogSystemLabelsMask.cs
@@ -1,0 +1,83 @@
+﻿using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Sql;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDialogSystemLabelsMask : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<short>(
+                name: "SystemLabelsMask",
+                table: "Dialog",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (short)1);
+
+            var scripts = new[]
+            {
+                "Dialog/SystemLabels/Function.RecomputeDialogSystemLabelsMask.sql",
+                "Dialog/SystemLabels/Function.SyncDialogSystemLabelsMaskFromLabelChanges.sql",
+                "Dialog/SystemLabels/Function.BackfillDialogSystemLabelsMaskBatch.sql",
+                "Dialog/SystemLabels/Procedure.RunBackfillDialogSystemLabelsMask.sql",
+                "Dialog/SystemLabels/Trigger.SyncDialogSystemLabelsMaskFromLabelChanges.sql",
+            };
+
+            foreach (var sql in MigrationSqlLoader.LoadAll(scripts))
+            {
+                migrationBuilder.Sql(sql);
+            }
+
+            migrationBuilder.DropIndex(
+                name: "IX_Dialog_ServiceResource_Party_ContentUpdatedAt_Id_NotDeleted",
+                table: "Dialog");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Dialog_ServiceResource_Party_ContentUpdatedAt_Id_NotDeleted",
+                table: "Dialog",
+                columns: new[] { "ServiceResource", "Party", "ContentUpdatedAt", "Id" },
+                descending: new[] { false, false, true, true },
+                filter: "\"Deleted\" = false")
+                .Annotation("Npgsql:IndexInclude", new[] { "StatusId", "VisibleFrom", "ExpiresAt", "IsApiOnly", "SystemLabelsMask" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                DROP TRIGGER IF EXISTS "TR_DialogSystemLabelsMask_AfterInsert_Statement" ON public."DialogEndUserContextSystemLabel";
+                DROP TRIGGER IF EXISTS "TR_DialogSystemLabelsMask_AfterDelete_Statement" ON public."DialogEndUserContextSystemLabel";
+                DROP TRIGGER IF EXISTS "TR_DialogSystemLabelsMask_AfterUpdate_Statement" ON public."DialogEndUserContextSystemLabel";
+
+                DROP PROCEDURE IF EXISTS public.run_backfill_dialog_system_labels_mask(integer, uuid);
+                DROP PROCEDURE IF EXISTS public.run_backfill_dialog_system_labels_mask(integer);
+                DROP FUNCTION IF EXISTS public.backfill_dialog_system_labels_mask_batch(uuid, integer);
+                DROP FUNCTION IF EXISTS public.sync_dialog_system_labels_mask_from_inserted_label_rows();
+                DROP FUNCTION IF EXISTS public.sync_dialog_system_labels_mask_from_deleted_label_rows();
+                DROP FUNCTION IF EXISTS public.sync_dialog_system_labels_mask_from_updated_label_rows();
+                DROP FUNCTION IF EXISTS public.sync_dialog_system_labels_mask_from_label_changes(uuid[]);
+                DROP FUNCTION IF EXISTS public.recompute_dialog_system_labels_mask(uuid[]);
+                """);
+
+            migrationBuilder.DropIndex(
+                name: "IX_Dialog_ServiceResource_Party_ContentUpdatedAt_Id_NotDeleted",
+                table: "Dialog");
+
+            migrationBuilder.DropColumn(
+                name: "SystemLabelsMask",
+                table: "Dialog");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Dialog_ServiceResource_Party_ContentUpdatedAt_Id_NotDeleted",
+                table: "Dialog",
+                columns: new[] { "ServiceResource", "Party", "ContentUpdatedAt", "Id" },
+                descending: new[] { false, false, true, true },
+                filter: "\"Deleted\" = false")
+                .Annotation("Npgsql:IndexInclude", new[] { "StatusId", "VisibleFrom", "ExpiresAt", "IsApiOnly" });
+        }
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/DialogEndUserSearchStrategySelector.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/DialogEndUserSearchStrategySelector.cs
@@ -1,43 +1,17 @@
-using Digdir.Domain.Dialogporten.Application;
-using Microsoft.Extensions.Options;
-
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearch;
 
 // Selects the most suitable end-user dialog search strategy based on a score.
 // This keeps the repository logic simple while allowing strategies to evolve independently.
 internal sealed class DialogEndUserSearchStrategySelector(
-    IOptionsSnapshot<ApplicationSettings> applicationSettings,
     IEnumerable<IQueryStrategy<EndUserSearchContext>> strategies) : ISearchStrategySelector<EndUserSearchContext>
 {
-    private const string DefaultStrategyName = PartyDrivenQueryStrategy.StrategyName;
     private readonly IReadOnlyList<IQueryStrategy<EndUserSearchContext>> _strategies = strategies.ToList();
 
-    public IQueryStrategy<EndUserSearchContext> Select(EndUserSearchContext context)
-    {
-        // Feature flag controls whether we branch at all; otherwise stick to the default strategy.
-        if (!applicationSettings.Value.FeatureToggle.UseBranchingLogicForDialogSearch)
-        {
-            return GetDefaultStrategy();
-        }
-
-        // Highest score wins; ties are stable by name.
-        return _strategies
+    public IQueryStrategy<EndUserSearchContext> Select(EndUserSearchContext context) =>
+        _strategies
             .Select(strategy => (Strategy: strategy, Score: strategy.Score(context)))
             .OrderByDescending(x => x.Score)
             .ThenBy(x => x.Strategy.Name, StringComparer.OrdinalIgnoreCase)
             .Select(x => x.Strategy)
             .First();
-    }
-
-    private IQueryStrategy<EndUserSearchContext> GetDefaultStrategy()
-    {
-        var fallback = _strategies
-            .FirstOrDefault(strategy => string.Equals(
-                strategy.Name,
-                DefaultStrategyName,
-                StringComparison.OrdinalIgnoreCase));
-
-        return fallback ?? throw new InvalidOperationException(
-            $"Missing default end-user search strategy '{DefaultStrategyName}'.");
-    }
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/EndUserSearchContext.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/EndUserSearchContext.cs
@@ -1,3 +1,4 @@
+using Digdir.Domain.Dialogporten.Application;
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 
@@ -5,4 +6,5 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.Dia
 
 internal sealed record EndUserSearchContext(
     GetDialogsQuery Query,
-    DialogSearchAuthorizationResult AuthorizedResources);
+    DialogSearchAuthorizationResult AuthorizedResources,
+    FeatureToggle FeatureToggle);

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/QueryStrategyScores.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/QueryStrategyScores.cs
@@ -1,0 +1,8 @@
+namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearch;
+
+internal static class QueryStrategyScores
+{
+    public const int Ineligible = 0;
+    public const int Default = 100;
+    public const int Preferred = 1000;
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/ServiceDrivenQueryStrategy.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/ServiceDrivenQueryStrategy.cs
@@ -20,7 +20,7 @@ internal sealed class ServiceDrivenQueryStrategy : IQueryStrategy<EndUserSearchC
     public int Score(EndUserSearchContext context)
     {
         _ = context;
-        return 100;
+        return QueryStrategyScores.Default;
     }
 
     public PostgresFormattableStringBuilder BuildSql(EndUserSearchContext context)

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/ServiceDrivenQueryStrategy.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/ServiceDrivenQueryStrategy.cs
@@ -17,7 +17,6 @@ internal sealed class ServiceDrivenQueryStrategy : IQueryStrategy<EndUserSearchC
 
     public string Name => "ServiceDriven";
 
-    // Service-driven is always preferred when branching logic is enabled.
     public int Score(EndUserSearchContext context)
     {
         _ = context;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/ServiceDrivenSystemLabelMaskQueryStrategy.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/ServiceDrivenSystemLabelMaskQueryStrategy.cs
@@ -4,34 +4,31 @@ using Microsoft.Extensions.Logging;
 
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearch;
 
-internal sealed class PartyDrivenQueryStrategy : IQueryStrategy<EndUserSearchContext>
+internal sealed class ServiceDrivenSystemLabelMaskQueryStrategy : IQueryStrategy<EndUserSearchContext>
 {
-    internal const string StrategyName = "PartyDriven";
-    private readonly ILogger<PartyDrivenQueryStrategy> _logger;
+    private readonly ILogger<ServiceDrivenSystemLabelMaskQueryStrategy> _logger;
 
-    public PartyDrivenQueryStrategy(ILogger<PartyDrivenQueryStrategy> logger)
+    public ServiceDrivenSystemLabelMaskQueryStrategy(ILogger<ServiceDrivenSystemLabelMaskQueryStrategy> logger)
     {
         ArgumentNullException.ThrowIfNull(logger);
 
         _logger = logger;
     }
 
-    public string Name => StrategyName;
+    public string Name => "ServiceDrivenSystemLabelMask";
 
-    // Party-driven is kept as fallback only when branching logic is disabled.
-    public int Score(EndUserSearchContext context)
-    {
-        _ = context;
-        return 0;
-    }
+    public int Score(EndUserSearchContext context) =>
+        context.FeatureToggle.UseSystemLabelsMaskForEndUserDialogSearch ? 110 : 0;
 
     public PostgresFormattableStringBuilder BuildSql(EndUserSearchContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
         var query = context.Query;
         var authorizedResources = context.AuthorizedResources;
-        var partiesAndServices = DialogEndUserSearchSqlHelpers.BuildPartiesAndServices(query, authorizedResources);
-        DialogEndUserSearchSqlHelpers.LogPartiesAndServicesCount(_logger, partiesAndServices, StrategyName);
+        var partiesAndServices = DialogEndUserSearchSqlHelpers.BuildPartiesAndServices(
+            query,
+            authorizedResources);
+        DialogEndUserSearchSqlHelpers.LogPartiesAndServicesCount(_logger, partiesAndServices, Name);
         var permissionCandidateDialogs = BuildPermissionCandidateDialogs(query);
         var delegatedCandidateDialogs = BuildDelegatedCandidateDialogs(query, authorizedResources.DialogIds.ToArray());
         var postPermissionOrderAndLimit = BuildPostPermissionOrderAndLimit(query);
@@ -50,25 +47,19 @@ internal sealed class PartyDrivenQueryStrategy : IQueryStrategy<EndUserSearchCon
                 """)
             .Append(
                 $"""
-                raw_permissions AS (
-                    SELECT p.party
-                         , s.service
+                permission_groups AS (
+                    SELECT x."Parties" AS parties
+                         , x."Services" AS services
                     FROM jsonb_to_recordset({JsonSerializer.Serialize(partiesAndServices)}::jsonb) AS x("Parties" text[], "Services" text[])
-                    CROSS JOIN LATERAL unnest(x."Services") AS s(service)
-                    CROSS JOIN LATERAL unnest(x."Parties") AS p(party)
                 )
-                ,party_permission_map AS (
-                    SELECT party
-                         , ARRAY_AGG(service) AS allowed_services
-                    FROM raw_permissions
-                    GROUP BY party
+                ,service_permissions AS (
+                    SELECT s.service
+                         , pg.parties AS allowed_parties
+                    FROM permission_groups pg
+                    CROSS JOIN LATERAL unnest(pg.services) AS s(service)
                 )
                 ,permission_candidate_ids AS (
-                    SELECT d_inner."Id"
-                    FROM party_permission_map ppm
-                    CROSS JOIN LATERAL (
-                        {permissionCandidateDialogs}
-                    ) d_inner
+                    {permissionCandidateDialogs}
                 )
                 ,delegated_dialogs AS (
                     {delegatedCandidateDialogs}
@@ -88,34 +79,27 @@ internal sealed class PartyDrivenQueryStrategy : IQueryStrategy<EndUserSearchCon
 
     private static PostgresFormattableStringBuilder BuildPermissionCandidateDialogs(GetDialogsQuery query)
     {
-        var permissionCandidateFilters = BuildPermissionCandidateFilters(query, includeSearchFilter: false);
+        var permissionCandidateFilters = BuildPermissionCandidateFilters(query);
+        var searchJoin = DialogEndUserSearchSqlHelpers.BuildSearchJoin(query.Search is not null);
 
         return new PostgresFormattableStringBuilder()
-            .AppendIf(query.Search is null,
-                """
-                SELECT d."Id"
-                FROM "Dialog" d
-                WHERE d."Party" = ppm.party
-
-                """)
-            .AppendIf(query.Search is not null,
-                """
-                SELECT d."Id"
-                FROM search."DialogSearch" ds
-                JOIN "Dialog" d ON d."Id" = ds."DialogId"
-                CROSS JOIN searchString ss
-                WHERE ds."Party" = ppm.party AND ds."SearchVector" @@ ss.searchVector
-
-                """)
             .Append(
-                """
-                AND d."ServiceResource" = ANY(ppm.allowed_services)
+                $"""
+                SELECT d_inner."Id"
+                FROM service_permissions sp
+                CROSS JOIN LATERAL (
+                    SELECT d."Id"
+                    FROM "Dialog" d
+                    {searchJoin}
+                    WHERE d."ServiceResource" = sp.service
+                      AND d."Party" = ANY(sp.allowed_parties)
+                      {permissionCandidateFilters}
                 """)
-            .Append($"{permissionCandidateFilters}")
             .ApplyPaginationOrder(query.OrderBy!, alias: "d")
             .Append(
                 $"""
-                 LIMIT {query.Limit + 1}
+                    LIMIT {query.Limit + 1}
+                ) d_inner
 
                 """);
     }
@@ -124,8 +108,8 @@ internal sealed class PartyDrivenQueryStrategy : IQueryStrategy<EndUserSearchCon
         GetDialogsQuery query,
         Guid[] dialogIds)
     {
-        var searchJoin = DialogEndUserSearchSqlHelpers.BuildSearchJoin(query.Search is not null);
         var permissionCandidateFilters = BuildPermissionCandidateFilters(query);
+        var searchJoin = DialogEndUserSearchSqlHelpers.BuildSearchJoin(query.Search is not null);
 
         return new PostgresFormattableStringBuilder()
             .Append(
@@ -136,7 +120,6 @@ internal sealed class PartyDrivenQueryStrategy : IQueryStrategy<EndUserSearchCon
                 {searchJoin}
                 WHERE 1=1
                 {permissionCandidateFilters}
-
                 """);
     }
 
@@ -145,11 +128,9 @@ internal sealed class PartyDrivenQueryStrategy : IQueryStrategy<EndUserSearchCon
             .ApplyPaginationOrder(query.OrderBy!, alias: "d")
             .ApplyPaginationLimit(query.Limit);
 
-    private static PostgresFormattableStringBuilder BuildPermissionCandidateFilters(
-        GetDialogsQuery query,
-        bool includeSearchFilter = true) =>
+    private static PostgresFormattableStringBuilder BuildPermissionCandidateFilters(GetDialogsQuery query) =>
         new PostgresFormattableStringBuilder()
-            .AppendIf(includeSearchFilter && query.Search is not null, """ AND ds."SearchVector" @@ ss.searchVector """)
+            .AppendIf(query.Search is not null, """ AND ds."SearchVector" @@ ss.searchVector """)
             .AppendManyFilter(query.Org, nameof(query.Org))
             .AppendManyFilter(query.Status, "StatusId", "int")
             .AppendManyFilter(query.ExtendedStatus, nameof(query.ExtendedStatus))
@@ -167,6 +148,6 @@ internal sealed class PartyDrivenQueryStrategy : IQueryStrategy<EndUserSearchCon
             .AppendIf(query.DueBefore is not null, $""" AND d."DueAt" <= {query.DueBefore}::timestamptz """)
             .AppendIf(query.Process is not null, $""" AND d."Process" = {query.Process}::text """)
             .AppendIf(query.ExcludeApiOnly is not null, $""" AND ({query.ExcludeApiOnly}::boolean = false OR {query.ExcludeApiOnly}::boolean = true AND d."IsApiOnly" = false) """)
-            .AppendSystemLabelFilterCondition(query.SystemLabel)
+            .AppendSystemLabelMaskFilterCondition(query.SystemLabel)
             .ApplyPaginationCondition(query.OrderBy!, query.ContinuationToken, alias: "d");
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/ServiceDrivenSystemLabelMaskQueryStrategy.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearch/ServiceDrivenSystemLabelMaskQueryStrategy.cs
@@ -18,7 +18,9 @@ internal sealed class ServiceDrivenSystemLabelMaskQueryStrategy : IQueryStrategy
     public string Name => "ServiceDrivenSystemLabelMask";
 
     public int Score(EndUserSearchContext context) =>
-        context.FeatureToggle.UseSystemLabelsMaskForEndUserDialogSearch ? 110 : 0;
+        context.FeatureToggle.UseSystemLabelsMaskForEndUserDialogSearch
+            ? QueryStrategyScores.Preferred
+            : QueryStrategyScores.Ineligible;
 
     public PostgresFormattableStringBuilder BuildSql(EndUserSearchContext context)
     {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearchRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearchRepository.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Dapper;
+using Digdir.Domain.Dialogporten.Application;
 using Digdir.Domain.Dialogporten.Application.Common.Pagination;
 using Digdir.Domain.Dialogporten.Application.Common.Pagination.Continuation;
 using Digdir.Domain.Dialogporten.Application.Common.Pagination.Order;
@@ -13,6 +14,7 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Contents;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearch;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Npgsql;
 
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories;
@@ -21,19 +23,23 @@ internal sealed class DialogSearchRepository : IDialogSearchRepository
 {
     private readonly DialogDbContext _db;
     private readonly NpgsqlDataSource _dataSource;
+    private readonly IOptionsSnapshot<ApplicationSettings> _applicationSettings;
     private readonly ISearchStrategySelector<EndUserSearchContext> _endUserSearchStrategySelector;
 
     public DialogSearchRepository(
         DialogDbContext dbContext,
         NpgsqlDataSource dataSource,
+        IOptionsSnapshot<ApplicationSettings> applicationSettings,
         ISearchStrategySelector<EndUserSearchContext> endUserSearchStrategySelector)
     {
         ArgumentNullException.ThrowIfNull(dbContext);
         ArgumentNullException.ThrowIfNull(dataSource);
+        ArgumentNullException.ThrowIfNull(applicationSettings);
         ArgumentNullException.ThrowIfNull(endUserSearchStrategySelector);
 
         _db = dbContext;
         _dataSource = dataSource;
+        _applicationSettings = applicationSettings;
         _endUserSearchStrategySelector = endUserSearchStrategySelector;
     }
 
@@ -270,7 +276,7 @@ internal sealed class DialogSearchRepository : IDialogSearchRepository
             return new PaginatedList<DialogEntity>([], false, null, query.OrderBy!.GetOrderString());
         }
 
-        var context = new EndUserSearchContext(query, authorizedResources);
+        var context = new EndUserSearchContext(query, authorizedResources, _applicationSettings.Value.FeatureToggle);
         var strategy = _endUserSearchStrategySelector.Select(context);
         return await GetDialogsAsEndUserInternal(strategy, context, cancellationToken);
     }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
@@ -234,6 +234,7 @@ internal static class PostgresFormattableStringBuilderExtensions
                 throw new ArgumentOutOfRangeException(nameof(labels), systemLabelId, "System label ids must be greater than zero.");
             }
 
+            // `short` in C# maps to `smallint` in PostgreSQL, and both are 16-bit signed integers. So, to avoid touching the sign bit, there are 15 distinct values that can be used.
             if (systemLabelId > 15)
             {
                 throw new ArgumentOutOfRangeException(nameof(labels), systemLabelId, "System label ids above 15 are not supported by the bitmask.");

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
@@ -234,10 +234,10 @@ internal static class PostgresFormattableStringBuilderExtensions
                 throw new ArgumentOutOfRangeException(nameof(labels), systemLabelId, "System label ids must be greater than zero.");
             }
 
-  if (systemLabelId > 15)                                                                                                                                                                                               
-  {
-      throw new ArgumentOutOfRangeException(nameof(labels), systemLabelId, "System label ids above 15 are not supported by the bitmask.");                                                                              
-  }   
+            if (systemLabelId > 15)
+            {
+                throw new ArgumentOutOfRangeException(nameof(labels), systemLabelId, "System label ids above 15 are not supported by the bitmask.");
+            }
 
             requiredMask |= (short)(1 << (systemLabelId - 1));
         }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
@@ -62,6 +62,20 @@ internal static class PostgresFormattableStringBuilderExtensions
         return queryBuilder;
     }
 
+    internal static PostgresFormattableStringBuilder AppendSystemLabelMaskFilterCondition(
+        this PostgresFormattableStringBuilder queryBuilder,
+        IEnumerable<SystemLabel.Values>? endUserLabels)
+    {
+        if (!TryBuildSystemLabelsMask(endUserLabels, out var requiredMask))
+        {
+            return queryBuilder;
+        }
+
+        return queryBuilder.Append($"""
+            AND (d."SystemLabelsMask" & {requiredMask}::smallint) = {requiredMask}::smallint
+            """);
+    }
+
     internal static PostgresFormattableStringBuilder AppendServiceOwnerLabelFilterCondition(
         this PostgresFormattableStringBuilder queryBuilder,
         IEnumerable<string>? serviceOwnerLabels)
@@ -199,6 +213,31 @@ internal static class PostgresFormattableStringBuilderExtensions
         }
 
         return results.Count > 0;
+    }
+
+    private static bool TryBuildSystemLabelsMask(
+        IEnumerable<SystemLabel.Values>? labels,
+        out short requiredMask)
+    {
+        requiredMask = 0;
+
+        if (labels is null)
+        {
+            return false;
+        }
+
+        foreach (var label in labels.Distinct())
+        {
+            var systemLabelId = (int)label;
+            if (systemLabelId <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(labels), systemLabelId, "System label ids must be greater than zero.");
+            }
+
+            requiredMask |= (short)(1 << (systemLabelId - 1));
+        }
+
+        return requiredMask != 0;
     }
 
     private static PostgresFormattableStringBuilder CreateLessThanGreaterThanPart(this PostgresFormattableStringBuilder builder, OrderPart orderPart) =>

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
@@ -234,6 +234,11 @@ internal static class PostgresFormattableStringBuilderExtensions
                 throw new ArgumentOutOfRangeException(nameof(labels), systemLabelId, "System label ids must be greater than zero.");
             }
 
+  if (systemLabelId > 15)                                                                                                                                                                                               
+  {
+      throw new ArgumentOutOfRangeException(nameof(labels), systemLabelId, "System label ids above 15 are not supported by the bitmask.");                                                                              
+  }   
+
             requiredMask |= (short)(1 << (systemLabelId - 1));
         }
 

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Sql/Dialog/SystemLabels/Function.BackfillDialogSystemLabelsMaskBatch.sql
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Sql/Dialog/SystemLabels/Function.BackfillDialogSystemLabelsMaskBatch.sql
@@ -1,0 +1,58 @@
+CREATE OR REPLACE FUNCTION public.backfill_dialog_system_labels_mask_batch(
+    p_last_dialog_id uuid DEFAULT NULL,
+    p_batch_size integer DEFAULT 50000
+)
+RETURNS TABLE
+(
+    "ProcessedRows" integer,
+    "LastDialogId" uuid,
+    "Completed" boolean
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_processed_rows integer := 0;
+    v_next_last_dialog_id uuid;
+BEGIN
+    IF p_batch_size <= 0 THEN
+        RAISE EXCEPTION 'p_batch_size must be > 0'
+            USING ERRCODE = '22023';
+    END IF;
+
+    WITH candidate_dialogs AS (
+        SELECT dec."DialogId" AS dialog_id
+        FROM public."DialogEndUserContext" dec
+        JOIN public."DialogEndUserContextSystemLabel" sl ON sl."DialogEndUserContextId" = dec."Id"
+        WHERE dec."DialogId" > COALESCE(p_last_dialog_id, '00000000-0000-0000-0000-000000000000'::uuid)
+        GROUP BY dec."DialogId"
+        HAVING COUNT(*) <> 1
+            OR MIN(sl."SystemLabelId") <> 1
+        ORDER BY dec."DialogId"
+        LIMIT p_batch_size
+    ),
+    computed_masks AS (
+        SELECT cd.dialog_id,
+               COALESCE(SUM(DISTINCT (1 << (sl."SystemLabelId" - 1))), 0)::smallint AS computed_system_labels_mask
+        FROM candidate_dialogs cd
+        JOIN public."DialogEndUserContext" dec ON dec."DialogId" = cd.dialog_id
+        JOIN public."DialogEndUserContextSystemLabel" sl ON sl."DialogEndUserContextId" = dec."Id"
+        GROUP BY cd.dialog_id
+    ),
+    updated_dialogs AS (
+        UPDATE public."Dialog" d
+        SET "SystemLabelsMask" = cm.computed_system_labels_mask
+        FROM computed_masks cm
+        WHERE d."Id" = cm.dialog_id
+          AND d."SystemLabelsMask" IS DISTINCT FROM cm.computed_system_labels_mask
+        RETURNING cm.dialog_id
+    )
+    SELECT COALESCE((SELECT COUNT(*) FROM candidate_dialogs), 0),
+           (SELECT dialog_id FROM candidate_dialogs ORDER BY dialog_id DESC LIMIT 1)
+    INTO v_processed_rows, v_next_last_dialog_id;
+
+    RETURN QUERY
+    SELECT v_processed_rows,
+           v_next_last_dialog_id,
+           v_processed_rows < p_batch_size;
+END;
+$$;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Sql/Dialog/SystemLabels/Function.RecomputeDialogSystemLabelsMask.sql
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Sql/Dialog/SystemLabels/Function.RecomputeDialogSystemLabelsMask.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE FUNCTION public.recompute_dialog_system_labels_mask(p_dialog_ids uuid[])
+RETURNS void
+LANGUAGE sql
+AS $$
+    WITH target_dialogs AS (
+        SELECT DISTINCT dialog_id
+        FROM unnest(p_dialog_ids) AS t(dialog_id)
+        WHERE dialog_id IS NOT NULL
+    ),
+    computed_masks AS (
+        SELECT td.dialog_id,
+               COALESCE(SUM(DISTINCT (1 << (sl."SystemLabelId" - 1))), 0)::smallint AS system_labels_mask
+        FROM target_dialogs td
+        LEFT JOIN public."DialogEndUserContext" dec ON dec."DialogId" = td.dialog_id
+        LEFT JOIN public."DialogEndUserContextSystemLabel" sl ON sl."DialogEndUserContextId" = dec."Id"
+        GROUP BY td.dialog_id
+    )
+    UPDATE public."Dialog" d
+    SET "SystemLabelsMask" = cm.system_labels_mask
+    FROM computed_masks cm
+    WHERE d."Id" = cm.dialog_id
+      AND d."SystemLabelsMask" IS DISTINCT FROM cm.system_labels_mask;
+$$;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Sql/Dialog/SystemLabels/Function.SyncDialogSystemLabelsMaskFromLabelChanges.sql
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Sql/Dialog/SystemLabels/Function.SyncDialogSystemLabelsMaskFromLabelChanges.sql
@@ -1,0 +1,83 @@
+CREATE OR REPLACE FUNCTION public.sync_dialog_system_labels_mask_from_label_changes(p_end_user_context_ids uuid[])
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_dialog_ids uuid[];
+BEGIN
+    SELECT COALESCE(array_agg(DISTINCT dec."DialogId"), ARRAY[]::uuid[])
+    INTO v_dialog_ids
+    FROM public."DialogEndUserContext" dec
+    WHERE dec."Id" = ANY(p_end_user_context_ids)
+      AND dec."DialogId" IS NOT NULL;
+
+    IF cardinality(v_dialog_ids) = 0 THEN
+        RETURN;
+    END IF;
+
+    PERFORM public.recompute_dialog_system_labels_mask(v_dialog_ids);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_dialog_system_labels_mask_from_inserted_label_rows()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_end_user_context_ids uuid[];
+BEGIN
+    SELECT COALESCE(array_agg(DISTINCT nr."DialogEndUserContextId"), ARRAY[]::uuid[])
+    INTO v_end_user_context_ids
+    FROM new_rows nr;
+
+    IF cardinality(v_end_user_context_ids) > 0 THEN
+        PERFORM public.sync_dialog_system_labels_mask_from_label_changes(v_end_user_context_ids);
+    END IF;
+
+    RETURN NULL;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_dialog_system_labels_mask_from_deleted_label_rows()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_end_user_context_ids uuid[];
+BEGIN
+    SELECT COALESCE(array_agg(DISTINCT orow."DialogEndUserContextId"), ARRAY[]::uuid[])
+    INTO v_end_user_context_ids
+    FROM old_rows orow;
+
+    IF cardinality(v_end_user_context_ids) > 0 THEN
+        PERFORM public.sync_dialog_system_labels_mask_from_label_changes(v_end_user_context_ids);
+    END IF;
+
+    RETURN NULL;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_dialog_system_labels_mask_from_updated_label_rows()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_end_user_context_ids uuid[];
+BEGIN
+    SELECT COALESCE(array_agg(DISTINCT rows."DialogEndUserContextId"), ARRAY[]::uuid[])
+    INTO v_end_user_context_ids
+    FROM (
+        SELECT nr."DialogEndUserContextId"
+        FROM new_rows nr
+        UNION
+        SELECT orow."DialogEndUserContextId"
+        FROM old_rows orow
+    ) rows;
+
+    IF cardinality(v_end_user_context_ids) > 0 THEN
+        PERFORM public.sync_dialog_system_labels_mask_from_label_changes(v_end_user_context_ids);
+    END IF;
+
+    RETURN NULL;
+END;
+$$;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Sql/Dialog/SystemLabels/Procedure.RunBackfillDialogSystemLabelsMask.sql
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Sql/Dialog/SystemLabels/Procedure.RunBackfillDialogSystemLabelsMask.sql
@@ -1,0 +1,53 @@
+CREATE OR REPLACE PROCEDURE public.run_backfill_dialog_system_labels_mask(
+    p_batch_size integer DEFAULT 50000,
+    p_start_dialog_id uuid DEFAULT NULL
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_last_dialog_id uuid := p_start_dialog_id;
+    v_batch record;
+    v_total_processed bigint := 0;
+    v_batch_number integer := 0;
+    v_started_at timestamptz := clock_timestamp();
+    v_batch_started_at timestamptz;
+BEGIN
+    IF p_batch_size <= 0 THEN
+        RAISE EXCEPTION 'p_batch_size must be > 0'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RAISE NOTICE 'Starting dialog system labels mask backfill with batch size %, start dialog id %.', p_batch_size, v_last_dialog_id;
+
+    LOOP
+        v_batch_started_at := clock_timestamp();
+
+        SELECT *
+        INTO v_batch
+        FROM public.backfill_dialog_system_labels_mask_batch(v_last_dialog_id, p_batch_size);
+
+        IF NOT FOUND OR v_batch."ProcessedRows" = 0 THEN
+            EXIT;
+        END IF;
+
+        v_batch_number := v_batch_number + 1;
+        v_total_processed := v_total_processed + v_batch."ProcessedRows";
+        v_last_dialog_id := v_batch."LastDialogId";
+
+        RAISE NOTICE 'Backfill batch % processed % dialogs, total %, last dialog id %, batch duration %.',
+            v_batch_number,
+            v_batch."ProcessedRows",
+            v_total_processed,
+            v_last_dialog_id,
+            clock_timestamp() - v_batch_started_at;
+
+        COMMIT;
+
+        EXIT WHEN v_batch."Completed";
+    END LOOP;
+
+    RAISE NOTICE 'Completed dialog system labels mask backfill. Total dialogs processed: %, total duration %.',
+        v_total_processed,
+        clock_timestamp() - v_started_at;
+END;
+$$;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Sql/Dialog/SystemLabels/Trigger.SyncDialogSystemLabelsMaskFromLabelChanges.sql
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Sql/Dialog/SystemLabels/Trigger.SyncDialogSystemLabelsMaskFromLabelChanges.sql
@@ -1,0 +1,21 @@
+DROP TRIGGER IF EXISTS "TR_DialogSystemLabelsMask_AfterInsert_Statement" ON public."DialogEndUserContextSystemLabel";
+DROP TRIGGER IF EXISTS "TR_DialogSystemLabelsMask_AfterDelete_Statement" ON public."DialogEndUserContextSystemLabel";
+DROP TRIGGER IF EXISTS "TR_DialogSystemLabelsMask_AfterUpdate_Statement" ON public."DialogEndUserContextSystemLabel";
+
+CREATE TRIGGER "TR_DialogSystemLabelsMask_AfterInsert_Statement"
+AFTER INSERT ON public."DialogEndUserContextSystemLabel"
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION public.sync_dialog_system_labels_mask_from_inserted_label_rows();
+
+CREATE TRIGGER "TR_DialogSystemLabelsMask_AfterDelete_Statement"
+AFTER DELETE ON public."DialogEndUserContextSystemLabel"
+REFERENCING OLD TABLE AS old_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION public.sync_dialog_system_labels_mask_from_deleted_label_rows();
+
+CREATE TRIGGER "TR_DialogSystemLabelsMask_AfterUpdate_Statement"
+AFTER UPDATE ON public."DialogEndUserContextSystemLabel"
+REFERENCING OLD TABLE AS old_rows NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION public.sync_dialog_system_labels_mask_from_updated_label_rows();

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/DialogApplication.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/DialogApplication.cs
@@ -148,8 +148,8 @@ public class DialogApplication : IAsyncLifetime
             .AddSingleton<ICloudEventBus, IntegrationTestCloudBus>()
             .AddScoped<IFeatureMetricServiceResourceCache, TestFeatureMetricServiceResourceCache>()
             .AddTransient<ISearchStrategySelector<EndUserSearchContext>, DialogEndUserSearchStrategySelector>()
-            .AddTransient<IQueryStrategy<EndUserSearchContext>, PartyDrivenQueryStrategy>()
             .AddTransient<IQueryStrategy<EndUserSearchContext>, ServiceDrivenQueryStrategy>()
+            .AddTransient<IQueryStrategy<EndUserSearchContext>, ServiceDrivenSystemLabelMaskQueryStrategy>()
             .AddTransient<IPartyResourceReferenceRepository, PartyResourceRepository>()
             .AddTransient<IDialogSearchRepository, DialogSearchRepository>();
     }
@@ -195,7 +195,7 @@ public class DialogApplication : IAsyncLifetime
                 {
                     UseAltinnAutoAuthorizedPartiesQueryParameters = true,
                     UseCorrectPersonNameOrdering = true,
-                    UseBranchingLogicForDialogSearch = true
+                    UseSystemLabelsMaskForEndUserDialogSearch = true
                 },
                 Dialogporten = new DialogportenSettings
                 {

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/SystemLabels/Commands/SetSystemLabelTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/SystemLabels/Commands/SetSystemLabelTests.cs
@@ -10,6 +10,7 @@ using AwesomeAssertions;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.EndUserContext.Queries.SearchLabelAssignmentLog;
 using Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.Common.Extensions;
 using Digdir.Domain.Dialogporten.Domain.Actors;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using static Digdir.Domain.Dialogporten.Application.Integration.Tests.Common.Common;
 
 namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.EndUser.SystemLabels.Commands;
@@ -17,6 +18,19 @@ namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.E
 [Collection(nameof(DialogCqrsCollectionFixture))]
 public class SetSystemLabelTests(DialogApplication application) : ApplicationCollectionFixture(application)
 {
+    [Fact]
+    public Task Create_Sets_Default_System_Labels_Mask_On_Dialog() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog()
+            .Do(async (_, ctx) =>
+            {
+                var dialogs = await Application.GetDbEntities<DialogEntity>();
+                dialogs.Should().ContainSingle(x =>
+                    x.Id == ctx.GetDialogId() &&
+                    x.SystemLabelsMask == 1);
+            })
+            .ExecuteAsync();
+
     [Fact]
     public Task Set_Updates_System_Label() =>
         FlowBuilder.For(Application)
@@ -90,6 +104,30 @@ public class SetSystemLabelTests(DialogApplication application) : ApplicationCol
 
         dialogSystemLabels.Should().NotContain(x => x.SystemLabelId == SystemLabel.Values.MarkedAsUnopened);
         dialogSystemLabels.Should().ContainSingle(x => x.SystemLabelId == SystemLabel.Values.Default);
+
+        var dialogs = await Application.GetDbEntities<DialogEntity>();
+        dialogs.Should().ContainSingle(x =>
+            x.Id == dialogId &&
+            x.SystemLabelsMask == 1);
+    }
+
+    [Fact]
+    public async Task Set_Updates_Dialog_System_Labels_Mask()
+    {
+        var dialogId = NewUuidV7();
+
+        await FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) => x.Dto.Id = dialogId)
+            .SetSystemLabelsEndUser(x =>
+                x.AddLabels = [SystemLabel.Values.MarkedAsUnopened])
+            .ExecuteAndAssert<SetSystemLabelSuccess>();
+
+        short expectedMask = 1 | (1 << ((int)SystemLabel.Values.MarkedAsUnopened - 1));
+        var dialogs = await Application.GetDbEntities<DialogEntity>();
+
+        dialogs.Should().ContainSingle(x =>
+            x.Id == dialogId &&
+            x.SystemLabelsMask == expectedMask);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

- Adds a denormalized SystemLabelsMask column on Dialog and keeps it in sync from end-user context label changes via database functions/triggers.
- Introduces a new end-user dialog search strategy that uses the mask column instead of the expensive label EXISTS join/ filter, improving performance for large parties.
- Adds backfill SQL and manual rollout scripts for schema setup, backfill, and index recreation.
- Optimizes the backfill to skip exact-default dialogs by using SystemLabelsMask = 1 as the default and selecting candidates from the label tables only.
- Updates the relevant covering index to include SystemLabelsMask.
- Simplifies end-user strategy selection by removing the old branching toggle and deleting the unused PartyDriven strategy.

## Related Issue(s)

- #3713

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 
- [x] Database changes manually applied to prod/YT01 (if relevant)
