### PR TITLE
fix: make metrics pipeline tolerate non-HTTP/background commands

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Behaviours/FeatureMetric/FeatureMetricBehaviour.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Behaviours/FeatureMetric/FeatureMetricBehaviour.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
 using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
@@ -35,10 +37,12 @@ internal sealed class FeatureMetricBehaviour<TRequest, TResponse> : IPipelineBeh
         RequestHandlerDelegate<TResponse> next,
         CancellationToken cancellationToken)
     {
-        var principal = _user.GetPrincipal();
-        principal.TryGetConsumerOrgNumber(out var callerOrgNr);
+        var callerOrgNr = TryGetPrincipal(out var principal)
+                          && principal.TryGetConsumerOrgNumber(out var orgNumber)
+            ? orgNumber
+            : null;
 
-        var hasAdminScope = principal.HasScope(AuthorizationScope.ServiceOwnerAdminScope);
+        var hasAdminScope = principal?.HasScope(AuthorizationScope.ServiceOwnerAdminScope) ?? false;
         var resource = await _featureMetricServiceResourceResolver.Resolve(request, cancellationToken);
 
         _featureMetricRecorder.Record(new(
@@ -50,5 +54,19 @@ internal sealed class FeatureMetricBehaviour<TRequest, TResponse> : IPipelineBeh
             ServiceResource: resource?.ResourceId));
 
         return await next(cancellationToken);
+    }
+
+    private bool TryGetPrincipal([NotNullWhen(true)] out ClaimsPrincipal? principal)
+    {
+        try
+        {
+            principal = _user.GetPrincipal();
+        }
+        catch (InvalidOperationException)
+        {
+            principal = null;
+            return false;
+        }
+        return true;
     }
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Behaviours/FeatureMetricBehaviourTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Behaviours/FeatureMetricBehaviourTests.cs
@@ -1,4 +1,5 @@
 using Digdir.Domain.Dialogporten.Application.Common.Behaviours.FeatureMetric;
+using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Create;
@@ -8,6 +9,8 @@ using Digdir.Library.Entity.Abstractions.Features.Identifiable;
 using AwesomeAssertions;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
 
 namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.Common.Behaviours;
 
@@ -141,4 +144,31 @@ public class FeatureMetricBehaviourTests : ApplicationCollectionFixture
         getDialogMetrics.Should().HaveCount(2);
     }
 
+    [Fact]
+    public async Task FeatureMetric_Should_Not_Throw_When_User_Principal_Is_Missing()
+    {
+        var user = Substitute.For<IUser>();
+        user.GetPrincipal().Returns(_ => throw new InvalidOperationException("No user principal found"));
+        var recorder = new FeatureMetricRecorder();
+        var resolver = new FeatureMetricServiceResourceIgnoreRequestResolver();
+        var hostEnvironment = Substitute.For<IHostEnvironment>();
+        hostEnvironment.EnvironmentName.Returns("Development");
+        var behaviour = new FeatureMetricBehaviour<FeatureMetricNoPrincipalRequest, Unit>(
+            user,
+            recorder,
+            resolver,
+            hostEnvironment);
+
+        await behaviour.Handle(
+            new FeatureMetricNoPrincipalRequest(),
+            _ => Task.FromResult(Unit.Value),
+            TestContext.Current.CancellationToken);
+
+        var metric = recorder.Records.Should().ContainSingle().Subject;
+        metric.FeatureName.Should().Be(typeof(FeatureMetricNoPrincipalRequest).FullName);
+        metric.HasAdminScope.Should().BeFalse();
+        metric.CallerOrg.Should().Be("unknown");
+    }
+
+    private sealed record FeatureMetricNoPrincipalRequest : IRequest<Unit>, IFeatureMetricServiceResourceIgnoreRequest;
 }


### PR DESCRIPTION
## Description
FeatureMetric should not throw when user principal is missing 

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/3784

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 