### PR TITLE
ci: publish alpha for new sdks

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -129,10 +129,32 @@ jobs:
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
+  publish-enduser-sdk-to-nuget:
+    uses: ./.github/workflows/workflow-publish-nuget.yml
+    needs: [ deploy-apps, get-current-version, generate-git-short-sha, check-for-changes, generate-timestamp ]
+    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasOpenApiEndUserSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiEndUserClientChanges == 'true' ) }}
+    with:
+      version: ${{ needs.get-current-version.outputs.version }}-alpha.${{ needs.generate-timestamp.outputs.timestamp }}+${{ needs.generate-git-short-sha.outputs.gitShortSha }}
+      path: 'src/Digdir.Library.Dialogporten.WebApiClient.EndUser/Digdir.Library.Dialogporten.WebApiClient.EndUser.csproj'
+      source: 'https://api.nuget.org/v3/index.json'
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+  publish-serviceowner-sdk-to-nuget:
+    uses: ./.github/workflows/workflow-publish-nuget.yml
+    needs: [ deploy-apps, get-current-version, generate-git-short-sha, check-for-changes, generate-timestamp ]
+    if: ${{ always() && !failure() && !cancelled() && ( needs.check-for-changes.outputs.hasOpenApiServiceOwnerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasWebApiServiceOwnerClientChanges == 'true' ) }}
+    with:
+      version: ${{ needs.get-current-version.outputs.version }}-alpha.${{ needs.generate-timestamp.outputs.timestamp }}+${{ needs.generate-git-short-sha.outputs.gitShortSha }}
+      path: 'src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.csproj'
+      source: 'https://api.nuget.org/v3/index.json'
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
   publish-schema-npm:
     name: Deploy schema npm package
     needs: [ check-for-changes, get-current-version, generate-git-short-sha, deploy-apps ]
-    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasGqlSchemaChanges == 'true') }}
+    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasSwaggerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasOpenApiEndUserSchemaChanges == 'true' || needs.check-for-changes.outputs.hasOpenApiServiceOwnerSchemaChanges == 'true' || needs.check-for-changes.outputs.hasGqlSchemaChanges == 'true') }}
     uses: ./.github/workflows/workflow-publish-schema.yml
     with:
       version: ${{ needs.get-current-version.outputs.version }}-${{ needs.generate-git-short-sha.outputs.gitShortSha }}

--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -21,14 +21,26 @@ on:
         description: "Backend related files changed"
         value: ${{ jobs.check-for-changes.outputs.hasBackendChanges }}
       hasWebApiClientChanges:
-        description: "WebApiClient related files changed"
+        description: "Legacy WebApiClient related files changed"
         value: ${{ jobs.check-for-changes.outputs.hasWebApiClientChanges }}
+      hasWebApiEndUserClientChanges:
+        description: "WebApi EndUser client related files changed"
+        value: ${{ jobs.check-for-changes.outputs.hasWebApiEndUserClientChanges }}
+      hasWebApiServiceOwnerClientChanges:
+        description: "WebApi ServiceOwner client related files changed"
+        value: ${{ jobs.check-for-changes.outputs.hasWebApiServiceOwnerClientChanges }}
       hasTestChanges:
         description: "Test related files changed"
         value: ${{ jobs.check-for-changes.outputs.hasTestChanges }}
       hasSwaggerSchemaChanges:
-        description: "Swagger schema has changed"
+        description: "Legacy swagger schema has changed"
         value: ${{ jobs.check-for-changes.outputs.hasSwaggerSchemaChanges }}
+      hasOpenApiEndUserSchemaChanges:
+        description: "EndUser OpenAPI schema has changed"
+        value: ${{ jobs.check-for-changes.outputs.hasOpenApiEndUserSchemaChanges }}
+      hasOpenApiServiceOwnerSchemaChanges:
+        description: "ServiceOwner OpenAPI schema has changed"
+        value: ${{ jobs.check-for-changes.outputs.hasOpenApiServiceOwnerSchemaChanges }}
       hasGqlSchemaChanges:
         description: "GraphQL schema has changed"
         value: ${{ jobs.check-for-changes.outputs.hasGqlSchemaChanges }}
@@ -50,9 +62,13 @@ jobs:
       hasBackendChanges: ${{ steps.filter-backend.outputs.backend_any_modified == 'true' || steps.filter.outputs.github_workflows_any_modified == 'true' }}
       hasTestChanges: ${{ steps.filter-backend.outputs.tests_any_modified == 'true' }}
       hasSwaggerSchemaChanges: ${{ steps.filter-backend.outputs.swagger_schema_any_modified == 'true'}}
+      hasOpenApiEndUserSchemaChanges: ${{ steps.filter-backend.outputs.openapi_enduser_schema_any_modified == 'true'}}
+      hasOpenApiServiceOwnerSchemaChanges: ${{ steps.filter-backend.outputs.openapi_serviceowner_schema_any_modified == 'true'}}
       hasGqlSchemaChanges: ${{ steps.filter-backend.outputs.gql_schema_any_modified == 'true'}}
       hasMigrationChanges: ${{ steps.filter-backend.outputs.migration_any_modified == 'true'}}
       hasWebApiClientChanges: ${{ steps.filter-backend.outputs.web_api_client_any_modified == 'true'}}
+      hasWebApiEndUserClientChanges: ${{ steps.filter-backend.outputs.web_api_enduser_client_any_modified == 'true'}}
+      hasWebApiServiceOwnerClientChanges: ${{ steps.filter-backend.outputs.web_api_serviceowner_client_any_modified == 'true'}}
       hasSchemaPackageChanges: ${{ steps.filter-backend.outputs.schema_package_any_modified == 'true'}}
     steps:
       - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
@@ -100,8 +116,19 @@ jobs:
               - 'tests/**/*'
             web_api_client:
               - 'src/Digdir.Library.Dialogporten.WebApiClient/**/*'
+              - 'src/Digdir.Library.Dialogporten.WebApiClient.Common/**/*'
+            web_api_enduser_client:
+              - 'src/Digdir.Library.Dialogporten.WebApiClient.EndUser/**/*'
+              - 'src/Digdir.Library.Dialogporten.WebApiClient.Common/**/*'
+            web_api_serviceowner_client:
+              - 'src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/**/*'
+              - 'src/Digdir.Library.Dialogporten.WebApiClient.Common/**/*'
             swagger_schema:
               - 'docs/schema/V1/swagger.verified.json'
+            openapi_enduser_schema:
+              - 'docs/schema/V1/openapi.v1.enduser.verified.json'
+            openapi_serviceowner_schema:
+              - 'docs/schema/V1/openapi.v1.serviceowner.verified.json'
             gql_schema:
               - 'docs/schema/V1/schema.verified.graphql'
             migration: 
@@ -113,8 +140,12 @@ jobs:
         run: |
           echo "Backend changes detected: ${{ steps.filter-backend.outputs.backend_any_modified }}"
           echo "Test changes detected: ${{ steps.filter-backend.outputs.tests_any_modified }}"
-          echo "Web API client changes detected: ${{ steps.filter-backend.outputs.web_api_client_any_modified }}"
-          echo "Swagger schema changes detected: ${{ steps.filter-backend.outputs.swagger_schema_any_modified }}"
+          echo "Legacy Web API client changes detected: ${{ steps.filter-backend.outputs.web_api_client_any_modified }}"
+          echo "Web API EndUser client changes detected: ${{ steps.filter-backend.outputs.web_api_enduser_client_any_modified }}"
+          echo "Web API ServiceOwner client changes detected: ${{ steps.filter-backend.outputs.web_api_serviceowner_client_any_modified }}"
+          echo "Legacy swagger schema changes detected: ${{ steps.filter-backend.outputs.swagger_schema_any_modified }}"
+          echo "EndUser OpenAPI schema changes detected: ${{ steps.filter-backend.outputs.openapi_enduser_schema_any_modified }}"
+          echo "ServiceOwner OpenAPI schema changes detected: ${{ steps.filter-backend.outputs.openapi_serviceowner_schema_any_modified }}"
           echo "GraphQL schema changes detected: ${{ steps.filter-backend.outputs.gql_schema_any_modified }}"
           echo "Migration changes detected: ${{ steps.filter-backend.outputs.migration_any_modified }}"
           echo "Schema package changes detected: ${{ steps.filter-backend.outputs.schema_package_any_modified }}"


### PR DESCRIPTION
## Description

- Add dedicated NuGet publish jobs for the EndUser and ServiceOwner SDKs in `ci-cd-main`.
- Split `workflow-check-for-changes` into separate legacy, EndUser, and ServiceOwner Web API client/schema flags, while keeping `WebApiClient.Common` in all three client buckets.
- Trigger schema package publishing in `ci-cd-main` when either split OpenAPI snapshot changes.

## Related Issue(s)

- None

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
