### PR TITLE
chore: improve health endpoint

### DIFF
--- a/docs/HealthCheck.md
+++ b/docs/HealthCheck.md
@@ -1,0 +1,147 @@
+# Health Checks
+
+Dialogporten exposes ASP.NET Core health checks through the shared `Digdir.Library.Utils.AspNet` health-check setup. The implementation separates local process liveness, Kubernetes readiness, infrastructure dependencies, and deeper external dependency checks.
+
+Health check responses use the HealthChecks UI JSON response writer. By default, ASP.NET Core returns HTTP 200 for `Healthy` and `Degraded`, and HTTP 503 for `Unhealthy`.
+
+## Endpoints
+
+| Endpoint | Included tags | Purpose |
+| --- | --- | --- |
+| `/health/liveness` | `self` | Process liveness only. This should not include external dependencies. |
+| `/health/readiness` | `critical` | Kubernetes readiness. A failing check here should mean the pod should stop receiving traffic. |
+| `/health/startup` | `dependencies` | Dependency startup visibility. |
+| `/health` | `dependencies` | Standard dependency health endpoint. |
+| `/health/deep` | `dependencies`, `external` | Dependency health plus configured outbound HTTP endpoint checks. |
+
+## Registered Checks
+
+### Self
+
+The `self` check always returns `Healthy`. It is used only by `/health/liveness`.
+
+### PostgreSQL
+
+PostgreSQL is registered through `AddDbContextCheck<DialogDbContext>("postgres", tags: ["dependencies", "critical"])`.
+
+It is the only `critical` infrastructure dependency today, so it is included in `/health/readiness`. PostgreSQL failures make readiness `Unhealthy`, which is appropriate because the application cannot serve normal requests or preserve outbox messages without PostgreSQL.
+
+### Redis
+
+Redis is implemented by `RedisHealthCheck` and registered as `redis` with the `dependencies` tag.
+
+The check creates a Redis connection and runs `PING`.
+
+| Condition | Result |
+| --- | --- |
+| Ping succeeds within 5 seconds | `Healthy` |
+| Ping succeeds but takes more than 5 seconds | `Degraded` |
+| Redis timeout | `Degraded` |
+| Redis connection failure | `Degraded` |
+| Unexpected exception | `Degraded` |
+
+Redis is not tagged `critical`, so Redis problems do not affect `/health/readiness`.
+
+### Azure Service Bus
+
+Azure Service Bus is implemented by `ServiceBusHealthCheck` and registered as `servicebus` with the `dependencies` tag. It is only registered in applications that enable MassTransit publish or publish/subscribe capabilities.
+
+The check does not use the Azure SDK directly. It wraps MassTransit's built-in health check through ASP.NET Core's generic `HealthCheckService`.
+
+There are two related checks in the container:
+
+| Check | Public endpoint visibility | Purpose |
+| --- | --- | --- |
+| `masstransit-servicebus` | Not selected by public health endpoints | Internal MassTransit bus-state check. |
+| `servicebus` | Included by `dependencies` endpoints | Dialogporten-level Service Bus health result. |
+
+The MassTransit check is deliberately named and tagged internally so `/health` does not show both the raw MassTransit result and the app-level `servicebus` result.
+
+| Condition | Result |
+| --- | --- |
+| Inner MassTransit check is `Healthy` | `Healthy` |
+| Inner MassTransit check is `Degraded` | `Degraded` |
+| Inner MassTransit check is `Unhealthy` | `Degraded` |
+| Inner MassTransit check is missing | `Unhealthy` |
+
+Azure Service Bus outages are reported as `Degraded`, not `Unhealthy`. The system can continue accepting requests because the PostgreSQL outbox preserves outbound messages until broker connectivity recovers. Restarting pods is not expected to fix broker connectivity problems.
+
+The missing-inner-check case is different: it indicates local application misconfiguration, so it is `Unhealthy`.
+
+### External HTTP Endpoints
+
+External HTTP endpoint checks are implemented by `EndpointsHealthCheck` and registered as `Endpoints` with the `external` tag. They are included only in `/health/deep`.
+
+Configured endpoints use this shape:
+
+```json
+{
+  "Name": "Some external API",
+  "AltinnPlatformRelativePath": "somecomponent/api/v1/health",
+  "HardDependency": true
+}
+```
+
+Each entry must set exactly one of:
+
+| Property | Meaning |
+| --- | --- |
+| `Url` | Absolute URL to check. |
+| `AltinnPlatformRelativePath` | Relative path resolved against `InfrastructureSettings.Altinn.BaseUri`. |
+
+`HardDependency` controls whether an endpoint failure makes the aggregate `Endpoints` check `Unhealthy` or only `Degraded`.
+
+WebApi and GraphQL also append configured JWT bearer well-known metadata endpoints to this list. These appended endpoints are soft dependencies: `HardDependency = false`.
+
+## External Endpoint Status Rules
+
+Each configured endpoint is checked with HTTP `GET`.
+
+| Condition | Per-endpoint status | Aggregate effect |
+| --- | --- | --- |
+| HTTP 2xx within 5 seconds | `Healthy` | No degradation |
+| HTTP 2xx after more than 5 seconds | `Slow` | `Degraded`, regardless of `HardDependency` |
+| Non-2xx response | `Failed` | `Unhealthy` if `HardDependency = true`, otherwise `Degraded` |
+| Exception | `Failed` | `Unhealthy` if `HardDependency = true`, otherwise `Degraded` |
+| Timeout after 20 seconds | `Failed` | `Unhealthy` if `HardDependency = true`, otherwise `Degraded` |
+
+Slow responses never make the aggregate check `Unhealthy`. `HardDependency` only affects actual failures.
+
+The `Endpoints` check includes diagnostic data:
+
+| Data field | Meaning |
+| --- | --- |
+| `checkedEndpoints` | List of endpoint name, URL, hard-dependency flag, status, and duration. |
+| `totalCount` | Total endpoints checked. |
+| `hardFailureCount` | Failed endpoints where `HardDependency = true`. |
+| `softFailureCount` | Failed endpoints where `HardDependency = false`. |
+| `slowCount` | Endpoints that succeeded but exceeded the 5 second degradation threshold. |
+
+## Configuration
+
+WebApi and GraphQL bind external endpoint checks from their app-specific settings sections. Service binds them from the top-level `HealthCheckSettings` section.
+
+Example WebApi configuration:
+
+```json
+{
+  "WebApi": {
+    "HealthCheckSettings": {
+      "HttpGetEndpointsToCheck": [
+        {
+          "Name": "Altinn CDN",
+          "Url": "https://altinncdn.no/orgs/altinn-orgs.json",
+          "HardDependency": false
+        },
+        {
+          "Name": "Altinn Access Management API",
+          "AltinnPlatformRelativePath": "accessmanagement/api/v1/meta/info/roles",
+          "HardDependency": true
+        }
+      ]
+    }
+  }
+}
+```
+
+Use `HardDependency = true` only when a failing endpoint means the system should be considered unhealthy. Use `HardDependency = false` when the dependency affects functionality or observability but should not cause Kubernetes to restart pods or remove the application from traffic.

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Common/GraphQlSettings.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Common/GraphQlSettings.cs
@@ -1,4 +1,5 @@
 ﻿using Digdir.Domain.Dialogporten.GraphQL.Common.Authentication;
+using Digdir.Library.Utils.AspNet;
 using FluentValidation;
 
 namespace Digdir.Domain.Dialogporten.GraphQL.Common;
@@ -8,6 +9,7 @@ public sealed class GraphQlSettings
     public const string SectionName = "GraphQl";
 
     public required AuthenticationOptions Authentication { get; init; }
+    public HealthCheckSettings HealthCheckSettings { get; init; } = new();
 
     public required GraphQlCorsOptions Cors { get; init; }
 }
@@ -27,5 +29,26 @@ internal sealed class GraphQlOptionsValidator : AbstractValidator<GraphQlSetting
     {
         RuleFor(x => x.Authentication)
             .SetValidator(authenticationOptionsValidator);
+
+        RuleForEach(x => x.HealthCheckSettings.HttpGetEndpointsToCheck)
+            .ChildRules(endpoint =>
+            {
+                endpoint.RuleFor(x => x.Name).NotEmpty();
+                endpoint.RuleFor(x => x)
+                    .Must(HaveExactlyOneEndpointAddress)
+                    .WithMessage("Exactly one of 'Url' or 'AltinnPlatformRelativePath' must be set.");
+                endpoint.When(x => !string.IsNullOrWhiteSpace(x.Url), () =>
+                    endpoint.RuleFor(x => x.Url)
+                        .Must(url => Uri.TryCreate(url, UriKind.Absolute, out _))
+                        .WithMessage("'{PropertyName}' must be a valid absolute URL."));
+                endpoint.When(x => !string.IsNullOrWhiteSpace(x.AltinnPlatformRelativePath), () =>
+                    endpoint.RuleFor(x => x.AltinnPlatformRelativePath)
+                        .NotEmpty()
+                        .Must(path => !Uri.TryCreate(path, UriKind.Absolute, out _))
+                        .WithMessage("'{PropertyName}' must be a relative path."));
+            });
     }
+
+    private static bool HaveExactlyOneEndpointAddress(HttpGetEndpointToCheck endpoint) =>
+        !string.IsNullOrWhiteSpace(endpoint.Url) ^ !string.IsNullOrWhiteSpace(endpoint.AltinnPlatformRelativePath);
 }

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Program.cs
@@ -128,13 +128,22 @@ static void BuildAndRun(string[] args)
                     };
                 }))
 
-        // Add health checks with the well-known URLs
-        .AddAspNetHealthChecks((x, y) => x.HealthCheckSettings.HttpGetEndpointsToCheck = y
-            .GetRequiredService<IOptions<GraphQlSettings>>().Value?
-            .Authentication?
-            .JwtBearerTokenSchemas?
-            .Select(z => z.WellKnown)
-            .ToList() ?? [])
+        // Add health checks with configured endpoints and well-known auth metadata endpoints
+        .AddAspNetHealthChecks((x, y) =>
+        {
+            var settings = y.GetRequiredService<IOptions<GraphQlSettings>>().Value;
+            var altinnBaseUri = y.GetRequiredService<IOptions<InfrastructureSettings>>().Value.Altinn.BaseUri;
+
+            x.HealthCheckSettings.HttpGetEndpointsToCheck = AspNetUtilitiesExtensions.ResolveHttpGetEndpointsToCheck(
+                settings.HealthCheckSettings.HttpGetEndpointsToCheck,
+                altinnBaseUri,
+                settings.Authentication.JwtBearerTokenSchemas.Select(schema => new HttpGetEndpointToCheck
+                {
+                    Name = schema.Name,
+                    Url = schema.WellKnown,
+                    HardDependency = false
+                }));
+        })
 
         // Auth
         .AddDialogportenAuthentication(builder.Configuration)

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/HealthChecks/ServiceBusHealthCheck.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/HealthChecks/ServiceBusHealthCheck.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.HealthChecks;
+
+// This is an application-level wrapper around MassTransit's built-in health check.
+// MassTransit owns the actual bus state probing; this wrapper controls how that state
+// is exposed from Dialogporten's public health endpoints.
+internal sealed class ServiceBusHealthCheck(HealthCheckService healthCheckService, ILogger<ServiceBusHealthCheck> logger) : IHealthCheck
+{
+    // These identify the inner MassTransit check. It is intentionally not tagged as a
+    // public dependency, otherwise /health would show both the raw MassTransit check
+    // and this app-level "servicebus" check.
+    internal const string InnerHealthCheckName = "masstransit-servicebus";
+    internal const string InnerHealthCheckTag = "masstransit-servicebus-internal";
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // The predicate limits execution to MassTransit's own check, so this wrapper does not run the
+        // full application health-check set recursively.
+        var report = await healthCheckService.CheckHealthAsync(IsMassTransitServiceBusHealthCheck, cancellationToken);
+
+        if (report.Entries.Count == 0)
+        {
+            // Missing inner check means local configuration is wrong. That differs from
+            // Azure Service Bus being unavailable, which the outbox can tolerate.
+            const string description = "MassTransit Service Bus health check is not registered.";
+            logger.LogError(description);
+            return HealthCheckResult.Unhealthy(description);
+        }
+
+        if (report.Status == HealthStatus.Healthy)
+        {
+            return HealthCheckResult.Healthy("Azure Service Bus is healthy.");
+        }
+
+        var exception = report.Entries.Values
+            .Select(static entry => entry.Exception)
+            .FirstOrDefault(static exception => exception is not null);
+
+        // Service Bus outages should not make this app unhealthy: PostgreSQL keeps
+        // outbound messages in the outbox until broker connectivity recovers.
+        logger.LogWarning(exception, "Azure Service Bus health check reported {Status}.", report.Status);
+        return HealthCheckResult.Degraded($"Azure Service Bus is {report.Status.ToString().ToLowerInvariant()}.", exception: exception);
+    }
+
+    private static bool IsMassTransitServiceBusHealthCheck(HealthCheckRegistration registration) =>
+        registration.Name.Equals(InnerHealthCheckName, StringComparison.Ordinal)
+        || registration.Tags.Contains(InnerHealthCheckTag);
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -321,13 +321,14 @@ public static class InfrastructureExtensions
                 customConfiguration(x);
             }
 
+            ConfigureServiceBusHealthCheck(x);
+
             if (builderContext.Environment.IsDevelopment() && builderContext.DevSettings.UseInMemoryServiceBusTransport)
             {
                 x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
                 return;
             }
 
-            x.ConfigureHealthCheckOptions(options => options.Tags.Add("dependencies"));
             x.AddConfigureEndpointsCallback((_, cfg) =>
             {
                 if (cfg is IServiceBusReceiveEndpointConfigurator sb)
@@ -342,6 +343,8 @@ public static class InfrastructureExtensions
                 cfg.ConfigureEndpoints(context);
             });
         });
+
+        builderContext.Services.AddServiceBusHealthCheck();
 
         new DummyRequestExecutorBuilder { Services = builderContext.Services }
             .AddRedisSubscriptions(_ => ConnectionMultiplexer.Connect(builderContext.InfraSettings.Redis.ConnectionString),
@@ -364,6 +367,8 @@ public static class InfrastructureExtensions
                 o.DisableInboxCleanupService();
             });
 
+            ConfigureServiceBusHealthCheck(x);
+
             if (builderContext.Environment.IsDevelopment() && builderContext.DevSettings.UseInMemoryServiceBusTransport)
             {
                 x.UsingInMemory();
@@ -372,6 +377,8 @@ public static class InfrastructureExtensions
 
             x.UsingAzureServiceBus();
         });
+
+        builderContext.Services.AddServiceBusHealthCheck();
 
         new DummyRequestExecutorBuilder { Services = builderContext.Services }
             .AddRedisSubscriptions(_ => ConnectionMultiplexer.Connect(builderContext.InfraSettings.Redis.ConnectionString),
@@ -425,10 +432,27 @@ public static class InfrastructureExtensions
         return services;
     }
 
+    private static void ConfigureServiceBusHealthCheck(IBusRegistrationConfigurator configurator) =>
+        configurator.ConfigureHealthCheckOptions(options =>
+        {
+            options.Name = ServiceBusHealthCheck.InnerHealthCheckName;
+            options.Tags.Add(ServiceBusHealthCheck.InnerHealthCheckTag);
+        });
+
+    private static IServiceCollection AddServiceBusHealthCheck(this IServiceCollection services)
+    {
+        services.AddHealthChecks()
+            .AddCheck<ServiceBusHealthCheck>("servicebus", tags: ["dependencies"]);
+
+        services.AddSingleton<ServiceBusHealthCheck>();
+
+        return services;
+    }
+
     private static IServiceCollection AddCustomHealthChecks(this IServiceCollection services)
     {
         services.AddHealthChecks()
-            .AddCheck<RedisHealthCheck>("redis", tags: ["dependencies", "redis"])
+            .AddCheck<RedisHealthCheck>("redis", tags: ["dependencies"])
             .AddDbContextCheck<DialogDbContext>("postgres", tags: ["dependencies", "critical"]);
 
         services.AddSingleton<RedisHealthCheck>();

--- a/src/Digdir.Domain.Dialogporten.Service/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.Service/Program.cs
@@ -9,6 +9,7 @@ using Digdir.Domain.Dialogporten.Service.Common;
 using Digdir.Library.Utils.AspNet;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
 
 // Using two-stage initialization to catch startup errors.
@@ -81,7 +82,14 @@ static void BuildAndRun(string[] args)
             })
             .Build()
         .AddTransient<IUser, ServiceUser>()
-        .AddAspNetHealthChecks();
+        .AddAspNetHealthChecks((x, y) =>
+        {
+            builder.Configuration.GetSection(nameof(HealthCheckSettings)).Bind(x.HealthCheckSettings);
+
+            x.HealthCheckSettings.HttpGetEndpointsToCheck = AspNetUtilitiesExtensions.ResolveHttpGetEndpointsToCheck(
+                x.HealthCheckSettings.HttpGetEndpointsToCheck,
+                y.GetRequiredService<IOptions<InfrastructureSettings>>().Value.Altinn.BaseUri);
+        });
 
     var app = builder.Build();
     app.MapAspNetHealthChecks();

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/WebApiSettings.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/WebApiSettings.cs
@@ -1,4 +1,5 @@
 ﻿using Digdir.Domain.Dialogporten.WebApi.Common.Authentication;
+using Digdir.Library.Utils.AspNet;
 using FluentValidation;
 
 namespace Digdir.Domain.Dialogporten.WebApi.Common;
@@ -8,6 +9,7 @@ public sealed class WebApiSettings
     public const string SectionName = "WebApi";
 
     public required AuthenticationOptions Authentication { get; init; }
+    public HealthCheckSettings HealthCheckSettings { get; init; } = new();
 }
 
 internal sealed class WebApiOptionsValidator : AbstractValidator<WebApiSettings>
@@ -17,5 +19,26 @@ internal sealed class WebApiOptionsValidator : AbstractValidator<WebApiSettings>
     {
         RuleFor(x => x.Authentication)
             .SetValidator(authenticationOptionsValidator);
+
+        RuleForEach(x => x.HealthCheckSettings.HttpGetEndpointsToCheck)
+            .ChildRules(endpoint =>
+            {
+                endpoint.RuleFor(x => x.Name).NotEmpty();
+                endpoint.RuleFor(x => x)
+                    .Must(HaveExactlyOneEndpointAddress)
+                    .WithMessage("Exactly one of 'Url' or 'AltinnPlatformRelativePath' must be set.");
+                endpoint.When(x => !string.IsNullOrWhiteSpace(x.Url), () =>
+                    endpoint.RuleFor(x => x.Url)
+                        .Must(url => Uri.TryCreate(url, UriKind.Absolute, out _))
+                        .WithMessage("'{PropertyName}' must be a valid absolute URL."));
+                endpoint.When(x => !string.IsNullOrWhiteSpace(x.AltinnPlatformRelativePath), () =>
+                    endpoint.RuleFor(x => x.AltinnPlatformRelativePath)
+                        .NotEmpty()
+                        .Must(path => !Uri.TryCreate(path, UriKind.Absolute, out _))
+                        .WithMessage("'{PropertyName}' must be a relative path."));
+            });
     }
+
+    private static bool HaveExactlyOneEndpointAddress(HttpGetEndpointToCheck endpoint) =>
+        !string.IsNullOrWhiteSpace(endpoint.Url) ^ !string.IsNullOrWhiteSpace(endpoint.AltinnPlatformRelativePath);
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -152,13 +152,22 @@ static void BuildAndRun(string[] args)
         .AddControllers(options => options.InputFormatters.Insert(0, JsonPatchInputFormatter.Get()))
             .AddNewtonsoftJson()
             .Services
-        // Add health checks with the retrieved URLs
-        .AddAspNetHealthChecks((x, y) => x.HealthCheckSettings.HttpGetEndpointsToCheck = y
-            .GetRequiredService<IOptions<WebApiSettings>>().Value?
-            .Authentication?
-            .JwtBearerTokenSchemas?
-            .Select(z => z.WellKnown)
-            .ToList() ?? [])
+        // Add health checks with configured endpoints and well-known auth metadata endpoints
+        .AddAspNetHealthChecks((x, y) =>
+        {
+            var settings = y.GetRequiredService<IOptions<WebApiSettings>>().Value;
+            var altinnBaseUri = y.GetRequiredService<IOptions<InfrastructureSettings>>().Value.Altinn.BaseUri;
+
+            x.HealthCheckSettings.HttpGetEndpointsToCheck = AspNetUtilitiesExtensions.ResolveHttpGetEndpointsToCheck(
+                settings.HealthCheckSettings.HttpGetEndpointsToCheck,
+                altinnBaseUri,
+                settings.Authentication.JwtBearerTokenSchemas.Select(schema => new HttpGetEndpointToCheck
+                {
+                    Name = schema.Name,
+                    Url = schema.WellKnown,
+                    HardDependency = false
+                }));
+        })
         // Auth
         .AddDialogportenAuthentication(builder.Configuration)
         .AddAuthorization();

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
@@ -41,5 +41,21 @@
       }
     }
   },
+  "WebApi": {
+    "HealthCheckSettings": {
+      "HttpGetEndpointsToCheck": [
+        {
+          "Name": "Altinn CDN",
+          "Url": "https://altinncdn.no/orgs/altinn-orgs.json",
+          "HardDependency": false
+        },
+        {
+          "Name": "Altinn Access Management API",
+          "AltinnPlatformRelativePath": "accessmanagement/api/v1/meta/info/roles",
+          "HardDependency": true
+        }
+      ]
+    }
+  },
   "AllowedHosts": "*"
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
@@ -51,9 +51,11 @@
         },
         {
           "Name": "Altinn Access Management API",
+          // TODO! Replace with health endpoint when available.
           "AltinnPlatformRelativePath": "accessmanagement/api/v1/meta/info/roles",
           "HardDependency": true
         }
+        // TODO! Add PDP, Register when health endpoints are available.
       ]
     }
   },

--- a/src/Digdir.Library.Utils.AspNet/AspNetUtilitiesExtensions.cs
+++ b/src/Digdir.Library.Utils.AspNet/AspNetUtilitiesExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Digdir.Library.Utils.AspNet;
 
@@ -39,5 +40,38 @@ public static class AspNetUtilitiesExtensions
     {
         app.MapHealthChecks(path, new HealthCheckOptions { Predicate = predicate, ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse });
         return app;
+    }
+
+    public static List<HttpGetEndpointToCheck> ResolveHttpGetEndpointsToCheck(
+        IEnumerable<HttpGetEndpointToCheck> endpoints,
+        Uri altinnBaseUri,
+        IEnumerable<HttpGetEndpointToCheck>? additionalEndpoints = null) =>
+        [
+            ..endpoints.Select(endpoint => ResolveHttpGetEndpointToCheck(endpoint, altinnBaseUri)),
+            ..(additionalEndpoints ?? []).Select(endpoint => ResolveHttpGetEndpointToCheck(endpoint, altinnBaseUri))
+        ];
+
+    public static HttpGetEndpointToCheck ResolveHttpGetEndpointToCheck(HttpGetEndpointToCheck endpoint, Uri altinnBaseUri)
+    {
+        if (HasAbsoluteUrl(endpoint, out var url))
+        {
+            return endpoint with
+            {
+                Url = url,
+                AltinnPlatformRelativePath = null
+            };
+        }
+
+        return endpoint with
+        {
+            Url = new Uri(altinnBaseUri, endpoint.AltinnPlatformRelativePath).AbsoluteUri,
+            AltinnPlatformRelativePath = null
+        };
+    }
+
+    private static bool HasAbsoluteUrl(HttpGetEndpointToCheck endpoint, [NotNullWhen(true)] out string? url)
+    {
+        url = endpoint.Url;
+        return !string.IsNullOrWhiteSpace(url);
     }
 }

--- a/src/Digdir.Library.Utils.AspNet/AspNetUtilitiesSettings.cs
+++ b/src/Digdir.Library.Utils.AspNet/AspNetUtilitiesSettings.cs
@@ -7,7 +7,15 @@ public sealed class AspNetUtilitiesSettings
 
 public sealed class HealthCheckSettings
 {
-    public List<string> HttpGetEndpointsToCheck { get; set; } = [];
+    public List<HttpGetEndpointToCheck> HttpGetEndpointsToCheck { get; set; } = [];
+}
+
+public sealed record HttpGetEndpointToCheck
+{
+    public required string Name { get; init; }
+    public string? Url { get; init; }
+    public string? AltinnPlatformRelativePath { get; init; }
+    public bool HardDependency { get; init; }
 }
 
 public sealed class TelemetrySettings

--- a/src/Digdir.Library.Utils.AspNet/Digdir.Library.Utils.AspNet.csproj
+++ b/src/Digdir.Library.Utils.AspNet/Digdir.Library.Utils.AspNet.csproj
@@ -27,4 +27,8 @@
         <ProjectReference Include="..\Digdir.Domain.Dialogporten.Infrastructure\Digdir.Domain.Dialogporten.Infrastructure.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="Digdir.Domain.Dialogporten.WebApi.Unit.Tests" />
+    </ItemGroup>
+
 </Project>

--- a/src/Digdir.Library.Utils.AspNet/HealthChecks/EndpointsHealthCheck.cs
+++ b/src/Digdir.Library.Utils.AspNet/HealthChecks/EndpointsHealthCheck.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 
 namespace Digdir.Library.Utils.AspNet.HealthChecks;
@@ -10,9 +9,9 @@ internal sealed class EndpointsHealthCheck : IHealthCheck
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<EndpointsHealthCheck> _logger;
-    private readonly List<string> _endpoints;
+    private readonly List<HttpGetEndpointToCheck> _endpoints;
     private const int DegradationThresholdInSeconds = 5;
-    private const int TimeoutInSeconds = 40;
+    private const int TimeoutInSeconds = 20;
 
     public EndpointsHealthCheck(
         IHttpClientFactory httpClientFactory,
@@ -29,50 +28,105 @@ internal sealed class EndpointsHealthCheck : IHealthCheck
         CancellationToken cancellationToken = default)
     {
         var client = _httpClientFactory.CreateClient();
-        var unhealthyEndpoints = new ConcurrentBag<string>();
 
-        var tasks = _endpoints.Select(async url =>
+        var results = await Task.WhenAll(_endpoints.Select(endpoint => CheckEndpointAsync(client, endpoint, cancellationToken)));
+        var hardFailures = results.Where(result =>
+            result is { Status: EndpointStatus.Failed, Endpoint.HardDependency: true }).ToList();
+        var degradedResults = results.Where(result =>
+            result.Status == EndpointStatus.Slow || result is { Status: EndpointStatus.Failed, Endpoint.HardDependency: false }).ToList();
+        var data = CreateHealthCheckData(results, hardFailures.Count);
+
+        if (hardFailures.Count == 0 && degradedResults.Count == 0)
         {
-            try
-            {
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cts.CancelAfter(TimeSpan.FromSeconds(TimeoutInSeconds));
-
-                var startTime = Stopwatch.GetTimestamp();
-                var response = await client.GetAsync(url, cts.Token);
-                var responseTime = Stopwatch.GetElapsedTime(startTime);
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    _logger.LogWarning("Health check failed for endpoint: {Url}. Status Code: {StatusCode}", url, response.StatusCode);
-                    unhealthyEndpoints.Add($"{url} (Status Code: {response.StatusCode})");
-                }
-                else if (responseTime > TimeSpan.FromSeconds(DegradationThresholdInSeconds))
-                {
-                    _logger.LogWarning("Health check response was slow for endpoint: {Url}. Elapsed time: {Elapsed:N1}s", url, responseTime.TotalSeconds);
-                    unhealthyEndpoints.Add($"{url} (Degraded - Response time: {responseTime.TotalSeconds:N1}s)");
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogWarning("Health check timed out for endpoint: {Url}", url);
-                unhealthyEndpoints.Add($"{url} (Timeout after {TimeoutInSeconds}s)");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Exception occurred while checking endpoint: {Url}", url);
-                unhealthyEndpoints.Add($"{url} (Exception: {ex.GetType().Name})");
-            }
-        });
-
-        await Task.WhenAll(tasks);
-
-        if (unhealthyEndpoints.IsEmpty)
-        {
-            return HealthCheckResult.Healthy("All endpoints are healthy.");
+            return HealthCheckResult.Healthy("All endpoints are healthy.", data);
         }
 
-        var description = $"The following endpoints are unhealthy: {string.Join(", ", unhealthyEndpoints)}";
-        return HealthCheckResult.Unhealthy(description);
+        List<string> descriptionParts = [];
+
+        if (hardFailures.Count != 0)
+        {
+            descriptionParts.Add($"Hard dependency failures: {string.Join(", ", hardFailures.Select(result => result.Description))}");
+        }
+
+        if (degradedResults.Count != 0)
+        {
+            descriptionParts.Add($"Degraded endpoints: {string.Join(", ", degradedResults.Select(result => result.Description))}");
+        }
+
+        var description = string.Join(". ", descriptionParts);
+        return hardFailures.Count != 0
+            ? HealthCheckResult.Unhealthy(description, data: data)
+            : HealthCheckResult.Degraded(description, data: data);
+    }
+
+    private async Task<EndpointCheckResult> CheckEndpointAsync(HttpClient client, HttpGetEndpointToCheck endpoint, CancellationToken cancellationToken)
+    {
+        var startTime = Stopwatch.GetTimestamp();
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(TimeoutInSeconds));
+
+            var response = await client.GetAsync(endpoint.Url, cts.Token);
+            var responseTime = Stopwatch.GetElapsedTime(startTime);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Health check failed for endpoint: {EndpointName} ({Url}). Status Code: {StatusCode}", endpoint.Name, endpoint.Url, response.StatusCode);
+                return new(endpoint, EndpointStatus.Failed, responseTime, $"{endpoint.Name} ({endpoint.Url}) failed with status code {(int)response.StatusCode}");
+            }
+
+            if (responseTime > TimeSpan.FromSeconds(DegradationThresholdInSeconds))
+            {
+                _logger.LogWarning("Health check response was slow for endpoint: {EndpointName} ({Url}). Elapsed time: {Elapsed:N1}s", endpoint.Name, endpoint.Url, responseTime.TotalSeconds);
+                return new(endpoint, EndpointStatus.Slow, responseTime, $"{endpoint.Name} ({endpoint.Url}) responded slowly in {responseTime.TotalSeconds:N1}s");
+            }
+
+            return new(endpoint, EndpointStatus.Healthy, responseTime, $"{endpoint.Name} ({endpoint.Url}) is healthy");
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("Health check timed out for endpoint: {EndpointName} ({Url})", endpoint.Name, endpoint.Url);
+            return new(endpoint, EndpointStatus.Failed, Stopwatch.GetElapsedTime(startTime), $"{endpoint.Name} ({endpoint.Url}) timed out after {TimeoutInSeconds}s");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception occurred while checking endpoint: {EndpointName} ({Url})", endpoint.Name, endpoint.Url);
+            return new(endpoint, EndpointStatus.Failed, Stopwatch.GetElapsedTime(startTime), $"{endpoint.Name} ({endpoint.Url}) failed with {ex.GetType().Name}");
+        }
+    }
+
+    private static Dictionary<string, object> CreateHealthCheckData(
+        IReadOnlyCollection<EndpointCheckResult> results,
+        int hardFailureCount)
+    {
+        var slowCount = results.Count(result => result.Status == EndpointStatus.Slow);
+        var softFailureCount = results.Count(result => result is { Status: EndpointStatus.Failed, Endpoint.HardDependency: false });
+
+        return new Dictionary<string, object>
+        {
+            ["checkedEndpoints"] = results.Select(result => new Dictionary<string, object>
+            {
+                ["name"] = result.Endpoint.Name,
+                ["url"] = result.Endpoint.Url ?? string.Empty,
+                ["hardDependency"] = result.Endpoint.HardDependency,
+                ["status"] = result.Status.ToString(),
+                ["durationMs"] = result.Duration.TotalMilliseconds
+            }).ToList(),
+            ["totalCount"] = results.Count,
+            ["hardFailureCount"] = hardFailureCount,
+            ["softFailureCount"] = softFailureCount,
+            ["slowCount"] = slowCount
+        };
+    }
+
+    private sealed record EndpointCheckResult(HttpGetEndpointToCheck Endpoint, EndpointStatus Status, TimeSpan Duration, string Description);
+
+    private enum EndpointStatus
+    {
+        Healthy,
+        Slow,
+        Failed
     }
 }

--- a/src/Digdir.Library.Utils.AspNet/HealthChecks/EndpointsHealthCheck.cs
+++ b/src/Digdir.Library.Utils.AspNet/HealthChecks/EndpointsHealthCheck.cs
@@ -68,7 +68,7 @@ internal sealed class EndpointsHealthCheck : IHealthCheck
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(TimeSpan.FromSeconds(TimeoutInSeconds));
 
-            var response = await client.GetAsync(endpoint.Url, cts.Token);
+            using var response = await client.GetAsync(endpoint.Url, cts.Token);
             var responseTime = Stopwatch.GetElapsedTime(startTime);
 
             if (!response.IsSuccessStatusCode)
@@ -84,6 +84,11 @@ internal sealed class EndpointsHealthCheck : IHealthCheck
             }
 
             return new(endpoint, EndpointStatus.Healthy, responseTime, $"{endpoint.Name} ({endpoint.Url}) is healthy");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Propagate caller/request aborts; only the linked CTS timeout below should be reported as endpoint failure.
+            throw;
         }
         catch (OperationCanceledException)
         {

--- a/tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests.csproj
+++ b/tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests.csproj
@@ -17,6 +17,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Digdir.Domain.Dialogporten.WebApi\Digdir.Domain.Dialogporten.WebApi.csproj"/>
+        <ProjectReference Include="..\..\src\Digdir.Library.Utils.AspNet\Digdir.Library.Utils.AspNet.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests/HealthChecks/EndpointsHealthCheckTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests/HealthChecks/EndpointsHealthCheckTests.cs
@@ -1,0 +1,130 @@
+using Digdir.Library.Utils.AspNet;
+using Digdir.Library.Utils.AspNet.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Net;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Unit.Tests.HealthChecks;
+
+public class EndpointsHealthCheckTests
+{
+    [Fact]
+    public void ResolveHttpGetEndpointToCheck_Should_Resolve_AltinnPlatformRelativePath_Against_BaseUri()
+    {
+        var resolved = AspNetUtilitiesExtensions.ResolveHttpGetEndpointToCheck(
+            new HttpGetEndpointToCheck
+            {
+                Name = "Altinn authorization",
+                AltinnPlatformRelativePath = "authorization/health",
+                HardDependency = true
+            },
+            new Uri("https://platform.altinn.no/"));
+
+        Assert.Equal("https://platform.altinn.no/authorization/health", resolved.Url);
+        Assert.Null(resolved.AltinnPlatformRelativePath);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_Should_Return_Healthy_When_All_Endpoints_Are_Healthy()
+    {
+        var sut = CreateHealthCheck(
+            [CreateEndpoint("Auth", "https://auth.example.test", hardDependency: true)],
+            _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+        var result = await sut.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Equal("All endpoints are healthy.", result.Description);
+        Assert.Equal(1, result.Data["totalCount"]);
+        Assert.Equal(0, result.Data["hardFailureCount"]);
+        Assert.Equal(0, result.Data["softFailureCount"]);
+        Assert.Equal(0, result.Data["slowCount"]);
+        Assert.Single((IEnumerable<object?>)result.Data["checkedEndpoints"]);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_Should_Return_Degraded_When_Soft_Dependency_Fails()
+    {
+        var sut = CreateHealthCheck(
+            [CreateEndpoint("Optional dependency", "https://optional.example.test", hardDependency: false)],
+            _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+
+        var result = await sut.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("Degraded endpoints", result.Description);
+        Assert.Contains("Optional dependency", result.Description);
+        Assert.Equal(1, result.Data["softFailureCount"]);
+        Assert.Equal(0, result.Data["hardFailureCount"]);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_Should_Return_Unhealthy_When_Hard_Dependency_Times_Out()
+    {
+        var sut = CreateHealthCheck(
+            [CreateEndpoint("Critical dependency", "https://critical.example.test", hardDependency: true)],
+            _ => throw new OperationCanceledException("Simulated timeout"));
+
+        var result = await sut.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("Hard dependency failures", result.Description);
+        Assert.Contains("Critical dependency", result.Description);
+        Assert.Equal(1, result.Data["hardFailureCount"]);
+        Assert.Equal(0, result.Data["softFailureCount"]);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_Should_Return_Degraded_When_Hard_Dependency_Is_Slow()
+    {
+        var sut = CreateHealthCheck(
+            [CreateEndpoint("Critical dependency", "https://critical.example.test", hardDependency: true)],
+            async cancellationToken =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(6), cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        var result = await sut.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("Degraded endpoints", result.Description);
+        Assert.Contains("responded slowly", result.Description);
+        Assert.Equal(1, result.Data["slowCount"]);
+        Assert.Equal(0, result.Data["hardFailureCount"]);
+    }
+
+    private static EndpointsHealthCheck CreateHealthCheck(
+        List<HttpGetEndpointToCheck> endpoints,
+        Func<CancellationToken, Task<HttpResponseMessage>> sendAsync) =>
+        new(
+            new FakeHttpClientFactory(sendAsync),
+            NullLogger<EndpointsHealthCheck>.Instance,
+            Options.Create(new AspNetUtilitiesSettings
+            {
+                HealthCheckSettings = new HealthCheckSettings
+                {
+                    HttpGetEndpointsToCheck = endpoints
+                }
+            }));
+
+    private static HttpGetEndpointToCheck CreateEndpoint(string name, string url, bool hardDependency) =>
+        new()
+        {
+            Name = name,
+            Url = url,
+            HardDependency = hardDependency
+        };
+
+    private sealed class FakeHttpClientFactory(Func<CancellationToken, Task<HttpResponseMessage>> sendAsync) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(new StubHttpMessageHandler(sendAsync));
+    }
+
+    private sealed class StubHttpMessageHandler(Func<CancellationToken, Task<HttpResponseMessage>> sendAsync) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            sendAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 - Added app-configurable HTTP health checks as named endpoint objects with Url or AltinnPlatformRelativePath and HardDependency.
  - Appended auth well-known metadata endpoints to deep health checks as soft dependencies.
  - Updated deep health aggregation: hard external failures make /health/deep unhealthy, soft failures and slow responses make it degraded.
  - Added detailed Endpoints health data with checked endpoints and aggregate counts.
  - Removed component-specific health tags for Redis and Service Bus.
  - Added ServiceBusHealthCheck wrapping MassTransit’s bus health check and reporting ASB connectivity issues as degraded.
  - Added health-check documentation covering endpoints, tags, status semantics, and configuration.


Here is an example "deep" output:

```json
{
    "status": "Healthy",
    "totalDuration": "00:00:00.9869539",
    "entries": {
        "redis": {
            "data": {},
            "description": "Redis connection is healthy.",
            "duration": "00:00:00.0337945",
            "status": "Healthy",
            "tags": [
                "dependencies"
            ]
        },
        "postgres": {
            "data": {},
            "duration": "00:00:00.0475665",
            "status": "Healthy",
            "tags": [
                "dependencies",
                "critical"
            ]
        },
        "servicebus": {
            "data": {},
            "description": "Azure Service Bus is healthy.",
            "duration": "00:00:00.0006072",
            "status": "Healthy",
            "tags": [
                "dependencies"
            ]
        },
        "Endpoints": {
            "data": {
                "checkedEndpoints": [
                    {
                        "name": "Altinn CDN",
                        "url": "https://altinncdn.no/orgs/altinn-orgs.json",
                        "hardDependency": false,
                        "status": "Healthy",
                        "durationMs": 137.8878
                    },
                    {
                        "name": "Altinn Access Management API",
                        "url": "https://platform.tt02.altinn.no/accessmanagement/api/v1/meta/info/roles",
                        "hardDependency": true,
                        "status": "Healthy",
                        "durationMs": 985.1263
                    },
                    {
                        "name": "Maskinporten",
                        "url": "https://test.maskinporten.no/.well-known/oauth-authorization-server/",
                        "hardDependency": false,
                        "status": "Healthy",
                        "durationMs": 108.829
                    },
                    {
                        "name": "AltinnTT02",
                        "url": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration",
                        "hardDependency": false,
                        "status": "Healthy",
                        "durationMs": 113.2138
                    },
                    {
                        "name": "Idporten",
                        "url": "https://test.idporten.no/.well-known/openid-configuration",
                        "hardDependency": false,
                        "status": "Healthy",
                        "durationMs": 112.004
                    }
                ],
                "totalCount": 5,
                "hardFailureCount": 0,
                "softFailureCount": 0,
                "slowCount": 0
            },
            "description": "All endpoints are healthy.",
            "duration": "00:00:00.9859888",
            "status": "Healthy",
            "tags": [
                "external"
            ]
        }
    }
}
```


## Related Issue(s)

- #2842 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

## Documentation

- [x] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
