### PR TITLE
docs(agents): clarify snapshot test workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,11 @@ If integration tests fail because test containers are blocked by sandboxing, use
 
 All code must compile with `TreatWarningsAsErrors=true` and pass the .NET analyzers.
 
-Changes that affect Swagger/GraphQL spec must be reflected in the `docs/schema/v1/*verified*.json` files. Use the corresponding `*received*.json` files, which are generated upon build, for synchronization.
-Do not edit `schema.verified.graphql` or `swagger.verified.json` directly; they are automatically generated and validated via snapshot tests.
-The SwaggerSnapshot test will fail if these files are not identical. It will also fail when run in Debug configuration (must use Release).
+## Snapshot Tests
+- Never manually edit, create, or hand-write `*.verified.*` snapshot files.
+- When adding or updating snapshot tests, run the relevant test and let Verify generate the corresponding `*.received.*` file.
+- Review the generated `*.received.*` output, then accept/promote it to `*.verified.*` using the repository’s normal Verify workflow.
+- If the snapshot test cannot run because of local environment issues, leave the snapshot uncommitted/uncreated and document the blocker instead of fabricating the expected snapshot.
 
 ## Code Style Guidelines
 - Use file-scoped namespaces with `using` directives outside the namespace.


### PR DESCRIPTION
## Description

Replaces the Swagger/GraphQL-specific snapshot guidance in `AGENTS.md` with a general "Snapshot Tests" section that applies to all Verify snapshot tests in the repo. The new rules make it explicit that `*.verified.*` files must never be hand-edited or fabricated — they should only be promoted from a generated `*.received.*` file via the normal Verify workflow, and any environment blocker should be documented rather than worked around.

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [x] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)