### PR TITLE
feat(adapter): loosen date validations for admin

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDtoValidator.cs
@@ -18,6 +18,7 @@ internal sealed class CreateDialogDtoValidator : AbstractValidator<CreateDialogD
         IValidator<SearchTagDto> searchTagValidator,
         IValidator<ContentDto?> contentValidator,
         IValidator<DialogServiceOwnerContextDto?> serviceOwnerContextValidator,
+        IUserResourceRegistry userResourceRegistry,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -76,7 +77,8 @@ internal sealed class CreateDialogDtoValidator : AbstractValidator<CreateDialogD
         RuleFor(x => x.DueAt)
             .GreaterThanOrEqualTo(x => x.VisibleFrom)
             .WithMessage(FluentValidationDateTimeOffsetExtensions.InFutureOfMessage)
-            .When(x => x.VisibleFrom.HasValue, ApplyConditionTo.CurrentValidator);
+            .When(x => x.VisibleFrom.HasValue && !userResourceRegistry.IsCurrentUserServiceOwnerAdmin(),
+                ApplyConditionTo.CurrentValidator);
 
 
         RuleFor(x => x.Status)

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDtoValidator.cs
@@ -77,6 +77,8 @@ internal sealed class CreateDialogDtoValidator : AbstractValidator<CreateDialogD
         RuleFor(x => x.DueAt)
             .GreaterThanOrEqualTo(x => x.VisibleFrom)
             .WithMessage(FluentValidationDateTimeOffsetExtensions.InFutureOfMessage)
+            // Due to Altinn apps/storage not having any restrictions on this, we need to
+            // drop this validation for admin-users (ie. the private API used by the adapter)
             .When(x => x.VisibleFrom.HasValue && !userResourceRegistry.IsCurrentUserServiceOwnerAdmin(),
                 ApplyConditionTo.CurrentValidator);
 

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDtoValidator.cs
@@ -1,3 +1,4 @@
+using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.Enumerables;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get;
@@ -16,7 +17,8 @@ internal sealed class UpdateDialogDtoValidator : AbstractValidator<UpdateDialogD
         IValidator<ApiActionDto> apiActionValidator,
         IValidator<ActivityDto> activityValidator,
         IValidator<SearchTagDto> searchTagValidator,
-        IValidator<ContentDto?> contentValidator)
+        IValidator<ContentDto?> contentValidator,
+        IUserResourceRegistry userResourceRegistry)
     {
         RuleFor(x => x.Progress)
             .InclusiveBetween(0, 100);
@@ -67,7 +69,8 @@ internal sealed class UpdateDialogDtoValidator : AbstractValidator<UpdateDialogD
                 return visibleFrom is null || dueAt is null || dueAt >= visibleFrom;
             })
             .WithMessage(visibleFromErrorMessage)
-            .When(DialogHasVisibleFrom);
+            .When((_, context) => DialogHasVisibleFrom(context) &&
+                                  !userResourceRegistry.IsCurrentUserServiceOwnerAdmin());
 
         RuleFor(x => x.ExpiresAt)
             .Must((_, expiresAt, context) =>
@@ -76,7 +79,7 @@ internal sealed class UpdateDialogDtoValidator : AbstractValidator<UpdateDialogD
                 return visibleFrom is null || expiresAt is null || expiresAt >= visibleFrom;
             })
             .WithMessage(visibleFromErrorMessage)
-            .When(DialogHasVisibleFrom);
+            .When((_, context) => DialogHasVisibleFrom(context));
 
         RuleForEach(x => x.Transmissions)
             .SetValidator(transmissionValidator);
@@ -134,7 +137,7 @@ internal sealed class UpdateDialogDtoValidator : AbstractValidator<UpdateDialogD
             .MaximumLength(Constants.DefaultMaxUriLength)
             .When(x => x.PrecedingProcess is not null);
     }
-    private static bool DialogHasVisibleFrom<T>(T _, IValidationContext context) =>
+    private static bool DialogHasVisibleFrom(IValidationContext context) =>
         GetVisibleFrom(context).HasValue;
 
     private static DateTimeOffset? GetVisibleFrom(IValidationContext context) =>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDtoValidator.cs
@@ -69,6 +69,8 @@ internal sealed class UpdateDialogDtoValidator : AbstractValidator<UpdateDialogD
                 return visibleFrom is null || dueAt is null || dueAt >= visibleFrom;
             })
             .WithMessage(visibleFromErrorMessage)
+            // Due to Altinn apps/storage not having any restrictions on this, we need to
+            // drop this validation for admin-users (ie. the private API used by the adapter)
             .When((_, context) => DialogHasVisibleFrom(context) &&
                                   !userResourceRegistry.IsCurrentUserServiceOwnerAdmin());
 

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogTests.cs
@@ -194,6 +194,55 @@ public class CreateDialogTests : ApplicationCollectionFixture
     }
 
     [Fact]
+    public Task Cannot_Create_DueAt_Before_VisibleFrom_Without_Admin_Scope()
+    {
+        var visibleFrom = DateTimeOffset.UtcNow.AddDays(10);
+
+        return FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.VisibleFrom = visibleFrom;
+                x.Dto.DueAt = visibleFrom.AddDays(-1);
+                x.Dto.ExpiresAt = visibleFrom.AddDays(1);
+            })
+            .ExecuteAndAssert<ValidationError>(error =>
+                error.ShouldHaveErrorWithText(nameof(CreateDialogDto.DueAt)));
+    }
+
+    [Fact]
+    public Task Cannot_Create_DueAt_Before_VisibleFrom_When_Silent_Update_Without_Admin_Scope()
+    {
+        var visibleFrom = DateTimeOffset.UtcNow.AddDays(10);
+
+        return FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.IsSilentUpdate = true;
+                x.Dto.VisibleFrom = visibleFrom;
+                x.Dto.DueAt = visibleFrom.AddDays(-1);
+                x.Dto.ExpiresAt = visibleFrom.AddDays(1);
+            })
+            .ExecuteAndAssert<ValidationError>(error =>
+                error.ShouldHaveErrorWithText(nameof(CreateDialogDto.DueAt)));
+    }
+
+    [Fact]
+    public Task Can_Create_DueAt_Before_VisibleFrom_When_Admin_Scope()
+    {
+        var visibleFrom = DateTimeOffset.UtcNow.AddDays(10);
+
+        return FlowBuilder.For(Application)
+            .AsAdminUser()
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.VisibleFrom = visibleFrom;
+                x.Dto.DueAt = visibleFrom.AddDays(-1);
+                x.Dto.ExpiresAt = visibleFrom.AddDays(1);
+            })
+            .ExecuteAndAssert<CreateDialogSuccess>();
+    }
+
+    [Fact]
     public Task Can_Create_Dialog_With_Empty_Content_Summary() =>
         FlowBuilder.For(Application)
             .CreateSimpleDialog((x, _) => x.Dto.Content!.Summary = null)

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogTests.cs
@@ -610,6 +610,44 @@ public class UpdateDialogTests(DialogApplication application) : ApplicationColle
     }
 
     [Fact]
+    public Task Cannot_Set_DueAt_Before_Saved_VisibleFrom_When_Silent_Update_Without_Admin_Scope()
+    {
+        var visibleFrom = DateTimeOffset.UtcNow.AddDays(10);
+
+        return FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.VisibleFrom = visibleFrom;
+                x.Dto.DueAt = visibleFrom.AddDays(1);
+                x.Dto.ExpiresAt = visibleFrom.AddDays(2);
+            })
+            .UpdateDialog(x =>
+            {
+                x.IsSilentUpdate = true;
+                x.Dto.DueAt = visibleFrom.AddDays(-1);
+            })
+            .ExecuteAndAssert<ValidationError>(error =>
+                error.ShouldHaveErrorWithText(nameof(UpdateDialogDto.DueAt)));
+    }
+
+    [Fact]
+    public Task Can_Set_DueAt_Before_Saved_VisibleFrom_When_Admin_Scope()
+    {
+        var visibleFrom = DateTimeOffset.UtcNow.AddDays(10);
+
+        return FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.VisibleFrom = visibleFrom;
+                x.Dto.DueAt = visibleFrom.AddDays(1);
+                x.Dto.ExpiresAt = visibleFrom.AddDays(2);
+            })
+            .AsAdminUser()
+            .UpdateDialog(x => x.Dto.DueAt = visibleFrom.AddDays(-1))
+            .ExecuteAndAssert<UpdateDialogSuccess>();
+    }
+
+    [Fact]
     public Task Cannot_Set_ExpiresAt_Before_Saved_VisibleFrom()
     {
         var visibleFrom = DateTimeOffset.UtcNow.AddDays(5);


### PR DESCRIPTION
## Description

This loosens the validator for DueAt/VisibleFrom adapter/admin-users to allow for app instances where this restriction does not exist

## Related Issue(s)

- #3776 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 
