### PR TITLE
fix: warmup shutdown lifetime race

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/HealthChecks/WarmupService.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/HealthChecks/WarmupService.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using System.Threading;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
@@ -72,10 +73,12 @@ internal sealed partial class WarmupService : IHostedService
             return;
         }
 
-        var internalCts = _internalCts
-            ?? throw new InvalidOperationException("Warmup task was started without a cancellation source.");
+        var internalCts = Interlocked.Exchange(ref _internalCts, null);
 
-        await internalCts.CancelAsync();
+        if (internalCts is not null)
+        {
+            await internalCts.CancelAsync();
+        }
 
         try
         {
@@ -83,10 +86,7 @@ internal sealed partial class WarmupService : IHostedService
         }
         finally
         {
-            if (_warmupTask.IsCompleted)
-            {
-                internalCts.Dispose();
-            }
+            internalCts?.Dispose();
         }
     }
 
@@ -130,6 +130,10 @@ internal sealed partial class WarmupService : IHostedService
         {
             _logger.LogError(ex, "Readiness warmup failed.");
             _warmupState.MarkWarmupFailed(_warmupState.CurrentPhase ?? "unknown", ex);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _internalCts, null)?.Dispose();
         }
     }
 

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/HealthChecks/WarmupService.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/HealthChecks/WarmupService.cs
@@ -20,23 +20,28 @@ internal sealed partial class WarmupService : IHostedService
     private readonly ILogger<WarmupService> _logger;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly WarmupState _warmupState;
+    private readonly IHostApplicationLifetime _hostApplicationLifetime;
     private readonly WarmupSettings _settings;
     private CancellationTokenSource? _internalCts;
+    private Task? _warmupTask;
 
     public WarmupService(
         ILogger<WarmupService> logger,
         IServiceScopeFactory scopeFactory,
         WarmupState warmupState,
+        IHostApplicationLifetime hostApplicationLifetime,
         IOptions<InfrastructureSettings> options)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(warmupState);
+        ArgumentNullException.ThrowIfNull(hostApplicationLifetime);
         ArgumentNullException.ThrowIfNull(options);
 
         _logger = logger;
         _scopeFactory = scopeFactory;
         _warmupState = warmupState;
+        _hostApplicationLifetime = hostApplicationLifetime;
         _settings = options.Value.Warmup;
     }
 
@@ -50,19 +55,39 @@ internal sealed partial class WarmupService : IHostedService
         }
 
         _logger.LogInformation("Queuing readiness warmup.");
-        _internalCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _internalCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            _hostApplicationLifetime.ApplicationStopping);
         var warmupToken = _internalCts.Token;
 
-        _ = Task.Run(() => PerformWarmupAsync(warmupToken), CancellationToken.None);
+        _warmupTask = Task.Run(() => PerformWarmupAsync(warmupToken), CancellationToken.None);
 
         return Task.CompletedTask;
     }
 
-    public Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
-        _internalCts?.Cancel();
-        _internalCts?.Dispose();
-        return Task.CompletedTask;
+        if (_warmupTask is null)
+        {
+            return;
+        }
+
+        var internalCts = _internalCts
+            ?? throw new InvalidOperationException("Warmup task was started without a cancellation source.");
+
+        await internalCts.CancelAsync();
+
+        try
+        {
+            await _warmupTask.WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            if (_warmupTask.IsCompleted)
+            {
+                internalCts.Dispose();
+            }
+        }
     }
 
     private async Task PerformWarmupAsync(CancellationToken cancellationToken)
@@ -96,6 +121,11 @@ internal sealed partial class WarmupService : IHostedService
             _logger.LogWarning(ex, "Readiness warmup was cancelled.");
             _warmupState.MarkWarmupFailed("cancelled", ex);
         }
+        catch (ObjectDisposedException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning(ex, "Readiness warmup was cancelled because application services are stopping.");
+            _warmupState.MarkWarmupFailed("cancelled", ex);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Readiness warmup failed.");
@@ -105,6 +135,7 @@ internal sealed partial class WarmupService : IHostedService
 
     private async Task RunPhaseAsync(string phase, Func<Task> action)
     {
+        _internalCts?.Token.ThrowIfCancellationRequested();
         _warmupState.MarkPhaseStarted(phase);
         WarmupPhaseStarting(_logger, phase);
         await action();

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/WarmupHealthCheckTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/WarmupHealthCheckTests.cs
@@ -2,6 +2,7 @@ using Digdir.Domain.Dialogporten.Infrastructure;
 using Digdir.Domain.Dialogporten.Infrastructure.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -54,10 +55,12 @@ public sealed class WarmupHealthCheckTests
     {
         var state = new WarmupState();
         var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        using var hostApplicationLifetime = new TestHostApplicationLifetime();
         var service = new WarmupService(
             NullLogger<WarmupService>.Instance,
             serviceProvider.GetRequiredService<IServiceScopeFactory>(),
             state,
+            hostApplicationLifetime,
             Options.Create(CreateInfrastructureSettings(new WarmupSettings { Enabled = false })));
 
         await service.StartAsync(TestContext.Current.CancellationToken);
@@ -102,4 +105,17 @@ public sealed class WarmupHealthCheckTests
             DialogSearch = new DialogSearchSettings(),
             Warmup = warmupSettings
         };
+
+    private sealed class TestHostApplicationLifetime : IHostApplicationLifetime, IDisposable
+    {
+        private readonly CancellationTokenSource _applicationStoppingCts = new();
+
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+        public CancellationToken ApplicationStopping => _applicationStoppingCts.Token;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication() => _applicationStoppingCts.Cancel();
+
+        public void Dispose() => _applicationStoppingCts.Dispose();
+    }
 }


### PR DESCRIPTION
## Description

- Fixes a warmup shutdown race where the background readiness warmup could continue after application services started disposing.
- Links warmup cancellation to ApplicationStopping.
- Tracks and awaits the warmup task during StopAsync.
- Treats disposal during shutdown as cancellation instead of a readiness warmup failure.
- Updates warmup unit test setup for the new host lifetime dependency.

## Related Issue(s)

- #3965 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added 

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
