### PR TITLE
trivial(infra): Bump prod Redis SKU to C2 Standard

### DIFF
--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -127,7 +127,7 @@ param deployerPrincipalName = 'GitHub: altinn/dialogporten - Prod'
 param redisSku = {
   name: 'Standard'
   family: 'C'
-  capacity: 1
+  capacity: 2
 }
 
 param serviceBusSku = {


### PR DESCRIPTION
## Summary
- Updates `prod.bicepparam` Redis capacity from 1 (C1) to 2 (C2) on the Standard tier.
- The scale-up itself is performed manually during tonight's scheduled maintenance window. This PR exists so IaC matches the new live state and the next prod deploy does not revert the cache back to C1.
- No other environments changed.

## Rollout order
1. Merge this PR before the maintenance window so main reflects the target state.
2. **Hold any prod deploy** between merge and the manual scale. If a prod deploy runs first, it will trigger the C1 -> C2 scale itself (outside the maintenance window).
3. Perform the manual C1 -> C2 scale during the maintenance window.
4. Allow prod deploys to resume; the next one should be a no-op on the Redis resource.

## Test plan
- [ ] Merged before the maintenance window starts.
- [ ] No prod deploy triggered between merge and manual scale.
- [ ] Manual scale C1 -> C2 completed in the Azure portal.
- [ ] First prod deploy after the scale shows no change to the Redis resource (IaC == live state).
- [ ] Spot-check Redis memory/CPU/connection metrics in Grafana post-maintenance.