### PR TITLE
trivial(ci): replace broken gh api run-rename calls with GITHUB_STEP_SUMMARY

### DIFF
--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: yt01
     permissions:
-      actions: write
       id-token: write
       contents: read
     steps:
@@ -291,9 +290,7 @@ jobs:
         if: inputs.postpone_until != ''
         env:
           GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
-          GITHUB_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
           POSTPONE_UNTIL: ${{ inputs.postpone_until }}
         shell: bash
         run: |
@@ -321,8 +318,7 @@ jobs:
               --env yt01 \
               --repo "$REPOSITORY"
             PRETTY_DATE=$(TZ=Europe/Oslo date -d "@$POSTPONE_TS" +"%b %-d, %Y %H:%M %Z")
-            GH_TOKEN="$GITHUB_TOKEN" gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
-              -f "name=Scale YT01 on (postpone until $PRETTY_DATE)"
+            echo "## Shutdown postponed until $PRETTY_DATE" >> "$GITHUB_STEP_SUMMARY"
             echo "Shutdown postponed until $POSTPONE_UNTIL"
           else
             echo "Warning: Postpone date is in the past. Clearing any existing postpone."
@@ -366,15 +362,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: yt01
     permissions:
-      actions: write
       contents: read
     steps:
       - name: Clear postpone variable
         env:
           GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
-          GITHUB_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
         shell: bash
         run: |
           set -euo pipefail
@@ -385,8 +378,7 @@ jobs:
 
           if [[ -n "$POSTPONE_UNTIL" ]]; then
             PRETTY_DATE=$(TZ=Europe/Oslo date -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M %Z" 2>/dev/null || echo "$POSTPONE_UNTIL")
-            GH_TOKEN="$GITHUB_TOKEN" gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
-              -f "name=Scale YT01 off (cleared postpone until $PRETTY_DATE)"
+            echo "## Cleared postpone (was until $PRETTY_DATE)" >> "$GITHUB_STEP_SUMMARY"
             gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
               --env yt01 \
               --repo "$REPOSITORY" || true

--- a/.github/workflows/dispatch-scale-yt01-scheduled.yml
+++ b/.github/workflows/dispatch-scale-yt01-scheduled.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: yt01
     permissions:
-      actions: write
       contents: read
     outputs:
       skip: ${{ steps.check-postpone.outputs.skip }}
@@ -21,9 +20,7 @@ jobs:
         id: check-postpone
         env:
           GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
-          GITHUB_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -39,20 +36,17 @@ jobs:
               echo "Shutdown postponed until $POSTPONE_UNTIL. Skipping."
               echo "skip=true" >> "$GITHUB_OUTPUT"
               PRETTY_DATE=$(TZ=Europe/Oslo date -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M %Z")
-              GH_TOKEN="$GITHUB_TOKEN" gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
-                -f "name=Scale YT01 Scheduled Shutdown — postponed until $PRETTY_DATE"
+              echo "## Shutdown postponed until $PRETTY_DATE" >> "$GITHUB_STEP_SUMMARY"
               exit 0
             else
               echo "Postpone date $POSTPONE_UNTIL is in the past. Clearing variable."
               gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
                 --env yt01 \
                 --repo "$REPOSITORY" || true
-              GH_TOKEN="$GITHUB_TOKEN" gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
-                -f "name=Scale YT01 Scheduled Shutdown — cleared expired postpone, shutting down"
+              echo "## Cleared expired postpone, shutting down" >> "$GITHUB_STEP_SUMMARY"
             fi
           else
-            GH_TOKEN="$GITHUB_TOKEN" gh api --method PATCH "/repos/$REPOSITORY/actions/runs/$RUN_ID" \
-              -f "name=Scale YT01 Scheduled Shutdown — shutting down"
+            echo "## Shutting down" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

The `gh api --method PATCH /repos/.../actions/runs/{id}` calls added in #3760 to rename workflow runs do not work — this endpoint does not exist in the GitHub REST API, causing 404 errors. This replaces all five `gh api` run-rename calls in the YT01 scale workflows with `$GITHUB_STEP_SUMMARY` writes, which display postpone status on the run's Summary tab instead. Also removes the now-unnecessary `actions: write` permissions and `GITHUB_TOKEN`/`RUN_ID` env vars.

## Related Issue(s)

- #3760

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)