### PR TITLE
chore(azure): bump resource groups api version

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -120,7 +120,7 @@ var additionalTags = {}
 var tags = baseTags(additionalTags, environment)
 
 // Create resource groups
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-11-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: '${namePrefix}-rg'
   location: location
   tags: tags


### PR DESCRIPTION
## Description

Bumps the `Microsoft.Resources/resourceGroups` API version in `.azure/infrastructure/main.bicep` from `2024-11-01` to `2025-04-01`.

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required): reviewed `git diff origin/main...` and confirmed only the API version string changed.
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)