### PR TITLE
chore(infra): persist postgresql overrides for production in iac

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -73,6 +73,7 @@ param appInsightsSku AppInsightsSku
 import { Sku as PostgresSku } from '../modules/postgreSql/create.bicep'
 import { StorageConfiguration as PostgresStorageConfig } from '../modules/postgreSql/create.bicep'
 import { HighAvailabilityConfiguration as PostgresHighAvailabilityConfig } from '../modules/postgreSql/create.bicep'
+import { ServerConfiguration as PostgresServerConfiguration } from '../modules/postgreSql/create.bicep'
 
 param postgresConfiguration {
   serverNameStem: string
@@ -81,6 +82,10 @@ param postgresConfiguration {
   storage: PostgresStorageConfig
   enableIndexTuning: bool
   enableQueryPerformanceInsight: bool
+  enableTrackIoTiming: bool?
+  additionalServerConfigurations: PostgresServerConfiguration[]?
+  staticServerConfigurations: PostgresServerConfiguration[]?
+  applyStaticServerConfigurations: bool?
   highAvailability: PostgresHighAvailabilityConfig?
   backupRetentionDays: int
   availabilityZone: string
@@ -245,6 +250,10 @@ module postgresql '../modules/postgreSql/create.bicep' = {
     appInsightWorkspaceName: appInsights.outputs.appInsightsWorkspaceName
     enableIndexTuning: postgresConfiguration.enableIndexTuning
     enableQueryPerformanceInsight: postgresConfiguration.enableQueryPerformanceInsight
+    enableTrackIoTiming: postgresConfiguration.?enableTrackIoTiming ?? false
+    additionalServerConfigurations: postgresConfiguration.?additionalServerConfigurations ?? []
+    staticServerConfigurations: postgresConfiguration.?staticServerConfigurations ?? []
+    applyStaticServerConfigurations: postgresConfiguration.?applyStaticServerConfigurations ?? false
     subnetId: vnet.outputs.postgresqlSubnetId
     vnetId: vnet.outputs.virtualNetworkId
     highAvailability: postgresConfiguration.?highAvailability

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -53,9 +53,66 @@ param postgresConfiguration = {
     iops: 24000
     throughput: 1200
   }
-  // Enabling index tuning will practically also enable query performance insight
-  enableIndexTuning: true
+  enableIndexTuning: false
   enableQueryPerformanceInsight: false
+  enableTrackIoTiming: true
+  additionalServerConfigurations: [
+    {
+      name: 'autovacuum_max_workers'
+      value: '12'
+    }
+    {
+      name: 'autovacuum_naptime'
+      value: '15'
+    }
+    {
+      name: 'autovacuum_vacuum_cost_delay'
+      value: '1'
+    }
+    {
+      name: 'autovacuum_vacuum_cost_limit'
+      value: '10000'
+    }
+    {
+      name: 'effective_io_concurrency'
+      value: '24'
+    }
+    {
+      name: 'maintenance_work_mem'
+      value: '2097151'
+    }
+    {
+      name: 'track_cost_delay_timing'
+      value: 'on'
+    }
+    {
+      name: 'vacuum_buffer_usage_limit'
+      value: '8192'
+    }
+    {
+      name: 'vacuum_cost_limit'
+      value: '10000'
+    }
+  ]
+  applyStaticServerConfigurations: false
+  staticServerConfigurations: [
+    {
+      name: 'commit_timestamp_buffers'
+      value: '1024'
+    }
+    {
+      name: 'io_max_concurrency'
+      value: '64'
+    }
+    {
+      name: 'subtransaction_buffers'
+      value: '1024'
+    }
+    {
+      name: 'transaction_buffers'
+      value: '1024'
+    }
+  ]
   backupRetentionDays: 32
   availabilityZone: '3'
   enableBackupVault: true

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -89,6 +89,26 @@ param enableQueryPerformanceInsight bool
 @description('Enable index tuning')
 param enableIndexTuning bool
 
+@description('Enable collection of database I/O timing statistics')
+param enableTrackIoTiming bool = false
+
+@export()
+type ServerConfiguration = {
+  @description('The PostgreSQL server parameter name.')
+  name: string
+  @description('The PostgreSQL server parameter value, without display units.')
+  value: string
+}
+
+@description('Additional PostgreSQL server parameters to persist as user overrides. Values must not duplicate the module-managed base/query-store settings.')
+param additionalServerConfigurations ServerConfiguration[] = []
+
+@description('Static PostgreSQL server parameters to persist but not apply unless applyStaticServerConfigurations is true.')
+param staticServerConfigurations ServerConfiguration[] = []
+
+@description('Apply static PostgreSQL server parameters. This may restart the server and should only be enabled in a planned maintenance window.')
+param applyStaticServerConfigurations bool = false
+
 @description('The name of the Application Insights workspace')
 param appInsightWorkspaceName string
 
@@ -142,6 +162,60 @@ var postgresStorage = storage.type == 'PremiumV2_LRS'
 
 var backupVaultNamePrefix = '${namePrefix}-backupvault'
 var restoreContainerName = toLower('${namePrefix}-postgresql-restore')
+var staticServerConfigurationNames = [
+  'autovacuum_freeze_max_age'
+  'autovacuum_multixact_freeze_max_age'
+  'autovacuum_worker_slots'
+  'azure_cdc.max_fabric_mirrors'
+  'commit_timestamp_buffers'
+  'cron.database_name'
+  'cron.log_run'
+  'cron.log_statement'
+  'cron.max_running_jobs'
+  'cron.timezone'
+  'duckdb.max_memory'
+  'duckdb.max_workers_per_postgres_scan'
+  'duckdb.memory_limit'
+  'duckdb.threads'
+  'duckdb.worker_threads'
+  'huge_pages'
+  'io_max_concurrency'
+  'io_method'
+  'max_active_replication_origins'
+  'max_connections'
+  'max_locks_per_transaction'
+  'max_logical_replication_workers'
+  'max_prepared_transactions'
+  'max_replication_slots'
+  'max_wal_senders'
+  'max_worker_processes'
+  'multixact_member_buffers'
+  'multixact_offset_buffers'
+  'notify_buffers'
+  'pg_stat_statements.max'
+  'serializable_buffers'
+  'shared_buffers'
+  'shared_preload_libraries'
+  'subtransaction_buffers'
+  'track_activity_query_size'
+  'track_commit_timestamp'
+  'transaction_buffers'
+  'wal_buffers'
+  'wal_level'
+]
+var additionalServerConfigurationStaticChecks = [
+  for configuration in additionalServerConfigurations: contains(staticServerConfigurationNames, toLower(configuration.name))
+]
+var additionalServerConfigurationsContainStatic = contains(additionalServerConfigurationStaticChecks, true)
+var additionalServerConfigurationsAreRestartSafe = !additionalServerConfigurationsContainStatic
+  ? true
+  : fail('Static PostgreSQL server parameters cannot be deployed through additionalServerConfigurations because they may restart the server. Remove static parameters from additionalServerConfigurations.')
+var staticServerConfigurationStaticChecks = [
+  for configuration in staticServerConfigurations: contains(staticServerConfigurationNames, toLower(configuration.name))
+]
+var staticServerConfigurationsContainOnlyStatic = !contains(staticServerConfigurationStaticChecks, false)
+  ? true
+  : fail('Only known static PostgreSQL server parameters can be deployed through staticServerConfigurations.')
 
 // Note: This provisions only the storage primitives used for PostgreSQL restores. The actual Azure Backup vault/RSV is clickopsed for now.
 module backupVaultStorageAccount '../storageAccount/main.bicep' = if (enableBackupVault) {
@@ -277,7 +351,7 @@ resource idle_transactions_timeout 'Microsoft.DBforPostgreSQL/flexibleServers/co
 // Enable Query Store when either index tuning or query performance insight is enabled
 var enableQueryStore = enableIndexTuning || enableQueryPerformanceInsight
 
-resource track_io_timing 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = if (enableQueryStore) {
+resource track_io_timing 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = if (enableTrackIoTiming || enableQueryStore) {
   parent: postgres
   name: 'track_io_timing'
   properties: {
@@ -316,6 +390,28 @@ resource index_tuning_mode 'Microsoft.DBforPostgreSQL/flexibleServers/configurat
   }
   dependsOn: [pgms_wait_sampling_query_capture_mode, pg_qs_query_capture_mode, track_io_timing, idle_transactions_timeout, enable_extensions]
 }
+
+@batchSize(1)
+resource additionalPostgresServerConfigurations 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = [for configuration in additionalServerConfigurations: if (additionalServerConfigurationsAreRestartSafe) {
+  parent: postgres
+  name: configuration.name
+  properties: {
+    value: configuration.value
+    source: 'user-override'
+  }
+  dependsOn: [index_tuning_mode, pgms_wait_sampling_query_capture_mode, pg_qs_query_capture_mode, track_io_timing, idle_transactions_timeout, enable_extensions]
+}]
+
+@batchSize(1)
+resource staticPostgresServerConfigurations 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = [for configuration in staticServerConfigurations: if (applyStaticServerConfigurations && staticServerConfigurationsContainOnlyStatic) {
+  parent: postgres
+  name: configuration.name
+  properties: {
+    value: configuration.value
+    source: 'user-override'
+  }
+  dependsOn: [additionalPostgresServerConfigurations]
+}]
 
 resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
   name: appInsightWorkspaceName

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -162,6 +162,16 @@ var postgresStorage = storage.type == 'PremiumV2_LRS'
 
 var backupVaultNamePrefix = '${namePrefix}-backupvault'
 var restoreContainerName = toLower('${namePrefix}-postgresql-restore')
+
+/*
+ These are known (as per 2026-04-18) static PostgreSQL 18 server parameters that require a server restart when updated.
+
+ Can be fetched with:
+ az postgres flexible-server parameter list \
+  --resource-group <resource_group> \
+  --server-name <server> \
+  --query "[?isDynamicConfig==\`false\` && isReadOnly==\`false\`] | [].name"
+*/
 var staticServerConfigurationNames = [
   'autovacuum_freeze_max_age'
   'autovacuum_multixact_freeze_max_age'


### PR DESCRIPTION
## Description

* Disabled performance tracking / index tuning in prod (since it's useless)
* Split track_io_timing to its own first class switch (still useful for EXPLAINs)
* Adds mechanism for applying additional settings, spltting dynamic (can be made without restart) and static (requires restart). Static changes are not applied in production, so this serves as a versioning mechanism only.
* Persists changes to dynamic settings already made in production
## Related Issue(s)

- n/a

## Verification

- [x] **Your** code builds clean without any errors or warnings
