### PR TITLE
trivial(ci): add consistent postpone state summaries

### DIFF
--- a/.github/workflows/dispatch-scale-yt01-manual.yml
+++ b/.github/workflows/dispatch-scale-yt01-manual.yml
@@ -317,14 +317,21 @@ jobs:
               --body "$POSTPONE_UNTIL" \
               --env yt01 \
               --repo "$REPOSITORY"
-            PRETTY_DATE=$(TZ=Europe/Oslo date -d "@$POSTPONE_TS" +"%b %-d, %Y %H:%M %Z")
-            echo "## Shutdown postponed until $PRETTY_DATE" >> "$GITHUB_STEP_SUMMARY"
             echo "Shutdown postponed until $POSTPONE_UNTIL"
           else
             echo "Warning: Postpone date is in the past. Clearing any existing postpone."
             gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
               --env yt01 \
               --repo "$REPOSITORY" || true
+          fi
+
+          CURRENT=$(gh variable get YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
+            --env yt01 --repo "$REPOSITORY" 2>/dev/null || echo "")
+          if [[ -n "$CURRENT" ]]; then
+            PRETTY=$(TZ=Europe/Oslo date -d "$CURRENT" +"%b %-d, %Y %H:%M %Z" 2>/dev/null || echo "$CURRENT")
+            echo "## Postpone active until $PRETTY" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## No postpone set" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Clear stale postpone variable
@@ -353,6 +360,15 @@ jobs:
             fi
           fi
 
+          CURRENT=$(gh variable get YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
+            --env yt01 --repo "$REPOSITORY" 2>/dev/null || echo "")
+          if [[ -n "$CURRENT" ]]; then
+            PRETTY=$(TZ=Europe/Oslo date -d "$CURRENT" +"%b %-d, %Y %H:%M %Z" 2>/dev/null || echo "$CURRENT")
+            echo "## Postpone active until $PRETTY" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## No postpone set" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Logout from Azure
         if: ${{ always() }}
         run: az logout
@@ -377,11 +393,18 @@ jobs:
             --repo "$REPOSITORY" 2>/dev/null || echo "")
 
           if [[ -n "$POSTPONE_UNTIL" ]]; then
-            PRETTY_DATE=$(TZ=Europe/Oslo date -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M %Z" 2>/dev/null || echo "$POSTPONE_UNTIL")
-            echo "## Cleared postpone (was until $PRETTY_DATE)" >> "$GITHUB_STEP_SUMMARY"
             gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
               --env yt01 \
               --repo "$REPOSITORY" || true
+          fi
+
+          CURRENT=$(gh variable get YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
+            --env yt01 --repo "$REPOSITORY" 2>/dev/null || echo "")
+          if [[ -n "$CURRENT" ]]; then
+            PRETTY=$(TZ=Europe/Oslo date -d "$CURRENT" +"%b %-d, %Y %H:%M %Z" 2>/dev/null || echo "$CURRENT")
+            echo "## Postpone active until $PRETTY" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## No postpone set" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   scale-off:

--- a/.github/workflows/dispatch-scale-yt01-scheduled.yml
+++ b/.github/workflows/dispatch-scale-yt01-scheduled.yml
@@ -34,19 +34,31 @@ jobs:
 
             if [[ "$POSTPONE_TS" -gt "$NOW_TS" ]]; then
               echo "Shutdown postponed until $POSTPONE_UNTIL. Skipping."
+              CURRENT=$(gh variable get YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
+                --env yt01 --repo "$REPOSITORY" 2>/dev/null || echo "")
+              if [[ -n "$CURRENT" ]]; then
+                PRETTY=$(TZ=Europe/Oslo date -d "$CURRENT" +"%b %-d, %Y %H:%M %Z" 2>/dev/null || echo "$CURRENT")
+                echo "## Postpone active until $PRETTY" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "## No postpone set" >> "$GITHUB_STEP_SUMMARY"
+              fi
               echo "skip=true" >> "$GITHUB_OUTPUT"
-              PRETTY_DATE=$(TZ=Europe/Oslo date -d "$POSTPONE_UNTIL" +"%b %-d, %Y %H:%M %Z")
-              echo "## Shutdown postponed until $PRETTY_DATE" >> "$GITHUB_STEP_SUMMARY"
               exit 0
             else
               echo "Postpone date $POSTPONE_UNTIL is in the past. Clearing variable."
               gh variable delete YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
                 --env yt01 \
                 --repo "$REPOSITORY" || true
-              echo "## Cleared expired postpone, shutting down" >> "$GITHUB_STEP_SUMMARY"
             fi
+          fi
+
+          CURRENT=$(gh variable get YT01_DB_SHUTDOWN_POSTPONE_UNTIL \
+            --env yt01 --repo "$REPOSITORY" 2>/dev/null || echo "")
+          if [[ -n "$CURRENT" ]]; then
+            PRETTY=$(TZ=Europe/Oslo date -d "$CURRENT" +"%b %-d, %Y %H:%M %Z" 2>/dev/null || echo "$CURRENT")
+            echo "## Postpone active until $PRETTY" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "## Shutting down" >> "$GITHUB_STEP_SUMMARY"
+            echo "## No postpone set" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/docs/YT01-Scaling.md
+++ b/docs/YT01-Scaling.md
@@ -55,6 +55,7 @@ Postponing prevents the scheduled shutdown from running until a given time. Key 
 - The scheduled workflow checks this variable each day. If the timestamp is in the future, shutdown is skipped
 - The scheduled shutdown only runs once per day (at 16:00 UTC), so a postpone that extends past that time will keep the environment running for an additional 24 hours until the next scheduled run
 - Stale (past-dated) postpone values are automatically cleaned up by both the manual and scheduled workflows
+- Every run of both workflows shows the current postpone state on the **Summary tab** — check the latest run of either workflow to see whether a postpone is active
 
 ### Examples
 

--- a/docs/YT01-Scaling.md
+++ b/docs/YT01-Scaling.md
@@ -64,6 +64,9 @@ Keep the environment running until 20:00 tonight:
 - Or, if the environment is already running, just run it with `state: on` and the `postpone_until` value — the scale-on is idempotent
 - The time is interpreted as Norwegian time (CET/CEST), so no need to think about UTC offsets
 
+Clear an active postpone without scaling off:
+- Run the manual workflow with `state: on` and `postpone_until` set to a time in the past (e.g. `2020-01-01 00:00`) — this clears the variable, and the next scheduled shutdown will proceed normally
+
 Immediately shut down regardless of any postpone:
 - Run the manual workflow with `state: off` — this clears the postpone first
 

--- a/docs/YT01-Scaling.md
+++ b/docs/YT01-Scaling.md
@@ -51,11 +51,11 @@ Postponing prevents the scheduled shutdown from running until a given time. Key 
 
 - Set via the `postpone_until` input when scaling on (e.g. if you need the environment to stay up past 18:00 CEST / 17:00 CET)
 - **Can be set even when the environment is already running** — it just sets a future timestamp that the scheduled shutdown checks
-- The timestamp is stored as a GitHub environment variable (`YT01_DB_SHUTDOWN_POSTPONE_UNTIL`). You can check if a postpone is currently set and its value at [Settings > Variables > Actions](https://github.com/Altinn/dialogporten/settings/variables/actions)
+- The timestamp is stored as a GitHub environment variable (`YT01_DB_SHUTDOWN_POSTPONE_UNTIL`). You can also check the raw value at [Settings > Variables > Actions](https://github.com/Altinn/dialogporten/settings/variables/actions), but this requires elevated permissions (likely admin)
+- Every run of both workflows shows the current postpone state on the **Summary tab** — check the latest run of either workflow to see whether a postpone is active
 - The scheduled workflow checks this variable each day. If the timestamp is in the future, shutdown is skipped
 - The scheduled shutdown only runs once per day (at 16:00 UTC), so a postpone that extends past that time will keep the environment running for an additional 24 hours until the next scheduled run
 - Stale (past-dated) postpone values are automatically cleaned up by both the manual and scheduled workflows
-- Every run of both workflows shows the current postpone state on the **Summary tab** — check the latest run of either workflow to see whether a postpone is active
 
 ### Examples
 


### PR DESCRIPTION
## Description

Replace per-branch `$GITHUB_STEP_SUMMARY` writes in the YT01 scale workflows with a single consistent block that reads `YT01_DB_SHUTDOWN_POSTPONE_UNTIL` after all logic runs and reports its current state. Every run of either the manual or scheduled workflow now shows "Postpone active until ..." or "No postpone set" on the Summary tab, regardless of which code path was taken.

Also updates `docs/YT01-Scaling.md` to document the Summary tab as the easy way to check postpone state (vs the GH variable UI which requires admin), and adds an example for clearing a postpone by setting a past date.

## Related Issue(s)

- Related to #3765

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [x] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)