### PR TITLE
trivial: add dialog-id to missing correspondence id error msg

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/IdentifierLookup/IdentifierLookupDialogResolver.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/IdentifierLookup/IdentifierLookupDialogResolver.cs
@@ -120,7 +120,7 @@ internal sealed class IdentifierLookupDialogResolver : IIdentifierLookupDialogRe
                 return AltinnAuthorizationConstants.CorrespondenceRefPrefix + correspondenceId;
             }
 
-            throw new InvalidOperationException("Unable to determine correspondence ID instance reference for correspondence dialog. No label found and FCE URL is not in expected format.");
+            throw new InvalidOperationException($"Unable to determine correspondence ID instance reference for correspondence dialog {dialogData.DialogId}. No label found and FCE URL is not in expected format.");
         }
 
         return outputInstanceRef.Value;


### PR DESCRIPTION
## Description
Add a dialog id to the error message to enable troubleshooting

## Related Issue(s)

- n/a

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
