### PR TITLE
chore: add preload libraries to postgresql

### DIFF
--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -105,6 +105,10 @@ param postgresConfiguration = {
       value: '64'
     }
     {
+      name: 'shared_preload_libraries'
+      value: 'pg_cron,pg_stat_statements,pg_hint_plan,auto_explain,pgaudit,pg_squeeze'
+    }
+    {
       name: 'subtransaction_buffers'
       value: '1024'
     }


### PR DESCRIPTION
This enables additional libraries in PostgreSQL in static settings. These will not be applied  (as applyStaticServerConfigurations is false), but will be saved in the IAC for versioning purposes.