### PR TITLE
trivial: add diagnostics to missing user external id exception

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -36,6 +36,22 @@ public static class ClaimsPrincipalExtensions
     public const string ScopeClaim = "scope";
     public const string AltinnOrgClaim = "urn:altinn:org";
 
+    extension(ClaimsPrincipal claimsPrincipal)
+    {
+        public string GetDiagnosticSummary()
+        {
+            ArgumentNullException.ThrowIfNull(claimsPrincipal);
+
+            // Takes the first 30 claims and formats them with a maximum length of 50 characters
+            // User data is included in the diagnostic summary.
+            return string.Join(", ", claimsPrincipal.Claims.Take(30).Select(claim =>
+            {
+                var s = claim.ToString();
+                return s[..Math.Min(s.Length, 50)];
+            }));
+        }
+    }
+
     public static bool TryGetClaimValue(this ClaimsPrincipal claimsPrincipal, string claimType,
         [NotNullWhen(true)] out string? value)
     {

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IUserRegistry.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IUserRegistry.cs
@@ -54,10 +54,11 @@ public sealed class UserRegistry : IUserRegistry
 
     public UserId GetCurrentUserId()
     {
-        var (userType, externalId) = _user.GetPrincipal().GetUserType();
+        var principal = _user.GetPrincipal();
+        var (userType, externalId) = principal.GetUserType();
         if (userType == UserIdType.Unknown)
         {
-            throw new InvalidOperationException("User external id not found");
+            throw new InvalidOperationException("User external id not found. " + principal.GetDiagnosticSummary());
         }
 
         return new() { Type = userType, ExternalId = externalId };

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
@@ -317,18 +318,8 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
 
     private async Task<DialogSearchAuthorizationResult> PerformDialogSearchAuthorization(DialogSearchAuthorizationRequest request, CancellationToken cancellationToken)
     {
-        var partyIdentifier = request.Claims.GetEndUserPartyIdentifier();
-        if (partyIdentifier is null)
-        {
-            var (userType, externalId) = _user.GetPrincipal().GetUserType();
-            var safeExternalId = userType is DialogUserType.Values.Person
-                or DialogUserType.Values.ServiceOwnerOnBehalfOfPerson
-                or DialogUserType.Values.IdportenEmailIdentifiedUser
-                ? "<redacted>"
-                : externalId;
-            throw new UnreachableException(
-                $"GetEndUserPartyIdentifier returned null. UserType={userType}, ExternalId={safeExternalId}");
-        }
+        var partyIdentifier = request.Claims.GetEndUserPartyIdentifier()
+            ?? throw CreateMissingEndUserPartyIdentifierException(_user.GetPrincipal());
 
         var authorizedPartiesRequest = new AuthorizedPartiesRequest(
             partyIdentifier,
@@ -369,6 +360,16 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
             cancellationToken);
 
         return result;
+    }
+
+    private static UnreachableException CreateMissingEndUserPartyIdentifierException(ClaimsPrincipal principal)
+    {
+        var (userType, _) = principal.GetUserType();
+
+        return new(
+            "GetEndUserPartyIdentifier returned null. " +
+            $"UserType={userType}, " +
+            principal.GetDiagnosticSummary());
     }
 
     private async Task PopulateDialogIdsFromInstanceRefs(

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/Common/Extensions/ClaimsPrincipalExtensionsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/Common/Extensions/ClaimsPrincipalExtensionsTests.cs
@@ -10,6 +10,24 @@ namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Features.V1.Common.E
 public class ClaimsPrincipalExtensionsTests
 {
     [Fact]
+    public void GetDiagnosticSummary_Should_Include_Claim_Keys_And_Claim_Values()
+    {
+        // Arrange
+        const string sensitiveClaimValue = "sensitive-value";
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity([
+            new Claim("custom_claim", sensitiveClaimValue),
+            new Claim("scope", "dialogporten:enduser"),
+            new Claim("acr", "Level4")
+        ], "Bearer"));
+
+        // Act
+        var summary = claimsPrincipal.GetDiagnosticSummary();
+
+        // Assert
+        Assert.Contains("custom_claim: sensitive-value, scope: dialogporten:enduser, acr: Level4", summary);
+    }
+
+    [Fact]
     public void GetAuthenticationLevel_Should_Parse_Idporten_Acr_Claim_For_Level3()
     {
         // Arrange


### PR DESCRIPTION
## Description

- Add diagnostic context to the `User external id not found` exception in `UserRegistry.GetCurrentUserId` and "GetEndUserPartyIdentifier returned null. " exception in `AltinnAuthorizationClient.PerformDialogSearchAuthorization`
- Include both claim type and value
- Cap after 30 claim and 50 bytes per claim
## Related issue
- https://github.com/Altinn/dialogporten/issues/3899

## Verification
- Add unit test for claimsPrincipalExtension
