### PR TITLE
chore: suppress automapper audit (GHSA-rvv3-g6hj-g44x)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,4 +21,10 @@
         <AnalysisLevel>10</AnalysisLevel>
     </PropertyGroup>
 
+    <ItemGroup>
+        <!-- See https://github.com/Altinn/dialogporten/issues/967
+             Suppressed until we remove automapper. -->
+        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Description

Suppresses the DoS vulnerability in AutoMapper 14.0.0 (GHSA-rvv3-g6hj-g44x) via uncontrolled recursion. No patch is available for the 14.x line; upgrading requires a paid license from v15 onward.

## Related Issue(s)

- #967

## Verification

- [x] Your code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)