### PR TITLE
trivial: remove DeletedAt from serviceowner search activity

### DIFF
--- a/docs/schema/V1/openapi.v1.serviceowner.verified.json
+++ b/docs/schema/V1/openapi.v1.serviceowner.verified.json
@@ -1697,11 +1697,6 @@
             "format": "date-time",
             "type": "string"
           },
-          "deletedAt": {
-            "format": "date-time",
-            "nullable": true,
-            "type": "string"
-          },
           "extendedType": {
             "format": "uri",
             "nullable": true,

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -6339,11 +6339,6 @@
             "format": "date-time",
             "type": "string"
           },
-          "deletedAt": {
-            "format": "date-time",
-            "nullable": true,
-            "type": "string"
-          },
           "extendedType": {
             "format": "uri",
             "nullable": true,

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/SearchActivities/ActivityDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/SearchActivities/ActivityDto.cs
@@ -10,7 +10,5 @@ public sealed class ActivityDto
 
     public DialogActivityType.Values Type { get; set; }
 
-    public DateTimeOffset? DeletedAt { get; set; }
-
     public Guid? TransmissionId { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/SearchActivities/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/SearchActivities/MappingProfile.cs
@@ -8,7 +8,6 @@ public sealed class MappingProfile : Profile
     public MappingProfile()
     {
         CreateMap<DialogActivity, ActivityDto>()
-            .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.TypeId))
-            .ForMember(dest => dest.DeletedAt, opt => opt.MapFrom(src => src.Dialog.DeletedAt));
+            .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.TypeId));
     }
 }

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/RefitterInterface.cs
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/RefitterInterface.cs
@@ -2131,9 +2131,6 @@ namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1
         [JsonConverter(typeof(JsonStringEnumConverter<DialogActivityType>))]
         public DialogActivityType Type { get; set; }
 
-        [JsonPropertyName("deletedAt")]
-        public System.DateTimeOffset? DeletedAt { get; set; }
-
         [JsonPropertyName("transmissionId")]
         public System.Guid? TransmissionId { get; set; }
 

--- a/src/Digdir.Library.Dialogporten.WebApiClient/Features/V1/RefitterInterface.cs
+++ b/src/Digdir.Library.Dialogporten.WebApiClient/Features/V1/RefitterInterface.cs
@@ -2131,9 +2131,6 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         [JsonConverter(typeof(JsonStringEnumConverter<DialogsEntitiesActivities_DialogActivityType>))]
         public DialogsEntitiesActivities_DialogActivityType Type { get; set; }
 
-        [JsonPropertyName("deletedAt")]
-        public System.DateTimeOffset? DeletedAt { get; set; }
-
         [JsonPropertyName("transmissionId")]
         public System.Guid? TransmissionId { get; set; }
 


### PR DESCRIPTION
Dead code, this field will never be populated as the endpoint returns 410 GONE for deleted dialogs.
- #1563 