### PR TITLE
fix: Add extra logging/catch all when domain errors in seenlog-handler

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Events/DialogSeenEvent.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/Events/DialogSeenEvent.cs
@@ -7,16 +7,19 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Events;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.Events;
 
 public sealed class DialogSeenEvent(
     IDialogDbContext db,
-    IUnitOfWork unitOfWork
+    IUnitOfWork unitOfWork,
+    ILogger<DialogSeenEvent> logger,
 ) : INotificationHandler<DialogSeenDomainEvent>
 {
     private readonly IDialogDbContext _db = db ?? throw new ArgumentNullException(nameof(db));
     private readonly IUnitOfWork _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    private readonly ILogger<DialogSeenEvent> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public async Task Handle(DialogSeenDomainEvent dialogSeenDomainEvent, CancellationToken cancellationToken)
     {
@@ -89,14 +92,20 @@ public sealed class DialogSeenEvent(
             success => { },
             domainError =>
             {
+                _logger.LogError("Domain errors occured in seen event handler: {DomainErrors}",
+                    domainError.Errors.Select(x => x.ErrorMessage));
+
                 if (IsDuplicateActorNameError(domainError))
                 {
                     throw new InvalidOperationException(domainError.Errors.First().ErrorMessage);
                 }
+
                 if (!IsDuplicateSeenLogIdError(domainError))
                 {
                     throw new UnreachableException("Should not get domain error when updating SeenAt.");
                 }
+
+                throw new UnreachableException("Unexpected domain error when updating SeenAt.");
             },
             concurrencyError =>
                 throw new UnreachableException("Should not get concurrencyError when updating SeenAt."),


### PR DESCRIPTION
## Description

Adds additional logging in seenlog event handler

## Related Issue(s)

- #3528 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
