### PR TITLE
chore: modernize renovate config and expand grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    ":dependencyDashboard"
   ],
   "schedule": [
     "before 7am on Sunday",
@@ -9,38 +10,84 @@
   ],
   "updateNotScheduled": false,
   "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "minimumReleaseAge": null,
+    "schedule": ["at any time"]
+  },
   "packageRules": [
     {
-      "matchPaths": [
-        "docs/**"
-      ],
-      "schedule": [
-        "every 3 months"
-      ]
+      "matchFileNames": ["docs/**"],
+      "schedule": ["every 3 months"]
     },
     {
-      "packagePatterns": [
-        "^Npgsql"
-      ],
+      "matchPackageNames": ["/^Npgsql/"],
       "groupName": "Npgsql dependencies"
     },
     {
-      "packagePatterns": [
-        "^Microsoft"
-      ],
+      "matchPackageNames": ["/^Microsoft/"],
       "groupName": "Microsoft dependencies"
     },
     {
-      "packagePatterns": [
-        "^Serilog"
-      ],
+      "matchPackageNames": ["/^Serilog/"],
       "groupName": "Serilog dependencies"
     },
     {
-      "packagePatterns": [
-        "^ZiggyCreatures"
-      ],
+      "matchPackageNames": ["/^ZiggyCreatures/"],
       "groupName": "FusionCache dependencies"
+    },
+    {
+      "matchPackageNames": [
+        "/^HotChocolate/",
+        "/^StrawberryShake/",
+        "AppAny.HotChocolate.FluentValidation"
+      ],
+      "groupName": "HotChocolate dependencies"
+    },
+    {
+      "matchPackageNames": [
+        "/^OpenTelemetry/",
+        "/\\.OpenTelemetry$/",
+        "Azure.Monitor.OpenTelemetry.AspNetCore"
+      ],
+      "groupName": "OpenTelemetry dependencies"
+    },
+    {
+      "matchPackageNames": ["/^Azure\\./"],
+      "groupName": "Azure SDK dependencies"
+    },
+    {
+      "matchPackageNames": ["/^MassTransit/"],
+      "groupName": "MassTransit dependencies"
+    },
+    {
+      "matchPackageNames": ["/^Altinn\\./"],
+      "groupName": "Altinn dependencies"
+    },
+    {
+      "matchPackageNames": ["/^Refit/", "/^Refitter/"],
+      "groupName": "Refit dependencies"
+    },
+    {
+      "matchPackageNames": ["/^NSwag/"],
+      "groupName": "NSwag dependencies"
+    },
+    {
+      "matchPackageNames": ["/^OneOf/"],
+      "groupName": "OneOf dependencies"
+    },
+    {
+      "matchPackageNames": [
+        "/^xunit/",
+        "Microsoft.NET.Test.Sdk",
+        "Verify.XunitV3",
+        "coverlet.collector",
+        "AwesomeAssertions",
+        "NSubstitute"
+      ],
+      "groupName": "Test dependencies"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -47,16 +47,16 @@
       "groupName": "HotChocolate dependencies"
     },
     {
+      "matchPackageNames": ["/^Azure\\./"],
+      "groupName": "Azure SDK dependencies"
+    },
+    {
       "matchPackageNames": [
         "/^OpenTelemetry/",
         "/\\.OpenTelemetry$/",
         "Azure.Monitor.OpenTelemetry.AspNetCore"
       ],
       "groupName": "OpenTelemetry dependencies"
-    },
-    {
-      "matchPackageNames": ["/^Azure\\./"],
-      "groupName": "Azure SDK dependencies"
     },
     {
       "matchPackageNames": ["/^MassTransit/"],


### PR DESCRIPTION
## Description

Modernizes `renovate.json` and expands package grouping to reduce PR noise:

- Migrates deprecated keys: `config:base` → `config:recommended`, `matchPaths` → `matchFileNames`, `packagePatterns` → `matchPackageNames` (with `/regex/` syntax).
- Adds `vulnerabilityAlerts` (bypasses the 7-day `minimumReleaseAge` cooldown for CVEs, runs any time, labeled `security`) plus `osvVulnerabilityAlerts` and the dependency dashboard.
- Adds groups for HotChocolate, OpenTelemetry, Azure SDK, MassTransit, Altinn, Refit, NSwag, OneOf, and the xUnit/test toolchain — these all move in lockstep across the solution today and currently produce N separate PRs per bump.

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)