### PR TITLE
chore: bump azure-login action AZ CLI version to 2.86.0

### DIFF
--- a/.github/actions/azure-login/action.yml
+++ b/.github/actions/azure-login/action.yml
@@ -17,7 +17,7 @@ inputs:
     default: 'false'
 
 env:
-  AZ_CLI_VERSION: 2.85.0
+  AZ_CLI_VERSION: 2.86.0
 
 runs:
   using: "composite"


### PR DESCRIPTION
Bumps Azure CLI version in the azure-login composite action from 2.85.0 to 2.86.0.