### PR TITLE
chore(app): add diagnostic details to UnreachableException in dialog search authorization

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -455,7 +455,19 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
 
     private async Task<DialogSearchAuthorizationResult> PerformDialogSearchAuthorization(DialogSearchAuthorizationRequest request, CancellationToken cancellationToken)
     {
-        var partyIdentifier = request.Claims.GetEndUserPartyIdentifier() ?? throw new UnreachableException();
+        var partyIdentifier = request.Claims.GetEndUserPartyIdentifier();
+        if (partyIdentifier is null)
+        {
+            var (userType, externalId) = _user.GetPrincipal().GetUserType();
+            var safeExternalId = userType is DialogUserType.Values.Person
+                or DialogUserType.Values.ServiceOwnerOnBehalfOfPerson
+                or DialogUserType.Values.IdportenEmailIdentifiedUser
+                ? "<redacted>"
+                : externalId;
+            throw new UnreachableException(
+                $"GetEndUserPartyIdentifier returned null. UserType={userType}, ExternalId={safeExternalId}");
+        }
+
         var authorizedPartiesRequest = new AuthorizedPartiesRequest(
             partyIdentifier,
             includeAccessPackages: true,


### PR DESCRIPTION
## Description

Enriches the `UnreachableException` in `PerformDialogSearchAuthorization` with diagnostic details so the exception message in Application Insights reveals which code path causes `GetEndUserPartyIdentifier()` to return null.

The exception message now includes:
- `UserType` — identifies which user type triggered the null return
- `ExternalId` — included for non-sensitive types (e.g. org numbers, system user UUIDs); redacted for PII types (`Person`, `ServiceOwnerOnBehalfOfPerson`, `IdportenEmailIdentifiedUser`)

This gives us the data needed to determine the correct follow-up fix, without requiring a redeployment or config change.

## Related Issue(s)

- Related to #3626

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)