### PR TITLE
chore(renovate): group hotchocolate and strawberryshake updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,8 +47,8 @@
     },
     {
       "matchPackageNames": [
-        "/^HotChocolate/",
-        "/^StrawberryShake/",
+        "/^HotChocolate/i",
+        "/^StrawberryShake/i",
         "AppAny.HotChocolate.FluentValidation"
       ],
       "groupName": "HotChocolate dependencies"


### PR DESCRIPTION
## Description

Make the HotChocolate Renovate package rule case-insensitive so lowercase tool manifest entries such as `strawberryshake.tools` are grouped with the existing HotChocolate dependency PRs.

## Related Issue(s)

- None

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
