### PR TITLE
trivial(ci): make postpone status visible in Actions UI

### DIFF
--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -319,7 +319,7 @@ jobs:
               --body "$POSTPONE_UNTIL" \
               --env yt01 \
               --repo "$REPOSITORY"
-            PRETTY_DATE=$(date -u -d "@$POSTPONE_TS" +"%b %-d, %Y %H:%M UTC")
+            PRETTY_DATE=$(TZ=Europe/Oslo date -d "@$POSTPONE_TS" +"%b %-d, %Y %H:%M %Z")
             gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
               -f "name=Scale YT01 on (postpone until $PRETTY_DATE)"
             echo "Shutdown postponed until $POSTPONE_UNTIL"
@@ -382,7 +382,7 @@ jobs:
             --repo "$REPOSITORY" 2>/dev/null || echo "")
 
           if [[ -n "$POSTPONE_UNTIL" ]]; then
-            PRETTY_DATE=$(date -u -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M UTC" 2>/dev/null || echo "$POSTPONE_UNTIL")
+            PRETTY_DATE=$(TZ=Europe/Oslo date -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M %Z" 2>/dev/null || echo "$POSTPONE_UNTIL")
             gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
               -f "name=Scale YT01 off (cleared postpone until $PRETTY_DATE)"
             gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \

--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -365,20 +365,30 @@ jobs:
     runs-on: ubuntu-latest
     environment: yt01
     permissions:
+      actions: write
       contents: read
     steps:
       - name: Clear postpone variable
         env:
           GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
           REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         shell: bash
         run: |
           set -euo pipefail
 
-          echo "Clearing any existing postpone variable before scale-off..."
-          gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
+          POSTPONE_UNTIL=$(gh variable get YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
             --env yt01 \
-            --repo "$REPOSITORY" || true
+            --repo "$REPOSITORY" 2>/dev/null || echo "")
+
+          if [[ -n "$POSTPONE_UNTIL" ]]; then
+            PRETTY_DATE=$(date -u -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M UTC" 2>/dev/null || echo "$POSTPONE_UNTIL")
+            gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
+              -f "name=Scale YT01 off (cleared postpone until $PRETTY_DATE)"
+            gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
+              --env yt01 \
+              --repo "$REPOSITORY" || true
+          fi
 
   scale-off:
     if: inputs.state == 'off'

--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
 
-run-name: Scale YT01 ${{ inputs.state }}${{ inputs.postpone_until && format(' (postpone until {0})', inputs.postpone_until) || '' }}
+run-name: Scale YT01 ${{ inputs.state }}
 
 jobs:
   scale-on:
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: yt01
     permissions:
+      actions: write
       id-token: write
       contents: read
     steps:
@@ -291,6 +292,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
           REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
           POSTPONE_UNTIL: ${{ inputs.postpone_until }}
         shell: bash
         run: |
@@ -317,6 +319,9 @@ jobs:
               --body "$POSTPONE_UNTIL" \
               --env yt01 \
               --repo "$REPOSITORY"
+            PRETTY_DATE=$(date -u -d "@$POSTPONE_TS" +"%b %-d, %Y %H:%M UTC")
+            gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
+              -f "name=Scale YT01 on (postpone until $PRETTY_DATE)"
             echo "Shutdown postponed until $POSTPONE_UNTIL"
           else
             echo "Warning: Postpone date is in the past. Clearing any existing postpone."

--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
 
-run-name: Scale YT01 ${{ inputs.state }}
+run-name: Scale YT01 ${{ inputs.state }}${{ inputs.postpone_until && format(' (postpone until {0})', inputs.postpone_until) || '' }}
 
 jobs:
   scale-on:

--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
         default: true
       postpone_until:
-        description: "Postpone scheduled shutdown until this datetime (ISO 8601, e.g. 2026-03-01T20:00:00+01:00). Only used with 'on'."
+        description: "Postpone scheduled shutdown until this datetime in Norwegian time (e.g. 2026-03-01 20:00). Full ISO 8601 also accepted. Only used with 'on'."
         required: false
         type: string
 
@@ -303,14 +303,14 @@ jobs:
             echo "Error: postpone_until looks malformed (too long). Got: $POSTPONE_UNTIL"
             exit 1
           fi
-          if ! date -d "$POSTPONE_UNTIL" +%s > /dev/null 2>&1; then
+          if ! TZ=Europe/Oslo date -d "$POSTPONE_UNTIL" +%s > /dev/null 2>&1; then
             echo "Error: postpone_until is not a valid datetime. Got: $POSTPONE_UNTIL"
             exit 1
           fi
 
-          # Canonicalize to UTC so relative expressions (e.g. "tomorrow") are
-          # stored as a fixed timestamp and not reinterpreted on each scheduled run.
-          POSTPONE_TS=$(date -d "$POSTPONE_UNTIL" +%s)
+          # Canonicalize to UTC. Plain datetimes (without offset) are interpreted
+          # as Norwegian time (Europe/Oslo) so users don't need to think about DST.
+          POSTPONE_TS=$(TZ=Europe/Oslo date -d "$POSTPONE_UNTIL" +%s)
           POSTPONE_UNTIL=$(date -u -d "@$POSTPONE_TS" +"%Y-%m-%dT%H:%M:%SZ")
           NOW_TS=$(date +%s)
 

--- a/.github/workflows/dispatch-scale-yt01-scheduled.yml
+++ b/.github/workflows/dispatch-scale-yt01-scheduled.yml
@@ -37,7 +37,7 @@ jobs:
             if [[ "$POSTPONE_TS" -gt "$NOW_TS" ]]; then
               echo "Shutdown postponed until $POSTPONE_UNTIL. Skipping."
               echo "skip=true" >> "$GITHUB_OUTPUT"
-              PRETTY_DATE=$(date -u -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M UTC")
+              PRETTY_DATE=$(TZ=Europe/Oslo date -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M %Z")
               gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
                 -f "name=Scale YT01 Scheduled Shutdown — postponed until $PRETTY_DATE"
               exit 0

--- a/.github/workflows/dispatch-scale-yt01-scheduled.yml
+++ b/.github/workflows/dispatch-scale-yt01-scheduled.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: yt01
     permissions:
+      actions: write
       contents: read
     outputs:
       skip: ${{ steps.check-postpone.outputs.skip }}
@@ -21,6 +22,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
           REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -35,13 +37,20 @@ jobs:
             if [[ "$POSTPONE_TS" -gt "$NOW_TS" ]]; then
               echo "Shutdown postponed until $POSTPONE_UNTIL. Skipping."
               echo "skip=true" >> "$GITHUB_OUTPUT"
+              gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
+                -f "name=Scale YT01 Scheduled Shutdown — postponed until $POSTPONE_UNTIL"
               exit 0
             else
               echo "Postpone date $POSTPONE_UNTIL is in the past. Clearing variable."
               gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
                 --env yt01 \
                 --repo "$REPOSITORY" || true
+              gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
+                -f "name=Scale YT01 Scheduled Shutdown — cleared expired postpone, shutting down"
             fi
+          else
+            gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
+              -f "name=Scale YT01 Scheduled Shutdown — shutting down"
           fi
 
           echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dispatch-scale-yt01-scheduled.yml
+++ b/.github/workflows/dispatch-scale-yt01-scheduled.yml
@@ -37,8 +37,9 @@ jobs:
             if [[ "$POSTPONE_TS" -gt "$NOW_TS" ]]; then
               echo "Shutdown postponed until $POSTPONE_UNTIL. Skipping."
               echo "skip=true" >> "$GITHUB_OUTPUT"
+              PRETTY_DATE=$(date -u -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M UTC")
               gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
-                -f "name=Scale YT01 Scheduled Shutdown — postponed until $POSTPONE_UNTIL"
+                -f "name=Scale YT01 Scheduled Shutdown — postponed until $PRETTY_DATE"
               exit 0
             else
               echo "Postpone date $POSTPONE_UNTIL is in the past. Clearing variable."

--- a/docs/YT01-Scaling.md
+++ b/docs/YT01-Scaling.md
@@ -5,7 +5,7 @@ The YT01 environment is scaled down outside working hours to save costs. A set o
 ## TL;DR
 
 1. Scale the environment on using the [manual scaling workflow](https://github.com/Altinn/dialogporten/actions/workflows/dispatch-scale-yt01-manual.yml) with `state: on`
-2. If you need the environment beyond 16:00 UTC, set `postpone_until` to a later date/time
+2. If you need the environment beyond 18:00 CEST / 17:00 CET, set `postpone_until` to a later time (e.g. `2026-04-10 20:00`)
 3. When you're done, scale the environment off using the manual workflow with `state: off` to keep costs low
 
 ## Scaling On
@@ -18,7 +18,7 @@ Inputs:
 |-------|----------|---------|-------------|
 | `state` | Yes | — | Set to `on` |
 | `deploy` | No | `true` | If a newer release exists, deploy it automatically |
-| `postpone_until` | No | — | ISO 8601 datetime to postpone the scheduled shutdown until (e.g. `2026-03-01T20:00:00+01:00`) |
+| `postpone_until` | No | — | Datetime to postpone the scheduled shutdown until, in Norwegian time (e.g. `2026-03-01 20:00`). Full ISO 8601 also accepted. |
 
 What happens when scaling on:
 1. Workload profile nodes are scaled up
@@ -49,7 +49,7 @@ The scheduled workflow cannot be triggered manually. This is by design — manua
 
 Postponing prevents the scheduled shutdown from running until a given time. Key points:
 
-- Set via the `postpone_until` input when scaling on (e.g. if you need the environment to stay up past 16:00 UTC)
+- Set via the `postpone_until` input when scaling on (e.g. if you need the environment to stay up past 18:00 CEST / 17:00 CET)
 - **Can be set even when the environment is already running** — it just sets a future timestamp that the scheduled shutdown checks
 - The timestamp is stored as a GitHub environment variable (`YT01_DB_SHUTDOWN_POSTPONE_UNTIL`). You can check if a postpone is currently set and its value at [Settings > Variables > Actions](https://github.com/Altinn/dialogporten/settings/variables/actions)
 - The scheduled workflow checks this variable each day. If the timestamp is in the future, shutdown is skipped
@@ -58,9 +58,10 @@ Postponing prevents the scheduled shutdown from running until a given time. Key 
 
 ### Examples
 
-Keep the environment running until 20:00 CEST tonight:
-- Run the manual workflow with `state: on` and `postpone_until: 2026-04-08T20:00:00+02:00`
+Keep the environment running until 20:00 tonight:
+- Run the manual workflow with `state: on` and `postpone_until: 2026-04-08 20:00`
 - Or, if the environment is already running, just run it with `state: on` and the `postpone_until` value — the scale-on is idempotent
+- The time is interpreted as Norwegian time (CET/CEST), so no need to think about UTC offsets
 
 Immediately shut down regardless of any postpone:
 - Run the manual workflow with `state: off` — this clears the postpone first


### PR DESCRIPTION
## Description

Makes the postpone status visible in the GitHub Actions run list so you can tell at a glance whether a postpone is active, was cleared, or the environment is just shutting down normally.

Changes:
- **Manual workflow**: Renames the run via GitHub API to show the postpone date when scaling on with a postpone, and shows the cleared postpone date when manually scaling off while a postpone was active.
- **Scheduled workflow**: Renames the run after determining the outcome — "postponed until ...", "cleared expired postpone, shutting down", or just "shutting down".
- **Date input**: Accepts plain datetimes in Norwegian time (e.g. `2026-04-10 20:00`) so users don't need to think about UTC offsets or DST. Full ISO 8601 still works.
- **Date display**: All dates in run names are shown in Norwegian time (CET/CEST).
- **Docs**: Updated `docs/YT01-Scaling.md` to reflect the simpler input format and Norwegian time references.

## Related Issue(s)

N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [x] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)