### PR TITLE
ci: add dispatch workflow for publishing SDK nuget packages

### DIFF
--- a/.github/workflows/dispatch-publish-nuget.yml
+++ b/.github/workflows/dispatch-publish-nuget.yml
@@ -1,0 +1,60 @@
+name: Dispatch Publish NuGet
+
+on:
+  workflow_dispatch:
+    inputs:
+      project:
+        description: "SDK project to publish"
+        required: true
+        type: choice
+        options:
+          - ServiceOwner (Legacy)
+          - ServiceOwner
+          - EndUser
+      version:
+        description: "Version to publish (e.g., `1.23.4`)"
+        required: true
+        type: string
+      publish_as_stable:
+        description: "Publish as stable release. If unchecked, publishes as RC (`<version>-rc+<shortSha>`)."
+        default: false
+        required: false
+        type: boolean
+      source:
+        description: "NuGet source"
+        required: true
+        default: "https://api.nuget.org/v3/index.json"
+        type: string
+      ref:
+        description: "Branch or tag ref to publish from. Defaults to the workflow ref."
+        required: false
+        type: string
+
+run-name: Dispatch publish nuget ${{ inputs.project }} v${{ inputs.version }}${{ inputs.publish_as_stable && ' (stable)' || ' (rc)' }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ inputs.project }}-${{ inputs.version }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  generate-git-short-sha:
+    name: Generate git short sha
+    uses: ./.github/workflows/workflow-generate-git-short-sha.yml
+
+  publish-nuget:
+    name: Publish ${{ inputs.project }} v${{ inputs.version }}
+    needs: [generate-git-short-sha]
+    uses: ./.github/workflows/workflow-publish-nuget.yml
+    with:
+      version: ${{ inputs.publish_as_stable && inputs.version || format('{0}-rc+{1}', inputs.version, needs.generate-git-short-sha.outputs.gitShortSha) }}
+      path: ${{ (inputs.project == 'ServiceOwner (Legacy)' && 'src/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj') || (inputs.project == 'ServiceOwner' && 'src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.csproj') || 'src/Digdir.Library.Dialogporten.WebApiClient.EndUser/Digdir.Library.Dialogporten.WebApiClient.EndUser.csproj' }}
+      source: ${{ inputs.source }}
+      ref: ${{ inputs.ref || github.ref }}
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    permissions:
+      contents: read
+      packages: write


### PR DESCRIPTION
## Description

Adds `dispatch-publish-nuget.yml` so the three WebApiClient SDK packages can be published manually via `workflow_dispatch`. The dropdown shows friendly names (`ServiceOwner (Legacy)`, `ServiceOwner`, `EndUser`), which are mapped to their csproj paths inside the workflow before being passed to the existing `workflow-publish-nuget.yml`.

To avoid accidental stable publishes to nuget.org, the workflow defaults to RC mode — appending `-rc+<shortSha>` to the version (matching `ci-cd-staging.yml`). Publishing as a stable release requires explicitly checking the `publish_as_stable` box.

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)