### PR TITLE
chore: add warmup service/check

### DIFF
--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -98,10 +98,10 @@ param probes Probes = {
     timeoutSeconds: 2
   }
   readiness: {
-    periodSeconds: 5
-    initialDelaySeconds: 15
+    periodSeconds: 2
+    initialDelaySeconds: 5
     successThreshold: 1
-    failureThreshold: 3
+    failureThreshold: 45
     timeoutSeconds: 2
   }
   liveness: {

--- a/.azure/modules/containerApp/main.json
+++ b/.azure/modules/containerApp/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.177.2456",
-      "templateHash": "9434673033489522426"
+      "version": "0.43.8.12551",
+      "templateHash": "510108903279980529"
     }
   },
   "definitions": {
@@ -40,7 +40,22 @@
                 }
               }
             }
-          }
+          },
+          "nullable": true
+        },
+        "http": {
+          "type": "object",
+          "properties": {
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "concurrentRequests": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "nullable": true
         }
       },
       "metadata": {
@@ -230,10 +245,10 @@
           "timeoutSeconds": 2
         },
         "readiness": {
-          "periodSeconds": 5,
-          "initialDelaySeconds": 15,
+          "periodSeconds": 2,
+          "initialDelaySeconds": 5,
           "successThreshold": 1,
-          "failureThreshold": 3,
+          "failureThreshold": 45,
           "timeoutSeconds": 2
         },
         "liveness": {

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IUserRegistry.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IUserRegistry.cs
@@ -54,7 +54,7 @@ public sealed class UserRegistry : IUserRegistry
 
     public UserId GetCurrentUserId()
     {
-        var principal = _user.GetPrincipal();
+        var principal = AmbientUserPrincipal.Current ?? _user.GetPrincipal();
         var (userType, externalId) = principal.GetUserType();
         if (userType == UserIdType.Unknown)
         {

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/Presentation/AmbientUserPrincipal.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/Presentation/AmbientUserPrincipal.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+
+namespace Digdir.Domain.Dialogporten.Application.Externals.Presentation;
+
+public static class AmbientUserPrincipal
+{
+    // Allows non-HTTP execution paths, such as hosted warmup services, to run application queries
+    // that require a user principal without coupling those paths to ASP.NET HttpContext.
+    private static readonly AsyncLocal<ClaimsPrincipal?> CurrentPrincipal = new();
+
+    public static ClaimsPrincipal? Current => CurrentPrincipal.Value;
+
+    public static IDisposable Use(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        var previousPrincipal = CurrentPrincipal.Value;
+        CurrentPrincipal.Value = principal;
+        return new ResetDisposable(previousPrincipal);
+    }
+
+    private sealed class ResetDisposable : IDisposable
+    {
+        private readonly ClaimsPrincipal? _previousPrincipal;
+
+        public ResetDisposable(ClaimsPrincipal? previousPrincipal)
+        {
+            _previousPrincipal = previousPrincipal;
+        }
+
+        public void Dispose()
+        {
+            CurrentPrincipal.Value = _previousPrincipal;
+        }
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Common/ApplicationUser.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Common/ApplicationUser.cs
@@ -15,5 +15,7 @@ internal sealed class ApplicationUser : IUser
     }
 
     public ClaimsPrincipal GetPrincipal()
-        => _httpContextAccessor.HttpContext?.User ?? throw new InvalidOperationException("No user principal found");
+        => AmbientUserPrincipal.Current ??
+            _httpContextAccessor.HttpContext?.User ??
+            throw new InvalidOperationException("No user principal found");
 }

--- a/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/appsettings.json
@@ -23,6 +23,13 @@
     "DialogSearch": {
       // Set to 0 to use the Npgsql/provider default command timeout.
       "UpsertCommandTimeoutSeconds": 5
+    },
+    "Warmup": {
+      "Enabled": true,
+      "TimeoutSeconds": 60,
+      "DbConnectionsToOpen": 4,
+      "DbConnectionParallelism": 2,
+      "RunEndUserSearch": true
     }
   },
   "Application": {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/HealthChecks/WarmupHealthCheck.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/HealthChecks/WarmupHealthCheck.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.HealthChecks;
+
+internal sealed class WarmupHealthCheck : IHealthCheck
+{
+    private readonly WarmupState _warmupState;
+
+    public WarmupHealthCheck(WarmupState warmupState)
+    {
+        ArgumentNullException.ThrowIfNull(warmupState);
+
+        _warmupState = warmupState;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var result = _warmupState.Status switch
+        {
+            WarmupStatus.Healthy => HealthCheckResult.Healthy("Readiness warmup completed."),
+            WarmupStatus.Failed => HealthCheckResult.Unhealthy(
+                $"Readiness warmup failed in phase '{_warmupState.FailedPhase ?? "unknown"}'.",
+                _warmupState.Exception),
+            WarmupStatus.Pending => HealthCheckResult.Unhealthy(
+                $"Readiness warmup is pending in phase '{_warmupState.CurrentPhase ?? "not-started"}'."),
+            _ => throw new InvalidOperationException($"Unknown warmup status '{_warmupState.Status}'.")
+        };
+
+        return Task.FromResult(result);
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/HealthChecks/WarmupService.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/HealthChecks/WarmupService.cs
@@ -1,0 +1,248 @@
+using System.Security.Claims;
+using Digdir.Domain.Dialogporten.Application.Common.Extensions;
+using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Search;
+using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using AuthConstants = Digdir.Domain.Dialogporten.Application.Common.Authorization.Constants;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.HealthChecks;
+
+internal sealed partial class WarmupService : IHostedService
+{
+    private readonly ILogger<WarmupService> _logger;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly WarmupState _warmupState;
+    private readonly WarmupSettings _settings;
+    private CancellationTokenSource? _internalCts;
+
+    public WarmupService(
+        ILogger<WarmupService> logger,
+        IServiceScopeFactory scopeFactory,
+        WarmupState warmupState,
+        IOptions<InfrastructureSettings> options)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(warmupState);
+        ArgumentNullException.ThrowIfNull(options);
+
+        _logger = logger;
+        _scopeFactory = scopeFactory;
+        _warmupState = warmupState;
+        _settings = options.Value.Warmup;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_settings.Enabled)
+        {
+            _logger.LogInformation("Readiness warmup is disabled.");
+            _warmupState.MarkWarmupComplete();
+            return Task.CompletedTask;
+        }
+
+        _logger.LogInformation("Queuing readiness warmup.");
+        _internalCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var warmupToken = _internalCts.Token;
+
+        _ = Task.Run(() => PerformWarmupAsync(warmupToken), CancellationToken.None);
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _internalCts?.Cancel();
+        _internalCts?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task PerformWarmupAsync(CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(_settings.TimeoutSeconds));
+
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var services = scope.ServiceProvider;
+
+            await RunPhaseAsync("db-pool", () => WarmupDbPoolAsync(services, timeoutCts.Token));
+            await RunPhaseAsync("ef-model", () => WarmupEfModelAsync(services, timeoutCts.Token));
+
+            if (_settings.RunEndUserSearch)
+            {
+                await RunPhaseAsync("end-user-search", () => WarmupEndUserSearchAsync(services, timeoutCts.Token));
+            }
+
+            _logger.LogInformation("Readiness warmup completed successfully.");
+            _warmupState.MarkWarmupComplete();
+        }
+        catch (OperationCanceledException ex) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogError(ex, "Readiness warmup timed out after {TimeoutSeconds}s.", _settings.TimeoutSeconds);
+            _warmupState.MarkWarmupFailed("timeout", ex);
+        }
+        catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning(ex, "Readiness warmup was cancelled.");
+            _warmupState.MarkWarmupFailed("cancelled", ex);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Readiness warmup failed.");
+            _warmupState.MarkWarmupFailed(_warmupState.CurrentPhase ?? "unknown", ex);
+        }
+    }
+
+    private async Task RunPhaseAsync(string phase, Func<Task> action)
+    {
+        _warmupState.MarkPhaseStarted(phase);
+        WarmupPhaseStarting(_logger, phase);
+        await action();
+        WarmupPhaseCompleted(_logger, phase);
+    }
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Starting readiness warmup phase {WarmupPhase}.")]
+    private static partial void WarmupPhaseStarting(ILogger logger, string warmupPhase);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Completed readiness warmup phase {WarmupPhase}.")]
+    private static partial void WarmupPhaseCompleted(ILogger logger, string warmupPhase);
+
+    private async Task WarmupDbPoolAsync(IServiceProvider services, CancellationToken cancellationToken)
+    {
+        var dataSource = services.GetRequiredService<NpgsqlDataSource>();
+        var options = new ParallelOptions
+        {
+            CancellationToken = cancellationToken,
+            MaxDegreeOfParallelism = _settings.DbConnectionParallelism
+        };
+
+        await Parallel.ForEachAsync(
+            Enumerable.Range(0, _settings.DbConnectionsToOpen),
+            options,
+            async (_, token) =>
+            {
+                await using var connection = await dataSource.OpenConnectionAsync(token);
+                await using var command = new NpgsqlCommand("SELECT 1", connection);
+                await command.ExecuteScalarAsync(token);
+            });
+    }
+
+    private static async Task WarmupEfModelAsync(IServiceProvider services, CancellationToken cancellationToken)
+    {
+        var dbContext = services.GetRequiredService<DialogDbContext>();
+        await dbContext.DialogStatuses
+            .AsNoTracking()
+            .Where(x => x.Id == DialogStatus.Values.Completed)
+            .Select(x => x.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private async Task WarmupEndUserSearchAsync(IServiceProvider services, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_settings.EndUserPid))
+        {
+            EndUserSearchSkippedMissingPid(_logger);
+            return;
+        }
+
+        try
+        {
+            using var _ = AmbientUserPrincipal.Use(new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimsPrincipalExtensions.ScopeClaim, "digdir:dialogporten"),
+                new Claim(ClaimsPrincipalExtensions.PidClaim, _settings.EndUserPid),
+                new Claim(ClaimsPrincipalExtensions.IdportenAuthLevelClaim, AuthConstants.IdportenLoaSubstantial)
+            ], "WarmupAuth")));
+
+            var sender = services.GetRequiredService<ISender>();
+            var result = await sender.Send(new SearchDialogQuery
+            {
+                Party = [$"urn:altinn:person:identifier-no:{_settings.EndUserPid}"],
+                Limit = 5
+            }, cancellationToken);
+
+            if (result.IsT0 && result.AsT0.Items.Count == 0)
+            {
+                EndUserSearchReturnedNoRows(_logger, _settings.EndUserPid);
+            }
+            else if (!result.IsT0)
+            {
+                EndUserSearchReturnedNonSuccess(_logger, result.Value.GetType().Name, _settings.EndUserPid);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+        {
+            EndUserSearchFailed(_logger, _settings.EndUserPid, ex);
+        }
+    }
+
+    [LoggerMessage(EventId = 3, Level = LogLevel.Warning, Message = "Skipping end-user search warmup because Infrastructure:Warmup:EndUserPid is not configured.")]
+    private static partial void EndUserSearchSkippedMissingPid(ILogger logger);
+
+    [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "End-user search warmup returned no rows for PID {EndUserPid}.")]
+    private static partial void EndUserSearchReturnedNoRows(ILogger logger, string endUserPid);
+
+    [LoggerMessage(EventId = 5, Level = LogLevel.Warning, Message = "End-user search warmup returned {ResultType} for PID {EndUserPid}.")]
+    private static partial void EndUserSearchReturnedNonSuccess(ILogger logger, string resultType, string endUserPid);
+
+    [LoggerMessage(EventId = 6, Level = LogLevel.Warning, Message = "End-user search warmup failed for PID {EndUserPid}; readiness will not be failed by this optional phase.")]
+    private static partial void EndUserSearchFailed(ILogger logger, string endUserPid, Exception exception);
+}
+
+internal enum WarmupStatus
+{
+    Pending,
+    Healthy,
+    Failed
+}
+
+internal sealed class WarmupState
+{
+    private readonly Lock _lock = new();
+
+    public WarmupStatus Status { get; private set; } = WarmupStatus.Pending;
+    public string? CurrentPhase { get; private set; }
+    public string? FailedPhase { get; private set; }
+    public Exception? Exception { get; private set; }
+    public bool IsWarmupComplete => Status == WarmupStatus.Healthy;
+
+    public void MarkPhaseStarted(string phase)
+    {
+        lock (_lock)
+        {
+            CurrentPhase = phase;
+        }
+    }
+
+    public void MarkWarmupComplete()
+    {
+        lock (_lock)
+        {
+            Status = WarmupStatus.Healthy;
+            CurrentPhase = null;
+            FailedPhase = null;
+            Exception = null;
+        }
+    }
+
+    public void MarkWarmupFailed(string phase, Exception ex)
+    {
+        lock (_lock)
+        {
+            Status = WarmupStatus.Failed;
+            CurrentPhase = null;
+            FailedPhase = phase;
+            Exception = ex;
+        }
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -46,6 +46,7 @@ using Digdir.Domain.Dialogporten.Application.Common.Behaviours.FeatureMetric;
 using Digdir.Domain.Dialogporten.Infrastructure.Common.Configurations.Dapper;
 using MassTransit;
 using MediatR;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Digdir.Domain.Dialogporten.Infrastructure;
 
@@ -463,9 +464,14 @@ public static class InfrastructureExtensions
     {
         services.AddHealthChecks()
             .AddCheck<RedisHealthCheck>("redis", tags: ["dependencies"])
-            .AddDbContextCheck<DialogDbContext>("postgres", tags: ["dependencies", "critical"]);
+            .AddDbContextCheck<DialogDbContext>("postgres", tags: ["dependencies", "critical"])
+            .AddCheck<WarmupHealthCheck>("warmup", tags: ["warmup"]);
 
-        services.AddSingleton<RedisHealthCheck>();
+        services
+            .AddSingleton<RedisHealthCheck>()
+            .AddSingleton<WarmupState>()
+            .AddSingleton<WarmupHealthCheck>()
+            .AddHostedService<WarmupService>();
 
         return services;
     }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureSettings.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureSettings.cs
@@ -15,8 +15,20 @@ public sealed class InfrastructureSettings
     public required MaskinportenSettings Maskinporten { get; init; }
     public required MassTransitSettings MassTransit { get; set; }
     public required DialogSearchSettings DialogSearch { get; init; } = new();
+    public WarmupSettings Warmup { get; init; } = new();
     public bool EnableSqlStatementLogging { get; init; }
     public bool EnableSqlParametersLogging { get; init; }
+}
+
+public sealed class WarmupSettings
+{
+    public bool Enabled { get; init; } = true;
+    public int TimeoutSeconds { get; init; } = 60;
+    public int DbConnectionsToOpen { get; init; } = 4;
+    public int DbConnectionParallelism { get; init; } = 2;
+    public bool RunEndUserSearch { get; init; } = true;
+    // Synthetic warmup user expected to exist in all non-prod environments. Override in prod and local dev.
+    public string? EndUserPid { get; init; } = "14886498226";
 }
 
 public sealed class DialogSearchSettings
@@ -62,6 +74,7 @@ internal sealed class InfrastructureSettingsValidator : AbstractValidator<Infras
         IValidator<MaskinportenSettings> maskinportenSettingsValidator,
         IValidator<RedisSettings> redisSettingsValidator,
         IValidator<DialogSearchSettings> dialogSearchSettingsValidator,
+        IValidator<WarmupSettings> warmupSettingsValidator,
         IValidator<MassTransitSettings> massTransitSettingsValidator)
     {
         RuleFor(x => x.DialogDbConnectionString)
@@ -87,6 +100,10 @@ internal sealed class InfrastructureSettingsValidator : AbstractValidator<Infras
             .NotNull()
             .SetValidator(dialogSearchSettingsValidator);
 
+        RuleFor(x => x.Warmup)
+            .NotNull()
+            .SetValidator(warmupSettingsValidator);
+
         RuleFor(x => x.MassTransit)
             .SetValidator(massTransitSettingsValidator);
     }
@@ -98,8 +115,24 @@ internal sealed class InfrastructureSettingsValidator : AbstractValidator<Infras
         new MaskinportenSettingsValidator(),
         new RedisSettingsValidator(),
         new DialogSearchSettingsValidator(),
+        new WarmupSettingsValidator(),
         new MassTransitSettingsValidator())
     { }
+}
+
+internal sealed class WarmupSettingsValidator : AbstractValidator<WarmupSettings>
+{
+    public WarmupSettingsValidator()
+    {
+        RuleFor(x => x.TimeoutSeconds)
+            .GreaterThan(0);
+
+        RuleFor(x => x.DbConnectionsToOpen)
+            .GreaterThanOrEqualTo(0);
+
+        RuleFor(x => x.DbConnectionParallelism)
+            .GreaterThan(0);
+    }
 }
 
 internal sealed class DialogSearchSettingsValidator : AbstractValidator<DialogSearchSettings>

--- a/src/Digdir.Domain.Dialogporten.Janitor/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.Janitor/appsettings.json
@@ -20,6 +20,13 @@
     "DialogSearch": {
       // Set to 0 to use the Npgsql/provider default command timeout.
       "UpsertCommandTimeoutSeconds": 5
+    },
+    "Warmup": {
+      "Enabled": true,
+      "TimeoutSeconds": 60,
+      "DbConnectionsToOpen": 4,
+      "DbConnectionParallelism": 2,
+      "RunEndUserSearch": false
     }
   },
   "AllowedHosts": "*"

--- a/src/Digdir.Domain.Dialogporten.Service/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.Service/appsettings.json
@@ -20,6 +20,13 @@
     "DialogSearch": {
       // Set to 0 to use the Npgsql/provider default command timeout.
       "UpsertCommandTimeoutSeconds": 5
+    },
+    "Warmup": {
+      "Enabled": true,
+      "TimeoutSeconds": 60,
+      "DbConnectionsToOpen": 4,
+      "DbConnectionParallelism": 2,
+      "RunEndUserSearch": false
     }
   },
   "AllowedHosts": "*"

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/ApplicationUser.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/ApplicationUser.cs
@@ -15,6 +15,7 @@ internal sealed class ApplicationUser : IUser
     }
 
     public ClaimsPrincipal GetPrincipal()
-        => _httpContextAccessor.HttpContext?.User ??
+        => AmbientUserPrincipal.Current ??
+            _httpContextAccessor.HttpContext?.User ??
             throw new InvalidOperationException("No user principal found");
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
+++ b/src/Digdir.Domain.Dialogporten.WebApi/appsettings.json
@@ -28,6 +28,13 @@
     "DialogSearch": {
       // Set to 0 to use the Npgsql/provider default command timeout.
       "UpsertCommandTimeoutSeconds": 5
+    },
+    "Warmup": {
+      "Enabled": true,
+      "TimeoutSeconds": 60,
+      "DbConnectionsToOpen": 4,
+      "DbConnectionParallelism": 2,
+      "RunEndUserSearch": true
     }
   },
   "Application": {

--- a/src/Digdir.Library.Utils.AspNet/AspNetUtilitiesExtensions.cs
+++ b/src/Digdir.Library.Utils.AspNet/AspNetUtilitiesExtensions.cs
@@ -32,7 +32,7 @@ public static class AspNetUtilitiesExtensions
     public static WebApplication MapAspNetHealthChecks(this WebApplication app) =>
         app.MapHealthCheckEndpoint("/health/startup", check => check.Tags.Contains("dependencies"))
             .MapHealthCheckEndpoint("/health/liveness", check => check.Tags.Contains("self"))
-            .MapHealthCheckEndpoint("/health/readiness", check => check.Tags.Contains("critical"))
+            .MapHealthCheckEndpoint("/health/readiness", check => check.Tags.Contains("critical") || check.Tags.Contains("warmup"))
             .MapHealthCheckEndpoint("/health", check => check.Tags.Contains("dependencies"))
             .MapHealthCheckEndpoint("/health/deep", check => check.Tags.Contains("dependencies") || check.Tags.Contains("external"));
 

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/WarmupHealthCheckTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/WarmupHealthCheckTests.cs
@@ -1,0 +1,105 @@
+using Digdir.Domain.Dialogporten.Infrastructure;
+using Digdir.Domain.Dialogporten.Infrastructure.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests;
+
+public sealed class WarmupHealthCheckTests
+{
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsUnhealthy_WhenWarmupIsPending()
+    {
+        var state = new WarmupState();
+        var healthCheck = new WarmupHealthCheck(state);
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("pending", result.Description);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsHealthy_WhenWarmupCompleted()
+    {
+        var state = new WarmupState();
+        state.MarkWarmupComplete();
+        var healthCheck = new WarmupHealthCheck(state);
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsUnhealthy_WhenWarmupFailed()
+    {
+        var state = new WarmupState();
+        var exception = new InvalidOperationException("boom");
+        state.MarkWarmupFailed("ef-model", exception);
+        var healthCheck = new WarmupHealthCheck(state);
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Same(exception, result.Exception);
+        Assert.Contains("ef-model", result.Description);
+    }
+
+    [Fact]
+    public async Task StartAsync_MarksWarmupComplete_WhenWarmupIsDisabled()
+    {
+        var state = new WarmupState();
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var service = new WarmupService(
+            NullLogger<WarmupService>.Instance,
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            state,
+            Options.Create(CreateInfrastructureSettings(new WarmupSettings { Enabled = false })));
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(state.IsWarmupComplete);
+    }
+
+    [Fact]
+    public void MarkPhaseStarted_ExposesPendingPhase()
+    {
+        var state = new WarmupState();
+
+        state.MarkPhaseStarted("db-pool");
+
+        Assert.Equal(WarmupStatus.Pending, state.Status);
+        Assert.Equal("db-pool", state.CurrentPhase);
+    }
+
+    private static InfrastructureSettings CreateInfrastructureSettings(WarmupSettings warmupSettings) =>
+        new()
+        {
+            DialogDbConnectionString = "Host=localhost;Database=dialogporten",
+            Redis = new RedisSettings { ConnectionString = "localhost" },
+            Altinn = new AltinnPlatformSettings
+            {
+                BaseUri = new Uri("https://platform.altinn.no/"),
+                EventsBaseUri = new Uri("https://platform.altinn.no/"),
+                SubscriptionKey = "test"
+            },
+            AltinnCdn = new AltinnCdnPlatformSettings
+            {
+                BaseUri = new Uri("https://altinncdn.no/")
+            },
+            Maskinporten = new()
+            {
+                Environment = "test",
+                ClientId = "test",
+                Scope = "test",
+                EncodedJwk = "test"
+            },
+            MassTransit = new MassTransitSettings { Host = "localhost" },
+            DialogSearch = new DialogSearchSettings(),
+            Warmup = warmupSettings
+        };
+}


### PR DESCRIPTION
## Description

- Adds a readiness warmup service that runs before `/health/readiness` becomes healthy.
- Warms key startup paths:
  - PostgreSQL connection pool with configurable connection count/parallelism
  - EF model/query path
  - Optional end-user dialog search path
- Adds `WarmupHealthCheck` and includes it in the readiness health endpoint.
- Adds `AmbientUserPrincipal` so hosted/background warmup code can execute application paths that normally require an HTTP user principal.
- Adds configurable warmup settings under `Infrastructure:Warmup`, including an overridable synthetic end-user PID for non- prod warmup searches.
- Updates Container App readiness probe defaults to poll earlier/more frequently while allowing warmup up to ~90 seconds.
- Adds unit tests for readiness warmup health states.

## Related Issue(s)

- #3965

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 