### PR TITLE
fix: stabilize activity search ordering

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchActivities/SearchActivityQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchActivities/SearchActivityQuery.cs
@@ -78,6 +78,10 @@ internal sealed class SearchActivityQueryHandler : IRequestHandler<SearchActivit
 
         dialog.FilterLocalizations(request.AcceptedLanguages);
 
-        return dialog.Activities.Select(x => x.ToDto()).ToList();
+        return dialog.Activities
+            .OrderBy(x => x.CreatedAt)
+            .ThenBy(x => x.Id)
+            .Select(x => x.ToDto())
+            .ToList();
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/SearchActivities/SearchActivityQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/SearchActivities/SearchActivityQuery.cs
@@ -58,6 +58,8 @@ internal sealed class SearchActivityQueryHandler : IRequestHandler<SearchActivit
         }
 
         return dialog.Activities
+            .OrderBy(x => x.CreatedAt)
+            .ThenBy(x => x.Id)
             .Select(x => x.ToDto())
             .ToList();
     }


### PR DESCRIPTION
## Description

Stabilizes end-user and service-owner activity search responses by ordering activities by `CreatedAt` then `Id` ascending before DTO mapping. This prevents PostgreSQL/EF navigation load order from flipping snapshots when the database chooses a different index scan order.

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings (build passed; existing warnings remain)
- [x] Manual testing done (required): `scripts/e2e/run-webapi-e2e.zsh webapi`
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)