### PR TITLE
fix(perf):  systemlabelmask filter logic

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Domain/DialogEndUserContexts/Entities/SystemLabel.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/DialogEndUserContexts/Entities/SystemLabel.cs
@@ -11,6 +11,7 @@ public sealed class SystemLabel(SystemLabel.Values id) :
 
     public enum Values
     {
+        // Keep PostgresFormattableStringBuilderExtensions.SupportedSystemLabelsMaskBitCount in sync when adding labels used by end-user search filters.
         Default = 1,
         Bin = 2,
         Archive = 3,

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
@@ -9,6 +9,9 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories;
 
 internal static class PostgresFormattableStringBuilderExtensions
 {
+    private const int SupportedSystemLabelsMaskBitCount = 5;
+    private const int MaxSupportedSystemLabelsMask = (1 << SupportedSystemLabelsMaskBitCount) - 1;
+
     [SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance")]
     internal static PostgresFormattableStringBuilder ApplyPaginationOrder<T>(this PostgresFormattableStringBuilder builder, IOrderSet<T> orderSet, string alias)
     {
@@ -72,7 +75,7 @@ internal static class PostgresFormattableStringBuilderExtensions
         }
 
         var excluded = new List<int>();
-        for (var value = 0; value <= 31; value++)
+        for (var value = 0; value <= MaxSupportedSystemLabelsMask; value++)
         {
             if ((value & requiredMask) != requiredMask)
                 excluded.Add(value);
@@ -270,10 +273,12 @@ internal static class PostgresFormattableStringBuilderExtensions
                 throw new ArgumentOutOfRangeException(nameof(labels), systemLabelId, "System label ids must be greater than zero.");
             }
 
-            // `short` in C# maps to `smallint` in PostgreSQL, and both are 16-bit signed integers. So, to avoid touching the sign bit, there are 15 distinct values that can be used.
-            if (systemLabelId > 15)
+            if (systemLabelId > SupportedSystemLabelsMaskBitCount)
             {
-                throw new ArgumentOutOfRangeException(nameof(labels), systemLabelId, "System label ids above 15 are not supported by the bitmask.");
+                throw new ArgumentOutOfRangeException(
+                    nameof(labels),
+                    systemLabelId,
+                    $"System label ids above {SupportedSystemLabelsMaskBitCount} require updating the search mask predicate.");
             }
 
             requiredMask |= (short)(1 << (systemLabelId - 1));

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/FormattableStringBuilderExtensions.cs
@@ -71,9 +71,21 @@ internal static class PostgresFormattableStringBuilderExtensions
             return queryBuilder;
         }
 
-        return queryBuilder.Append($"""
-            AND (d."SystemLabelsMask" & {requiredMask}::smallint) = {requiredMask}::smallint
-            """);
+        var excluded = new List<int>();
+        for (var value = 0; value <= 31; value++)
+        {
+            if ((value & requiredMask) != requiredMask)
+                excluded.Add(value);
+        }
+
+        if (excluded.Count == 0)
+            return queryBuilder;
+
+        queryBuilder.Append("AND ");
+        return queryBuilder.Append(string.Join(
+            " AND ",
+            excluded.Select(v => $"d.\"SystemLabelsMask\" != {v}")
+        ));
     }
 
     internal static PostgresFormattableStringBuilder AppendIsContentSeenFilterCondition(


### PR DESCRIPTION
## Description
- Changed systemlabelmask filter logic to generate AND operations rather than BIT operations in the sql to be able to use an optimized index.

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
