### PR TITLE
fix: make dialog search upsert timeout configurable

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.json
@@ -19,6 +19,10 @@
   "Infrastructure": {
     "AltinnCdn": {
       "BaseUri": "https://altinncdn.no/"
+    },
+    "DialogSearch": {
+      // Set to 0 to use the Npgsql/provider default command timeout.
+      "UpsertCommandTimeoutSeconds": 5
     }
   },
   "Application": {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureSettings.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureSettings.cs
@@ -14,8 +14,17 @@ public sealed class InfrastructureSettings
     public required AltinnCdnPlatformSettings AltinnCdn { get; init; }
     public required MaskinportenSettings Maskinporten { get; init; }
     public required MassTransitSettings MassTransit { get; set; }
+    public required DialogSearchSettings DialogSearch { get; init; } = new();
     public bool EnableSqlStatementLogging { get; init; }
     public bool EnableSqlParametersLogging { get; init; }
+}
+
+public sealed class DialogSearchSettings
+{
+    /// <summary>
+    /// Set to 0 to use the Npgsql/provider default command timeout.
+    /// </summary>
+    public int? UpsertCommandTimeoutSeconds { get; init; } = 5;
 }
 
 public sealed class MassTransitSettings
@@ -52,6 +61,7 @@ internal sealed class InfrastructureSettingsValidator : AbstractValidator<Infras
         IValidator<AltinnCdnPlatformSettings> altinnCdnPlatformSettingsValidator,
         IValidator<MaskinportenSettings> maskinportenSettingsValidator,
         IValidator<RedisSettings> redisSettingsValidator,
+        IValidator<DialogSearchSettings> dialogSearchSettingsValidator,
         IValidator<MassTransitSettings> massTransitSettingsValidator)
     {
         RuleFor(x => x.DialogDbConnectionString)
@@ -73,6 +83,10 @@ internal sealed class InfrastructureSettingsValidator : AbstractValidator<Infras
             .NotEmpty()
             .SetValidator(redisSettingsValidator);
 
+        RuleFor(x => x.DialogSearch)
+            .NotNull()
+            .SetValidator(dialogSearchSettingsValidator);
+
         RuleFor(x => x.MassTransit)
             .SetValidator(massTransitSettingsValidator);
     }
@@ -83,8 +97,18 @@ internal sealed class InfrastructureSettingsValidator : AbstractValidator<Infras
         new AltinnCdnPlatformSettingsValidator(),
         new MaskinportenSettingsValidator(),
         new RedisSettingsValidator(),
+        new DialogSearchSettingsValidator(),
         new MassTransitSettingsValidator())
     { }
+}
+
+internal sealed class DialogSearchSettingsValidator : AbstractValidator<DialogSearchSettings>
+{
+    public DialogSearchSettingsValidator()
+    {
+        RuleFor(x => x.UpsertCommandTimeoutSeconds)
+            .GreaterThanOrEqualTo(0);
+    }
 }
 
 internal sealed class MassTransitSettingsValidator : AbstractValidator<MassTransitSettings>;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearchRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/DialogSearchRepository.cs
@@ -14,6 +14,7 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Contents;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearch.Abstractions;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearch.EndUser;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Npgsql;
 
 namespace Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories;
@@ -23,33 +24,52 @@ internal sealed class DialogSearchRepository : IDialogSearchRepository
     private readonly DialogDbContext _db;
     private readonly NpgsqlDataSource _dataSource;
     private readonly ISearchStrategySelector<EndUserSearchContext> _endUserSearchStrategySelector;
+    private readonly IOptionsSnapshot<InfrastructureSettings> _infrastructureSettings;
 
     public DialogSearchRepository(
         DialogDbContext dbContext,
         NpgsqlDataSource dataSource,
-        ISearchStrategySelector<EndUserSearchContext> endUserSearchStrategySelector)
+        ISearchStrategySelector<EndUserSearchContext> endUserSearchStrategySelector,
+        IOptionsSnapshot<InfrastructureSettings> infrastructureSettings)
     {
         ArgumentNullException.ThrowIfNull(dbContext);
         ArgumentNullException.ThrowIfNull(dataSource);
         ArgumentNullException.ThrowIfNull(endUserSearchStrategySelector);
+        ArgumentNullException.ThrowIfNull(infrastructureSettings);
 
         _db = dbContext;
         _dataSource = dataSource;
         _endUserSearchStrategySelector = endUserSearchStrategySelector;
+        _infrastructureSettings = infrastructureSettings;
     }
 
     public async Task UpsertFreeTextSearchIndex(Guid dialogId, CancellationToken cancellationToken)
     {
         await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
-        await using var command = new NpgsqlCommand(
-            @"SELECT search.""UpsertDialogSearchOne""(@p_dialog_id)",
-            connection)
-        {
-            CommandTimeout = 5
-        };
-        command.Parameters.AddWithValue("p_dialog_id", dialogId);
+        await using var command = CreateUpsertFreeTextSearchIndexCommand(
+            connection,
+            dialogId,
+            _infrastructureSettings.Value.DialogSearch.UpsertCommandTimeoutSeconds);
 
         await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    internal static NpgsqlCommand CreateUpsertFreeTextSearchIndexCommand(
+        NpgsqlConnection connection,
+        Guid dialogId,
+        int? commandTimeoutSeconds)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        var command = new NpgsqlCommand(
+            @"SELECT search.""UpsertDialogSearchOne""(@p_dialog_id)",
+            connection);
+        if (commandTimeoutSeconds is > 0)
+        {
+            command.CommandTimeout = commandTimeoutSeconds.Value;
+        }
+        command.Parameters.AddWithValue("p_dialog_id", dialogId);
+        return command;
     }
 
     public async Task<int> SeedFullAsync(bool resetExisting, CancellationToken ct) =>

--- a/src/Digdir.Domain.Dialogporten.Janitor/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.Janitor/appsettings.json
@@ -16,6 +16,10 @@
   "Infrastructure": {
     "AltinnCdn": {
       "BaseUri": "https://altinncdn.no/"
+    },
+    "DialogSearch": {
+      // Set to 0 to use the Npgsql/provider default command timeout.
+      "UpsertCommandTimeoutSeconds": 5
     }
   },
   "AllowedHosts": "*"

--- a/src/Digdir.Domain.Dialogporten.Service/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.Service/appsettings.json
@@ -16,6 +16,10 @@
   "Infrastructure": {
     "AltinnCdn": {
       "BaseUri": "https://altinncdn.no/"
+    },
+    "DialogSearch": {
+      // Set to 0 to use the Npgsql/provider default command timeout.
+      "UpsertCommandTimeoutSeconds": 5
     }
   },
   "AllowedHosts": "*"

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
@@ -24,6 +24,10 @@
   "Infrastructure": {
     "AltinnCdn": {
       "BaseUri": "https://altinncdn.no/"
+    },
+    "DialogSearch": {
+      // Set to 0 to use the Npgsql/provider default command timeout.
+      "UpsertCommandTimeoutSeconds": 5
     }
   },
   "Application": {

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DialogSearchRepositoryTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DialogSearchRepositoryTests.cs
@@ -1,0 +1,50 @@
+using AwesomeAssertions;
+using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories;
+using Npgsql;
+using Xunit;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests;
+
+public sealed class DialogSearchRepositoryTests
+{
+    [Fact]
+    public void CreateUpsertFreeTextSearchIndexCommand_Should_Apply_Configured_Command_Timeout()
+    {
+        using var connection = new NpgsqlConnection();
+
+        using var command = DialogSearchRepository.CreateUpsertFreeTextSearchIndexCommand(
+            connection,
+            Guid.CreateVersion7(),
+            commandTimeoutSeconds: 17);
+
+        command.CommandTimeout.Should().Be(17);
+    }
+
+    [Fact]
+    public void CreateUpsertFreeTextSearchIndexCommand_Should_Keep_Provider_Default_Command_Timeout_When_Configured_Timeout_Is_0()
+    {
+        using var connection = new NpgsqlConnection();
+        using var defaultCommand = new NpgsqlCommand();
+
+        using var command = DialogSearchRepository.CreateUpsertFreeTextSearchIndexCommand(
+            connection,
+            Guid.CreateVersion7(),
+            commandTimeoutSeconds: 0);
+
+        command.CommandTimeout.Should().Be(defaultCommand.CommandTimeout);
+    }
+
+    [Fact]
+    public void CreateUpsertFreeTextSearchIndexCommand_Should_Keep_Provider_Default_Command_Timeout_When_Configured_Timeout_Is_Null()
+    {
+        using var connection = new NpgsqlConnection();
+        using var defaultCommand = new NpgsqlCommand();
+
+        using var command = DialogSearchRepository.CreateUpsertFreeTextSearchIndexCommand(
+            connection,
+            Guid.CreateVersion7(),
+            commandTimeoutSeconds: null);
+
+        command.CommandTimeout.Should().Be(defaultCommand.CommandTimeout);
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DialogSearchSettingsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DialogSearchSettingsTests.cs
@@ -1,0 +1,47 @@
+using AwesomeAssertions;
+using Digdir.Domain.Dialogporten.Infrastructure;
+using Xunit;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests;
+
+public sealed class DialogSearchSettingsTests
+{
+    [Fact]
+    public void DialogSearchSettings_Should_Default_Upsert_Command_Timeout_To_5()
+    {
+        var settings = new DialogSearchSettings();
+
+        settings.UpsertCommandTimeoutSeconds.Should().Be(5);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(5)]
+    public void DialogSearchSettingsValidator_Should_Accept_Non_Negative_Upsert_Command_Timeout(int? timeoutSeconds)
+    {
+        var settings = new DialogSearchSettings
+        {
+            UpsertCommandTimeoutSeconds = timeoutSeconds
+        };
+
+        var result = new DialogSearchSettingsValidator().Validate(settings);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DialogSearchSettingsValidator_Should_Reject_Negative_Upsert_Command_Timeout()
+    {
+        var settings = new DialogSearchSettings
+        {
+            UpsertCommandTimeoutSeconds = -1
+        };
+
+        var result = new DialogSearchSettingsValidator().Validate(settings);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x =>
+            x.PropertyName == nameof(DialogSearchSettings.UpsertCommandTimeoutSeconds));
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests.csproj
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
         <PackageReference Include="coverlet.collector" Version="8.0.1" />

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests.csproj
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
         <PackageReference Include="coverlet.collector" Version="8.0.1" />

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/packages.lock.json
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.4.0, )",
+        "resolved": "9.4.0",
+        "contentHash": "dJxkWiQ8D+xT6Gr2sSL83+Mar+Vpy2JTcUPxFcckpPJ8VYBfSgnk+zqpS6t7kcGnjz8NLyF14qfuoL4bKzzoew=="
+      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[8.0.1, )",


### PR DESCRIPTION
## Summary

References #3940.

Adds configuration for the direct Npgsql command timeout used by dialog search index upserts.

- Adds `Infrastructure:DialogSearch:UpsertCommandTimeoutSeconds`
- Keeps the default behavior at 5 seconds
- Allows `0` or explicit `null` to leave `NpgsqlCommand.CommandTimeout` unset and use the provider/connection-string default
- Validates negative timeout values
- Adds focused unit tests for settings validation and command timeout behavior

## Verification

- `dotnet build Digdir.Domain.Dialogporten.slnx --configuration Release`
- `dotnet test Digdir.Domain.Dialogporten.slnx --configuration Release --no-build --filter 'FullyQualifiedName!~E2E'`