### PR TITLE
test(e2e): ignore runtime local config during local E2E

### DIFF
--- a/.run/GraphQL.run.xml
+++ b/.run/GraphQL.run.xml
@@ -12,6 +12,7 @@
     <envs>
       <env name="ASPNETCORE_ENVIRONMENT" value="Development" />
       <env name="DOTNET_ENVIRONMENT" value="Development" />
+      <env name="RUNNING_E2E_TESTS" value="true" />
       <env name="LocalDevelopment__UseLocalDevelopmentUser" value="false" />
       <env name="LocalDevelopment__UseLocalDevelopmentResourceRegister" value="false" />
       <env name="LocalDevelopment__UseLocalDevelopmentOrganizationRegister" value="false" />

--- a/.run/Service.run.xml
+++ b/.run/Service.run.xml
@@ -12,6 +12,7 @@
     <envs>
       <env name="ASPNETCORE_ENVIRONMENT" value="Development" />
       <env name="DOTNET_ENVIRONMENT" value="Development" />
+      <env name="RUNNING_E2E_TESTS" value="true" />
       <env name="LocalDevelopment__UseLocalDevelopmentUser" value="false" />
       <env name="LocalDevelopment__UseLocalDevelopmentResourceRegister" value="false" />
       <env name="LocalDevelopment__UseLocalDevelopmentOrganizationRegister" value="false" />

--- a/.run/WebApi.run.xml
+++ b/.run/WebApi.run.xml
@@ -12,6 +12,7 @@
     <envs>
       <env name="ASPNETCORE_ENVIRONMENT" value="Development" />
       <env name="DOTNET_ENVIRONMENT" value="Development" />
+      <env name="RUNNING_E2E_TESTS" value="true" />
       <env name="LocalDevelopment__UseLocalDevelopmentUser" value="false" />
       <env name="LocalDevelopment__UseLocalDevelopmentResourceRegister" value="false" />
       <env name="LocalDevelopment__UseLocalDevelopmentOrganizationRegister" value="false" />

--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Toggling these flags will enable/disable the external resources. The `DisableAut
 During local development, it is natural to tweak configurations. Some of these configurations are _meant_ to be shared through git, such as the endpoint for a new integration that may be used during local development. Other configurations are only meant for a specific debug session or a developer's personal preferences, which _should not be shared_ through git, such as lowering the log level below warning.
 
 The configuration in the `appsettings.local.json` file takes precedence over **all** other configurations and is only loaded in the **Development environment**. Additionally, it is ignored by git through the `.gitignore` file.
+Local E2E launchers set `RUNNING_E2E_TESTS=true`, which skips `appsettings.local.json` for the runtime projects so E2E runs use the checked-in development configuration instead of developer-specific overrides.
+This does not affect the E2E test-project `appsettings.local.json` used for `ExplicitTests`.
 
 If developers need to add configuration that should be shared, they should use `appsettings.Development.json`. If the configuration is not meant to be shared, they can create an `appsettings.local.json` file to override the desired settings.
 
@@ -364,6 +366,7 @@ builder.Configuration
 
 // Left out for brevity
 ```
+`AddLocalConfiguration` also skips `appsettings.local.json` when `RUNNING_E2E_TESTS=true`.
 
 ## Additional documentation
 - [CI/CD](docs/CI-CD.md)
@@ -382,6 +385,8 @@ Besides ordinary unit and integration tests, the primary end-to-end tests are th
 - [E2E tests (WebAPI + GraphQL)](docs/E2E-Tests.md)
 - [Scripts E2E](scripts/e2e/README.md)
 - [K6 testing](tests/k6/README.md)
+
+If you use Rider for local E2E, the repository includes ready-made `.run/` profiles for `WebApi (E2E)`, `GraphQL (E2E)`, `Service (E2E)`, and `E2E (WebAPI/GQL/Service)`.
 
 ## Pull requests
 For pull requests, the title must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

--- a/docs/E2E-Tests.md
+++ b/docs/E2E-Tests.md
@@ -31,14 +31,18 @@ The tests can also be run with the scripts at [scripts/e2e/README.md](../scripts
 
 ## Prerequisites
 - Dialogporten running locally (see repo [README.md](../README.md)).
-  - WebAPI E2E: WebAPI only.
-  - GraphQL E2E: WebAPI + GraphQL.
+  - WebAPI E2E: WebApi + Service.
+  - GraphQL E2E: WebApi + GraphQL + Service.
 - Access to Altinn testtools token generator credentials.
 
 ## Setup
-1. Start Dialogporten locally.
-   - Make sure DB/Redis are running: `podman compose -f docker-compose-db-redis.yml up -d`.
-   - Ensure `appsettings.Development.json` or `appsettings.local.json` for the relevant projects are set to:
+1. Start DB/Redis locally:
+   - `podman compose -f docker-compose-db-redis.yml up -d`
+2. Configure user secrets for the runtime projects you will start locally:
+   - Set the required project-scoped secrets for `src/Digdir.Domain.Dialogporten.WebApi`, `src/Digdir.Domain.Dialogporten.GraphQL`, and `src/Digdir.Domain.Dialogporten.Service` as needed.
+   - The checked-in `appsettings.Development.json` files already target AT23. Keep your secret values aligned with the same environment, preferably AT23, when running local E2E in `Development`.
+   - In practice, that means local DB/Redis values can stay local, while external values such as `Infrastructure:Maskinporten:ClientId`, `Infrastructure:Maskinporten:EncodedJwk`, `Infrastructure:Altinn:SubscriptionKey`, and `Application:Dialogporten:Ed25519KeyPairs:*` must belong to the same external environment as the rest of the development config.
+   - If you override environment-specific values in `appsettings.local.json` or user secrets, make sure they still match the AT23-oriented defaults in `appsettings.Development.json`, such as:
 ```json
 {
   "LocalDevelopment": {
@@ -59,11 +63,12 @@ The tests can also be run with the scripts at [scripts/e2e/README.md](../scripts
   }
 }
 ```
-2. Set the environment for the tests:
+3. Set the environment for local E2E:
 ```bash
 export DOTNET_ENVIRONMENT=Development
 ```
-3. Configure token generator credentials (user secrets):
+   - In `Development`, the E2E token generator uses `at23`.
+4. Configure token generator credentials (user secrets) for the E2E test projects:
 These are the same user/pass as in the `dialogporten-bruno` repo `.env` file.
 Ask the team on Slack if you do not have them.
 This can be done in the Solution Explorer in JetBrains Rider, right-click on the project, select `Tools => .NET User Secrets`.
@@ -75,6 +80,11 @@ dotnet user-secrets set -p tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests Tok
 dotnet user-secrets set -p tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests TokenGeneratorUser "<user>"
 dotnet user-secrets set -p tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests TokenGeneratorPassword "<password>"
 ```
+5. Start Dialogporten locally:
+   - Shell script: [scripts/e2e/run-webapi-e2e.zsh](../scripts/e2e/run-webapi-e2e.zsh)
+   - Rider: use the checked-in `.run` profiles `WebApi (E2E)`, `GraphQL (E2E)`, `Service (E2E)`, or the compound `E2E (WebAPI/GQL/Service)`.
+   - The shell script and Rider E2E profiles set `RUNNING_E2E_TESTS=true`, which prevents `appsettings.local.json` from being loaded for `WebApi`, `GraphQL`, and `Service`. This avoids accidental local overrides during E2E runs.
+   - The test-project file `tests/Digdir.Library.Dialogporten.E2E.Common/appsettings.local.json` is unaffected and is still the place to set `ExplicitTests=false` if you want explicit tests to run by default in your IDE.
 
 ## Writing tests
 Use the shared E2E base class and custom attributes so hooks and explicit behavior are consistent:

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -1,12 +1,14 @@
-# WebAPI/GraphQL E2E Script
+# WebAPI/GraphQL/Service E2E Script
 
-Runs the WebAPI and/or GraphQL end-to-end tests and manages the local API processes.
+Runs the local E2E setup for WebAPI, Service, and optionally GraphQL, then executes the matching E2E tests.
 
 ## Prerequisites
 - DB/Redis are running locally:
 ```bash
 podman compose -f docker-compose-db-redis.yml up -d
 ```
+- User secrets are configured for the projects you start locally (`WebApi`, `GraphQL`, `Service`) and for the E2E test projects.
+  See [docs/E2E-Tests.md](../../docs/E2E-Tests.md).
 
 ## Run
 From this directory:
@@ -21,6 +23,9 @@ Modes:
 ./run-webapi-e2e.zsh both
 ```
 
+The script always starts `WebApi` and `Service`. `graphql` and `both` also start `GraphQL`.
+It exports `RUNNING_E2E_TESTS=true`, so `appsettings.local.json` is ignored for the runtime projects during E2E runs.
+
 ## Configuration (.env)
 The script loads `.env` from this folder by default. You can override by setting `ENV_FILE` to a different path.
 
@@ -28,6 +33,9 @@ Default `.env` values in this folder:
 ```bash
 WEBAPI_ENVIRONMENT=Development
 DialogportenBaseUri=https://localhost
+WEBAPI_PORT=7214
+GRAPHQL_PORT=5181
+SERVICE_PORT=56842
 LocalDevelopment__UseLocalDevelopmentUser=false
 LocalDevelopment__UseLocalDevelopmentResourceRegister=false
 LocalDevelopment__UseLocalDevelopmentOrganizationRegister=false
@@ -46,8 +54,9 @@ LocalDevelopment__UseLocalMetricsAggregationStorage=true
 
 Optional overrides (if set in `.env` or the shell):
 ```bash
-WEBAPI_PORT=7215
+WEBAPI_PORT=7214
 GRAPHQL_PORT=5181
+SERVICE_PORT=56842
 ```
 
 ## Optional

--- a/scripts/e2e/run-webapi-e2e.zsh
+++ b/scripts/e2e/run-webapi-e2e.zsh
@@ -226,6 +226,7 @@ done
 
 export DOTNET_ENVIRONMENT="${WEBAPI_ENVIRONMENT}"
 export ASPNETCORE_ENVIRONMENT="${WEBAPI_ENVIRONMENT}"
+export RUNNING_E2E_TESTS=true
 export DialogportenBaseUri="${DialogportenBaseUri:-https://localhost}"
 export WebApiPort="${WEBAPI_PORT:-7215}" # Default port should not colide with default port of APIs
 export GraphQlPort="${GRAPHQL_PORT:-5180}"

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ConfigurationExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ConfigurationExtensions.cs
@@ -6,14 +6,22 @@ namespace Digdir.Domain.Dialogporten.Application.Common.Extensions;
 public static class ConfigurationExtensions
 {
     private const string AppsettingsLocalJson = "appsettings.local.json";
+    private const string RunningE2ETestsEnvironmentVariable = "RUNNING_E2E_TESTS";
 
 
     /// <summary>
     /// Adds the local configuration file (appsettings.local.json) to the configuration builder if the environment is Development.
+    /// Local E2E launchers can set RUNNING_E2E_TESTS=true to prevent runtime-specific local overrides.
     /// </summary>
     /// <param name="builder">The configuration builder to add the local configuration file to.</param>
     /// <param name="environment">The host environment to check if it is in development.</param>
     /// <returns>The configuration builder with the local configuration file added if in development.</returns>
     public static IConfigurationBuilder AddLocalConfiguration(this IConfigurationBuilder builder, IHostEnvironment environment)
-        => !environment.IsDevelopment() ? builder : builder.AddJsonFile(AppsettingsLocalJson, optional: true, reloadOnChange: true);
+        => !environment.IsDevelopment() || IsRunningE2ETests()
+            ? builder
+            : builder.AddJsonFile(AppsettingsLocalJson, optional: true, reloadOnChange: true);
+
+    private static bool IsRunningE2ETests() =>
+        bool.TryParse(Environment.GetEnvironmentVariable(RunningE2ETestsEnvironmentVariable), out var isRunningE2ETests)
+        && isRunningE2ETests;
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/ConfigurationExtensionsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/ConfigurationExtensionsTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using AwesomeAssertions;
+using Digdir.Domain.Dialogporten.Application.Common.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace Digdir.Domain.Dialogporten.Application.Unit.Tests;
+
+public class ConfigurationExtensionsTests
+{
+    private const string RunningE2ETestsEnvironmentVariable = "RUNNING_E2E_TESTS";
+
+    [Fact]
+    public void AddLocalConfiguration_Should_Add_AppsettingsLocalJson_In_Development_When_Not_Running_E2E_Tests()
+    {
+        // Arrange
+        using var _ = new EnvironmentVariableScope(RunningE2ETestsEnvironmentVariable, null);
+        var builder = new ConfigurationBuilder();
+
+        // Act
+        builder.AddLocalConfiguration(new TestHostEnvironment(Environments.Development));
+
+        // Assert
+        builder.Sources
+            .OfType<JsonConfigurationSource>()
+            .Select(x => x.Path)
+            .Should()
+            .ContainSingle(path => path == "appsettings.local.json");
+    }
+
+    [Fact]
+    public void AddLocalConfiguration_Should_Not_Add_AppsettingsLocalJson_When_Running_E2E_Tests()
+    {
+        // Arrange
+        using var _ = new EnvironmentVariableScope(RunningE2ETestsEnvironmentVariable, bool.TrueString);
+        var builder = new ConfigurationBuilder();
+
+        // Act
+        builder.AddLocalConfiguration(new TestHostEnvironment(Environments.Development));
+
+        // Assert
+        builder.Sources
+            .OfType<JsonConfigurationSource>()
+            .Select(x => x.Path)
+            .Should()
+            .NotContain(path => path == "appsettings.local.json");
+    }
+
+    private sealed class TestHostEnvironment(string environmentName) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = environmentName;
+        public string ApplicationName { get; set; } = nameof(ConfigurationExtensionsTests);
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string _variableName;
+        private readonly string? _originalValue;
+
+        public EnvironmentVariableScope(string variableName, string? value)
+        {
+            _variableName = variableName;
+            _originalValue = Environment.GetEnvironmentVariable(variableName);
+            Environment.SetEnvironmentVariable(variableName, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(_variableName, _originalValue);
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Prevent local E2E runtime hosts from loading `appsettings.local.json` by honoring `RUNNING_E2E_TESTS`.
- Set that env var in the E2E shell script and Rider `.run` profiles, and document that local E2E requires `WebApi + Service` with `GraphQL` added for GraphQL tests.
- Expand the E2E docs with user-secrets guidance, AT23 alignment, and the checked-in Rider profiles.

## Related Issue(s)

- None

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

Build: `HOME="$PWD/.context/fakehome" DOTNET_CLI_HOME="$PWD/.context/fakehome" dotnet build Digdir.Domain.Dialogporten.slnx -c Release`

Tests: `HOME="$PWD/.context/fakehome" DOTNET_CLI_HOME="$PWD/.context/fakehome" dotnet test Digdir.Domain.Dialogporten.slnx -c Release --filter 'FullyQualifiedName!~E2E.Tests&FullyQualifiedName!~E2E.Cleanup.Tests'`\n\nNote: this workspace has `tests/Digdir.Library.Dialogporten.E2E.Common/appsettings.local.json` with `ExplicitTests=false`, so unfiltered E2E suites try to hit local services and fail unless they are running.\n\n## Documentation\n\n- [x] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)\n