### PR TITLE
trivial(infra): validate postpone_until input in YT01 scale workflow

### DIFF
--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -306,8 +306,10 @@ jobs:
             exit 1
           fi
 
-          # Validate the date is in the future
+          # Canonicalize to UTC so relative expressions (e.g. "tomorrow") are
+          # stored as a fixed timestamp and not reinterpreted on each scheduled run.
           POSTPONE_TS=$(date -d "$POSTPONE_UNTIL" +%s)
+          POSTPONE_UNTIL=$(date -u -d "@$POSTPONE_TS" +"%Y-%m-%dT%H:%M:%SZ")
           NOW_TS=$(date +%s)
 
           if [[ "$POSTPONE_TS" -gt "$NOW_TS" ]]; then

--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -296,8 +296,18 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Validate input is a single parseable datetime
+          if [[ ${#POSTPONE_UNTIL} -gt 35 ]]; then
+            echo "Error: postpone_until looks malformed (too long). Got: $POSTPONE_UNTIL"
+            exit 1
+          fi
+          if ! date -d "$POSTPONE_UNTIL" +%s > /dev/null 2>&1; then
+            echo "Error: postpone_until is not a valid datetime. Got: $POSTPONE_UNTIL"
+            exit 1
+          fi
+
           # Validate the date is in the future
-          POSTPONE_TS=$(date -d "$POSTPONE_UNTIL" +%s 2>/dev/null || echo "0")
+          POSTPONE_TS=$(date -d "$POSTPONE_UNTIL" +%s)
           NOW_TS=$(date +%s)
 
           if [[ "$POSTPONE_TS" -gt "$NOW_TS" ]]; then


### PR DESCRIPTION
## Description

Adds input validation on the `postpone_until` field in the YT01 manual scale workflow. Previously, a malformed value (e.g. two concatenated datetimes) would silently fall through to the "date is in the past" branch because `date -d` failure was swallowed by `|| echo "0"`. Now the workflow fails early with a clear error message if the input is too long or unparseable.

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)