### PR TITLE
fix: correctly use redisAccessKeys for primaryKey

### DIFF
--- a/.azure/modules/redis/main.bicep
+++ b/.azure/modules/redis/main.bicep
@@ -59,6 +59,8 @@ resource redis 'Microsoft.Cache/Redis@2024-11-01' = {
   tags: tags
 }
 
+var redisAccessKeys = redis.listKeys()
+
 // private endpoint name max characters is 80
 var redisPrivateEndpointName = uniqueResourceName('${namePrefix}-redis-pe', 80)
 
@@ -112,7 +114,7 @@ module redisConnectionString '../keyvault/upsertSecret.bicep' = {
   params: {
     destKeyVaultName: environmentKeyVaultName
     secretName: 'dialogportenRedisConnectionString'
-    secretValue: '${redis.properties.hostName}:${redis.properties.sslPort},password=${redis.properties.accessKeys.primaryKey},ssl=True,abortConnect=False'
+    secretValue: '${redis.properties.hostName}:${redis.properties.sslPort},password=${redisAccessKeys.primaryKey},ssl=True,abortConnect=False'
     tags: tags
   }
 }


### PR DESCRIPTION
The Redis module previously built the secret from redis.properties.accessKeys.primaryKey. That property is not safe to depend on in template evaluation, because Microsoft documents properties.accessKeys as only being populated when the object is the response to a Create or Update operation. In the failing deployment, ARM could not evaluate primaryKey, which caused the nested redisConnectionString deployment to fail.

https://learn.microsoft.com/en-us/javascript/api/%40azure/arm-rediscache/redisproperties?view=azure-node-latest#@azure-arm-rediscache-redisproperties-accesskeys