### PR TITLE
fix: limit dialog search upsert lock waits

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearchRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearchRepository.cs
@@ -40,7 +40,16 @@ internal sealed class DialogSearchRepository : IDialogSearchRepository
 
     public async Task UpsertFreeTextSearchIndex(Guid dialogId, CancellationToken cancellationToken)
     {
-        await _db.Database.ExecuteSqlAsync($@"SELECT search.""UpsertDialogSearchOne""({dialogId})", cancellationToken);
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(
+            @"SELECT search.""UpsertDialogSearchOne""(@p_dialog_id)",
+            connection)
+        {
+            CommandTimeout = 5
+        };
+        command.Parameters.AddWithValue("p_dialog_id", dialogId);
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     public async Task<int> SeedFullAsync(bool resetExisting, CancellationToken ct) =>


### PR DESCRIPTION
## Summary
- execute `search."UpsertDialogSearchOne"` through a direct `NpgsqlCommand`
- set a 5-second timeout scoped to this specific command
- keep timeout exceptions propagating so existing MassTransit retry/redelivery handles retries

References #3940

## Verification
- `dotnet build Digdir.Domain.Dialogporten.slnx --configuration Release`
- `dotnet test Digdir.Domain.Dialogporten.slnx --configuration Release --no-build --filter 'FullyQualifiedName!~E2E'`