### PR TITLE
fix: shorten Azure Container Apps revision suffix

### DIFF
--- a/.github/workflows/workflow-deploy-apps.yml
+++ b/.github/workflows/workflow-deploy-apps.yml
@@ -161,7 +161,7 @@ jobs:
       id-token: write
       contents: read
     env:
-      REVISION_SUFFIX: "${{ github.run_id }}-${{ inputs.version }}-${{ github.run_attempt}}"
+      REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_attempt }}"
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/workflow-deploy-apps.yml
+++ b/.github/workflows/workflow-deploy-apps.yml
@@ -161,7 +161,7 @@ jobs:
       id-token: write
       contents: read
     env:
-      REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_attempt }}"
+      REVISION_SUFFIX: "${{ inputs.version }}-${{ github.run_attempt }}-${{ github.run_number }}"
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Description

Removes `github.run_id` from the Azure Container Apps revision suffix so generated revision names stay below Azure's 54-character limit.
The suffix still includes the deployed image version and run attempt.

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

Verified with `git diff --check`, workflow YAML parsing, and revision length checks for test/staging/prod examples.

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
