### PR TITLE
ci: persist at23 SHA watermark so failed deploys does not orphan PRs

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -109,15 +109,49 @@ jobs:
       version: ${{ needs.get-current-version.outputs.version }}-${{ needs.generate-git-short-sha.outputs.gitShortSha }}
       runMigration: true
 
+  get-previous-deployed-sha:
+    name: Get previous deployed SHA for test
+    runs-on: ubuntu-latest
+    environment: test
+    if: ${{ github.event_name == 'push' }}
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Resolve watermark
+        id: resolve
+        env:
+          STORED_SHA: ${{ vars.LATEST_DEPLOYED_SHA }}
+          FALLBACK_SHA: ${{ github.event.before }}
+        run: |
+          if [[ -n "$STORED_SHA" ]]; then
+            echo "Using stored watermark: $STORED_SHA"
+            echo "sha=$STORED_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "No stored watermark; falling back to github.event.before: $FALLBACK_SHA"
+            echo "sha=$FALLBACK_SHA" >> "$GITHUB_OUTPUT"
+          fi
+
   tag-issues-with-environment:
     name: Tag deployed PRs and issues for test
-    needs: [ deploy-apps, deploy-infra ]
+    needs: [ deploy-apps, deploy-infra, get-previous-deployed-sha ]
     if: ${{ always() && !failure() && !cancelled() && github.event_name == 'push' && (needs.deploy-apps.outputs.deployment_executed == 'true' || needs.deploy-infra.outputs.deployment_executed == 'true') }}
     uses: ./.github/workflows/workflow-tag-issues-with-environment.yml
     with:
       environment-label: at23
-      from-sha: ${{ github.event.before }}
+      from-sha: ${{ needs.get-previous-deployed-sha.outputs.sha }}
       to-sha: ${{ github.sha }}
+
+  store-latest-deployed-sha:
+    name: Store latest deployed SHA for test
+    needs: [ tag-issues-with-environment ]
+    if: ${{ always() && !failure() && !cancelled() && needs.tag-issues-with-environment.result == 'success' }}
+    uses: ./.github/workflows/workflow-store-github-env-variable.yml
+    with:
+      variable_name: LATEST_DEPLOYED_SHA
+      variable_value: ${{ github.sha }}
+      environment: test
+    secrets:
+      GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
 
   generate-timestamp:
     name: Generate timestamp
@@ -216,7 +250,9 @@ jobs:
     needs: [
       deploy-infra,
       deploy-apps,
+      get-previous-deployed-sha,
       tag-issues-with-environment,
+      store-latest-deployed-sha,
       run-e2e-tests,
       run-graphql-e2e-tests,
       run-webapi-e2e-tests,


### PR DESCRIPTION
## Summary
- Previously, `ci-cd-main.yml` tagged PRs/issues with `at23` using the push event's commit range (`github.event.before...github.sha`). When a deploy failed, the next successful push advanced the range past the orphaned commits, silently dropping those PRs from being labeled.
- This change persists `LATEST_DEPLOYED_SHA` in the `test` GitHub environment and only advances it after a successful deploy **and** successful tagging. Failed runs leave the watermark behind so the next green run sweeps up the orphans.
- Re-labeling already-labeled PRs is a no-op on GitHub's side (no duplicate, no `labeled` webhook fired), so overlapping ranges are safe.

## How it works
1. `get-previous-deployed-sha` job reads `vars.LATEST_DEPLOYED_SHA` from the `test` environment, falling back to `github.event.before` on first run.
2. `tag-issues-with-environment` uses that SHA as `from-sha` instead of `github.event.before`.
3. `store-latest-deployed-sha` advances `LATEST_DEPLOYED_SHA` to `github.sha` only after tagging succeeds (via the existing `workflow-store-github-env-variable.yml`).

## Before merging
- **Seed the variable** in Settings → Environments → `test` → Variables: set `LATEST_DEPLOYED_SHA` to a current (or slightly older, if you want to retro-tag) main SHA. Without seeding, the first run after merge behaves like today (falls back to `github.event.before`) — safe, just no benefit until the second run.
- Note: `RELEASE_VERSION_STORAGE_PAT` is reused (same PAT already used for staging/yt01/prod version stores).

## Follow-up (not in this PR)
Same orphan problem theoretically applies to `tt02` / `yt01` / `prod`, but those already store `LATEST_DEPLOYED_APPS_VERSION` and use release-body parsing. Will address in a separate PR once at23 has been observed.

## Test plan
- [x] Seed `LATEST_DEPLOYED_SHA` in the `test` env to current `main` HEAD before merging
- [ ] After merge, observe the first push: `get-previous-deployed-sha` should report "Using stored watermark"
- [ ] Confirm `tag-issues-with-environment` runs and labels the expected PRs
- [ ] Confirm `store-latest-deployed-sha` advances the variable to the new HEAD
- [ ] Simulate a failed deploy (or wait for a real one) and verify the watermark stays put, then the next green run picks up the orphaned PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)