### PR TITLE
docs: update agent E2E test guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,17 +3,25 @@
 This file describes how AI coding agents should interact with the repository.
 
 ## Build & Test Commands
-- **Build**: `dotnet build Digdir.Domain.Dialogporten.slnx`
-- **Test all**: `dotnet test Digdir.Domain.Dialogporten.slnx`
+- **Build**: `dotnet build Digdir.Domain.Dialogporten.slnx --configuration Release`
+- **Test default (non-E2E)**: `dotnet test Digdir.Domain.Dialogporten.slnx --configuration Release --no-build --filter 'FullyQualifiedName!~E2E'`
 - **Test single**: `dotnet test --filter "FullyQualifiedName=Namespace.TestClass.TestMethod"`
 - **Run project**: `cd src/ProjectDir && dotnet run`
 - **Add DB migration**: `dotnet ef migrations add <Name> -p .\src\Digdir.Domain.Dialogporten.Infrastructure\`
+- **Run C# E2E tests**: `scripts/e2e/run-webapi-e2e.zsh [webapi|graphql|both]`
 - **Run K6 functional tests**: `./tests/k6/run.sh -e localdev -a v1 -u "$TOKENGENERATOR_USERNAME" -p "$TOKENGENERATOR_PASSWORD" suites/all-single-pass.js`
 - Do **not** run performance test suites. All K6 tests requires internet connectivity.
 
-Always run `dotnet build` and `dotnet test` after making changes to *.cs files in `./src/**` or `./tests/**`.  
+Always run `dotnet build Digdir.Domain.Dialogporten.slnx --configuration Release` and `dotnet test Digdir.Domain.Dialogporten.slnx --configuration Release --no-build --filter 'FullyQualifiedName!~E2E'` after making changes to *.cs files in `./src/**` or `./tests/**`.
 
-If integration tests fail because test containers are blocked by sandboxing, use `dotnet test Digdir.Domain.Dialogporten.slnx --filter 'FullyQualifiedName!~Integration'` to skip them.
+Do not run E2E tests by default. Run them only when adding or changing E2E tests, when the task explicitly requires E2E validation, or when the user asks for E2E verification. The default non-E2E test command still builds the E2E projects through the preceding solution build.
+
+When E2E tests are required, use `scripts/e2e/.env` as the source of local ports: WebApi `https://localhost:7215`, GraphQL `http://localhost:5180/graphql`, and Service `http://localhost:56843`.
+Check the required ports before starting the E2E launcher. If the required ports are free, run `scripts/e2e/run-webapi-e2e.zsh webapi`, `scripts/e2e/run-webapi-e2e.zsh graphql`, or `scripts/e2e/run-webapi-e2e.zsh both`. The launcher starts DB/Redis if needed, starts the required app processes, runs the selected E2E tests with explicit tests enabled, and cleans up the app processes it started. DB/Redis are intentionally left running.
+
+If all required services are already responding on the configured ports, reuse them by exporting the same environment variables derived by the launcher and run the relevant E2E test project directly with `-- xUnit.Explicit=on`. If only some ports are occupied, or a port is occupied by something that does not respond as expected, stop and report the conflict instead of killing unknown processes. Do not start WebApi, GraphQL, or Service manually in separate long-lived sessions; rely on the E2E launcher for lifecycle management.
+
+If integration tests fail because test containers are blocked by sandboxing, use `dotnet test Digdir.Domain.Dialogporten.slnx --configuration Release --no-build --filter 'FullyQualifiedName!~E2E&FullyQualifiedName!~Integration'` to skip them.
 
 All code must compile with `TreatWarningsAsErrors=true` and pass the .NET analyzers.
 


### PR DESCRIPTION
## Description

Updates AGENTS.md so agents build in Release and run non-E2E tests by default after C# changes. Adds opt-in E2E guidance for using scripts/e2e/run-webapi-e2e.zsh, checking configured ports, reusing healthy existing services, and avoiding cleanup of unknown processes.

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required): reviewed AGENTS.md diff and ran git diff --check
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [x] Documentation is updated (AGENTS.md)
