### PR TITLE
trivial: use port 5540 for redisinsight in docker-compose

### DIFF
--- a/docker-compose-db-redis.yml
+++ b/docker-compose-db-redis.yml
@@ -40,9 +40,9 @@ services:
   dialogporten-redisinsight:
     image: redis/redisinsight
     ports:
-      - "7216:80"
+      - "7216:5540"
     environment:
-      RI_APP_PORT: 80
+      RI_APP_PORT: 5540
       RI_APP_HOST: '0.0.0.0'
     volumes:
       - redisinsight_cache:/data


### PR DESCRIPTION
## Description

The newer `redis/redisinsight` image runs as a non-root user and cannot bind to port 80, causing `EACCES` on container startup. Switched `RI_APP_PORT` and the container-side port mapping to the image's default 5540 (host port 7216 unchanged).

## Related Issue(s)

- n/a

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated