### PR TITLE
trivial(ci): use GITHUB_TOKEN for run-rename API calls

### DIFF
--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -291,6 +291,7 @@ jobs:
         if: inputs.postpone_until != ''
         env:
           GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           POSTPONE_UNTIL: ${{ inputs.postpone_until }}
@@ -320,7 +321,7 @@ jobs:
               --env yt01 \
               --repo "$REPOSITORY"
             PRETTY_DATE=$(TZ=Europe/Oslo date -d "@$POSTPONE_TS" +"%b %-d, %Y %H:%M %Z")
-            gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
+            GH_TOKEN="$GITHUB_TOKEN" gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
               -f "name=Scale YT01 on (postpone until $PRETTY_DATE)"
             echo "Shutdown postponed until $POSTPONE_UNTIL"
           else
@@ -371,6 +372,7 @@ jobs:
       - name: Clear postpone variable
         env:
           GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         shell: bash
@@ -383,7 +385,7 @@ jobs:
 
           if [[ -n "$POSTPONE_UNTIL" ]]; then
             PRETTY_DATE=$(TZ=Europe/Oslo date -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M %Z" 2>/dev/null || echo "$POSTPONE_UNTIL")
-            gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
+            GH_TOKEN="$GITHUB_TOKEN" gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
               -f "name=Scale YT01 off (cleared postpone until $PRETTY_DATE)"
             gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
               --env yt01 \

--- a/.github/workflows/dispatch-scale-yt01-scheduled.yml
+++ b/.github/workflows/dispatch-scale-yt01-scheduled.yml
@@ -21,6 +21,7 @@ jobs:
         id: check-postpone
         env:
           GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
@@ -38,7 +39,7 @@ jobs:
               echo "Shutdown postponed until $POSTPONE_UNTIL. Skipping."
               echo "skip=true" >> "$GITHUB_OUTPUT"
               PRETTY_DATE=$(TZ=Europe/Oslo date -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M %Z")
-              gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
+              GH_TOKEN="$GITHUB_TOKEN" gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
                 -f "name=Scale YT01 Scheduled Shutdown — postponed until $PRETTY_DATE"
               exit 0
             else
@@ -46,11 +47,11 @@ jobs:
               gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
                 --env yt01 \
                 --repo "$REPOSITORY" || true
-              gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
+              GH_TOKEN="$GITHUB_TOKEN" gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
                 -f "name=Scale YT01 Scheduled Shutdown — cleared expired postpone, shutting down"
             fi
           else
-            gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
+            GH_TOKEN="$GITHUB_TOKEN" gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
               -f "name=Scale YT01 Scheduled Shutdown — shutting down"
           fi
 


### PR DESCRIPTION
## Summary
- The `gh api` calls to rename workflow runs fail with HTTP 404 because `GH_TOKEN` is set to `RELEASE_VERSION_STORAGE_PAT`, which overrides the default token. The Actions API run-rename endpoint requires the workflow's `GITHUB_TOKEN` with `actions: write` permission.
- Adds `GITHUB_TOKEN: ${{ github.token }}` to the env blocks and prefixes each `gh api` call with `GH_TOKEN="$GITHUB_TOKEN"` to override the PAT for just that command.
- Affects 5 `gh api` calls total: 2 in the manual workflow, 3 in the scheduled workflow.

## Test plan
- [ ] Trigger the manual workflow with `state: on` and a `postpone_until` value — confirm the run name updates without a 404 error