### PR TITLE
trivial(infra): document postgres administrator objectId uniqueness

### DIFF
--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -328,6 +328,8 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   tags: tags
 }
 
+// Admin records must have a unique objectId per server; the RP does not dedupe by
+// objectId when principalName differs, so a stray duplicate will hang this write.
 resource postgresAdministrators 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2024-08-01' = {
   name: deployer().objectId
   parent: postgres


### PR DESCRIPTION
## Summary

Adds a two-line comment above the `postgresAdministrators` resource in `.azure/modules/postgreSql/create.bicep` documenting a non-obvious invariant: the PostgreSQL resource provider does not deduplicate admin records by `objectId` when `principalName` differs, so a duplicate (e.g. one created manually via the portal with a different display name) collides with this write and causes the deploy to hang in `Accepted` state.

This is a doc-only change. No behavior change.

## Test plan
- [x] `bicep build .azure/modules/postgreSql/create.bicep` passes (only pre-existing warnings on unrelated lines)