### PR TITLE
fix(perf): when skipping cache population, also skip cache lookup fanout

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/PartyResourceRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/PartyResourceRepository.cs
@@ -58,6 +58,16 @@ internal sealed class PartyResourceRepository : IPartyResourceReferenceRepositor
         }
 
         var shouldPopulateCache = ShouldPopulateCache(request.Parties.Count);
+        if (!shouldPopulateCache)
+        {
+            // Large party sets intentionally bypass per-party cache lookups to avoid Redis/cache fanout.
+            var fetchedResourcesByParty = await FetchResourcesByParty(request.Parties, cancellationToken);
+            return BuildResult(
+                request.Parties,
+                request.Resources,
+                fetchedResourcesByParty);
+        }
+
         var cacheLookup = await LoadCachedResourcesByParty(request.Parties, cancellationToken);
         await PopulateCacheMisses(cacheLookup, shouldPopulateCache, cancellationToken);
 


### PR DESCRIPTION
## Description

Skips cache lookup attempt when `MaxPartiesCachingThreshold` is exceeded, which is suspected to cause significant delays in service-filtered searches.

## Related Issue(s)

- #3971 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added 
