### PR TITLE
trivial(infra): Add daily Key Vault secret expiry alert workflow

### DIFF
--- a/.github/keyvault-expiry-monitored-secrets.yml
+++ b/.github/keyvault-expiry-monitored-secrets.yml
@@ -1,0 +1,9 @@
+# Secrets listed here MUST have `attributes.expires` set in every environment's Key Vault.
+# A missing expiry on a monitored secret triggers a configuration-error Slack alert.
+# Add an entry when introducing a new rotatable credential (JWK, cert, vendor API key, etc.).
+#
+# This list does NOT control which secrets are checked for upcoming expiry — every secret
+# with `attributes.expires` set is checked. This list only flags secrets where a missing
+# expiry would itself be a problem.
+required_expires:
+  - Infrastructure--Maskinporten--EncodedJwk

--- a/.github/scripts/check-keyvault-expiry.py
+++ b/.github/scripts/check-keyvault-expiry.py
@@ -291,6 +291,13 @@ def render_step_summary(
 
 
 def main() -> int:
+    if not EXPECTED_ENVS:
+        raise RuntimeError(
+            "EXPECTED_ENVS_JSON is empty. The workflow's prepare job is supposed to "
+            "populate it with the envs to check; an empty list would silently "
+            "succeed with zero findings."
+        )
+
     expiry_findings, missing, present_envs = collect_findings()
     missing_envs = sorted(set(EXPECTED_ENVS) - set(present_envs))
 

--- a/.github/scripts/check-keyvault-expiry.py
+++ b/.github/scripts/check-keyvault-expiry.py
@@ -37,6 +37,7 @@ MONITORED_FILE = pathlib.Path(os.environ["MONITORED_SECRETS_FILE"])
 SECRETS_DIR = pathlib.Path(os.environ["SECRETS_DIR"])
 RUN_URL = os.environ.get("GITHUB_RUN_URL", "")
 RUNBOOK_URL = os.environ.get("RUNBOOK_URL", "")
+EXPECTED_ENVS = json.loads(os.environ.get("EXPECTED_ENVS_JSON", "[]"))
 STEP_SUMMARY = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
 STEP_OUTPUT = pathlib.Path(os.environ["GITHUB_OUTPUT"])
 
@@ -73,14 +74,18 @@ def tier_icon(tier: int) -> str:
 
 
 def load_monitored() -> set[str]:
-    if not MONITORED_FILE.exists():
-        return set()
     data = yaml.safe_load(MONITORED_FILE.read_text()) or {}
     return set(data.get("required_expires", []) or [])
 
 
 def collect_findings() -> tuple[list[dict], list[dict], list[str]]:
-    """Returns (expiry_findings, missing_findings, env_list)."""
+    """Returns (expiry_findings, missing_findings, present_envs).
+
+    `present_envs` is the list of envs whose `secrets-<env>.json` was actually
+    present in $SECRETS_DIR — distinct from $EXPECTED_ENVS_JSON, which is what
+    the prepare job said we should check. The difference is the set of envs
+    whose matrix leg failed to upload its artifact.
+    """
     monitored = load_monitored()
     today = datetime.now(timezone.utc).date()
 
@@ -124,11 +129,29 @@ def collect_findings() -> tuple[list[dict], list[dict], list[str]]:
     return expiry_findings, missing_findings, envs
 
 
-def build_blocks(alerted: list[dict], missing: list[dict], header_suffix: str = "") -> list[dict]:
+def build_blocks(
+    alerted: list[dict],
+    missing: list[dict],
+    missing_envs: list[str],
+    header_suffix: str = "",
+) -> list[dict]:
     blocks: list[dict] = [{
         "type": "header",
         "text": {"type": "plain_text", "text": f"Key Vault secret expiry{header_suffix}"},
     }]
+
+    if missing_envs:
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    ":rotating_light: *Data unavailable for: "
+                    f"{', '.join(missing_envs)}* — the matrix leg(s) for these envs failed. "
+                    "Findings below reflect only the envs that were checked successfully."
+                ),
+            },
+        })
 
     if alerted:
         rows = []
@@ -179,18 +202,23 @@ def build_blocks(alerted: list[dict], missing: list[dict], header_suffix: str = 
     return blocks
 
 
-def mention_for(alerted: list[dict], missing: list[dict]) -> str:
+def mention_for(alerted: list[dict], missing: list[dict], missing_envs: list[str]) -> str:
     tiers = {f["tier"] for f in alerted}
     if 3 in tiers:
         return "<!channel>"
-    if 2 in tiers or missing:
+    if 2 in tiers or missing or missing_envs:
         return "<!here>"
     return ""
 
 
-def build_payload(alerted: list[dict], missing: list[dict], header_suffix: str = "") -> dict:
-    blocks = build_blocks(alerted, missing, header_suffix=header_suffix)
-    mention = mention_for(alerted, missing)
+def build_payload(
+    alerted: list[dict],
+    missing: list[dict],
+    missing_envs: list[str],
+    header_suffix: str = "",
+) -> dict:
+    blocks = build_blocks(alerted, missing, missing_envs, header_suffix=header_suffix)
+    mention = mention_for(alerted, missing, missing_envs)
     if mention:
         blocks.insert(1, {
             "type": "section",
@@ -207,10 +235,20 @@ def write_payload(path: str, payload: dict) -> None:
     pathlib.Path(path).write_text(json.dumps(payload, indent=2))
 
 
-def render_step_summary(expiry_findings: list[dict], missing: list[dict], envs: list[str]) -> str:
+def render_step_summary(
+    expiry_findings: list[dict],
+    missing: list[dict],
+    present_envs: list[str],
+    missing_envs: list[str],
+) -> str:
     lines: list[str] = []
     lines.append("# Key Vault secret expiry — daily check\n")
-    lines.append(f"Checked envs: {', '.join(envs) if envs else '(none)'}\n")
+    lines.append(f"Checked envs: {', '.join(present_envs) if present_envs else '(none)'}\n")
+    if missing_envs:
+        lines.append(
+            f":rotating_light: **Data unavailable for: {', '.join(missing_envs)}** "
+            "— matrix leg(s) for these envs failed; rerun or check workflow logs.\n"
+        )
     if RUNBOOK_URL:
         lines.append(f"Rotation runbook: {RUNBOOK_URL}\n")
 
@@ -253,7 +291,8 @@ def render_step_summary(expiry_findings: list[dict], missing: list[dict], envs: 
 
 
 def main() -> int:
-    expiry_findings, missing, envs = collect_findings()
+    expiry_findings, missing, present_envs = collect_findings()
+    missing_envs = sorted(set(EXPECTED_ENVS) - set(present_envs))
 
     alerted = [f for f in expiry_findings if f["tier"] is not None]
 
@@ -266,23 +305,40 @@ def main() -> int:
     nonprod_missing = [m for m in missing if not is_prod(m["env"])]
     prod_missing = [m for m in missing if is_prod(m["env"])]
 
-    if nonprod_alerted or nonprod_missing:
-        write_payload("slack-nonprod.json", build_payload(nonprod_alerted, nonprod_missing, header_suffix=" alert (non-prod)"))
-    if prod_alerted or prod_missing:
-        write_payload("slack-prod.json", build_payload(prod_alerted, prod_missing, header_suffix=" alert (prod)"))
+    nonprod_missing_envs = [e for e in missing_envs if not is_prod(e)]
+    prod_missing_envs = [e for e in missing_envs if is_prod(e)]
+
+    if nonprod_alerted or nonprod_missing or nonprod_missing_envs:
+        write_payload(
+            "slack-nonprod.json",
+            build_payload(nonprod_alerted, nonprod_missing, nonprod_missing_envs,
+                          header_suffix=" alert (non-prod)"),
+        )
+    if prod_alerted or prod_missing or prod_missing_envs:
+        write_payload(
+            "slack-prod.json",
+            build_payload(prod_alerted, prod_missing, prod_missing_envs,
+                          header_suffix=" alert (prod)"),
+        )
     if prod_tier3:
-        write_payload("slack-prod-critical.json", build_payload(prod_tier3, [], header_suffix=" — PROD CRITICAL"))
+        write_payload(
+            "slack-prod-critical.json",
+            build_payload(prod_tier3, [], [], header_suffix=" — PROD CRITICAL"),
+        )
 
-    STEP_SUMMARY.write_text(render_step_summary(expiry_findings, missing, envs))
+    STEP_SUMMARY.write_text(render_step_summary(expiry_findings, missing, present_envs, missing_envs))
 
-    any_rule_tripped = bool(alerted or missing)
+    any_rule_tripped = bool(alerted or missing or missing_envs)
     with STEP_OUTPUT.open("a") as out:
         out.write(f"any_rule_tripped={'true' if any_rule_tripped else 'false'}\n")
-        out.write(f"have_nonprod_payload={'true' if (nonprod_alerted or nonprod_missing) else 'false'}\n")
-        out.write(f"have_prod_payload={'true' if (prod_alerted or prod_missing) else 'false'}\n")
+        out.write(f"have_nonprod_payload={'true' if (nonprod_alerted or nonprod_missing or nonprod_missing_envs) else 'false'}\n")
+        out.write(f"have_prod_payload={'true' if (prod_alerted or prod_missing or prod_missing_envs) else 'false'}\n")
         out.write(f"have_prod_critical_payload={'true' if prod_tier3 else 'false'}\n")
 
-    print(f"Findings: {len(alerted)} expiring, {len(missing)} configuration issues across envs {envs}")
+    print(
+        f"Findings: {len(alerted)} expiring, {len(missing)} configuration issues "
+        f"across present envs {present_envs}; missing envs: {missing_envs}"
+    )
     return 0
 
 

--- a/.github/scripts/check-keyvault-expiry.py
+++ b/.github/scripts/check-keyvault-expiry.py
@@ -1,0 +1,276 @@
+"""Aggregate Key Vault secret expiry findings across envs, emit Slack payloads and step summary.
+
+Reads:
+  - $MONITORED_SECRETS_FILE: YAML with `required_expires:` list of secret names that MUST have expires set.
+  - $SECRETS_DIR: directory containing one `secrets-<env>.json` per env, each a list of
+      {"name": "...", "expires": "ISO8601 or null"} for every ENABLED secret in that env's KV.
+  - $GITHUB_RUN_URL: link to current workflow run, embedded in Slack messages.
+
+Writes:
+  - slack-nonprod.json / slack-prod.json / slack-prod-critical.json: payloads for the
+    Slack chat.postMessage step (only files for channels that have something to say).
+  - $GITHUB_STEP_SUMMARY: public-facing markdown summary (env + secret name + expires + days,
+    NO vault names).
+  - $GITHUB_OUTPUT: sets `any_rule_tripped=true|false` so the workflow can red-flag the run.
+
+Routing tiers (per finding):
+  - Tier 1: 8 <= days_left <= 30, no mention
+  - Tier 2: 2 <= days_left <= 7, @here
+  - Tier 3: days_left <= 1 (incl. expired), @channel; for prod, also cross-posts to the
+    prod-critical channel
+Configuration-error findings (a monitored secret missing or without expires) post at
+the @here level with no tier escalation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+import yaml
+
+
+MONITORED_FILE = pathlib.Path(os.environ["MONITORED_SECRETS_FILE"])
+SECRETS_DIR = pathlib.Path(os.environ["SECRETS_DIR"])
+RUN_URL = os.environ.get("GITHUB_RUN_URL", "")
+STEP_SUMMARY = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
+STEP_OUTPUT = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+
+CHANNEL_PLACEHOLDER = "${{ env.CHANNEL_ID }}"  # filled in by slack-github-action's payload-templated
+
+PROD_ENV = "prod"
+
+
+def parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def classify_tier(days_left: int) -> int | None:
+    if days_left <= 1:
+        return 3
+    if days_left <= 7:
+        return 2
+    if days_left <= 30:
+        return 1
+    return None
+
+
+def days_phrase(days: int) -> str:
+    if days < 0:
+        n = abs(days)
+        return f"expired {n} day{'s' if n != 1 else ''} ago"
+    if days == 0:
+        return "expires today"
+    return f"{days} day{'s' if days != 1 else ''} left"
+
+
+def tier_icon(tier: int) -> str:
+    return {1: ":large_yellow_circle:", 2: ":large_orange_diamond:", 3: ":red_circle:"}[tier]
+
+
+def load_monitored() -> set[str]:
+    if not MONITORED_FILE.exists():
+        return set()
+    data = yaml.safe_load(MONITORED_FILE.read_text()) or {}
+    return set(data.get("required_expires", []) or [])
+
+
+def collect_findings() -> tuple[list[dict], list[dict], list[str]]:
+    """Returns (expiry_findings, missing_findings, env_list)."""
+    monitored = load_monitored()
+    today = datetime.now(timezone.utc).date()
+
+    expiry_findings: list[dict] = []
+    missing_findings: list[dict] = []
+    envs: list[str] = []
+
+    for f in sorted(SECRETS_DIR.glob("secrets-*.json")):
+        env_name = f.stem[len("secrets-"):]
+        envs.append(env_name)
+        secrets = json.loads(f.read_text())
+        by_name = {s["name"]: s for s in secrets}
+
+        for s in secrets:
+            if not s.get("expires"):
+                continue
+            days = (parse_iso(s["expires"]).date() - today).days
+            tier = classify_tier(days)
+            expiry_findings.append({
+                "env": env_name,
+                "name": s["name"],
+                "expires": s["expires"],
+                "days": days,
+                "tier": tier,
+            })
+
+        for required_name in sorted(monitored):
+            if required_name not in by_name:
+                missing_findings.append({
+                    "env": env_name,
+                    "name": required_name,
+                    "state": "absent",
+                })
+            elif not by_name[required_name].get("expires"):
+                missing_findings.append({
+                    "env": env_name,
+                    "name": required_name,
+                    "state": "no-expires",
+                })
+
+    return expiry_findings, missing_findings, envs
+
+
+def build_blocks(alerted: list[dict], missing: list[dict], header_suffix: str = "") -> list[dict]:
+    blocks: list[dict] = [{
+        "type": "header",
+        "text": {"type": "plain_text", "text": f"Key Vault secret expiry{header_suffix}"},
+    }]
+
+    if alerted:
+        rows = []
+        for f in sorted(alerted, key=lambda x: (x["days"], x["env"], x["name"])):
+            rows.append(
+                f"{tier_icon(f['tier'])} *{f['env']}* `{f['name']}` "
+                f"— {days_phrase(f['days'])} (expires {f['expires'][:10]})"
+            )
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "*Expiring soon:*\n" + "\n".join(rows)},
+        })
+
+    if missing:
+        rows = []
+        for m in sorted(missing, key=lambda x: (x["env"], x["name"])):
+            detail = (
+                "no `attributes.expires` set"
+                if m["state"] == "no-expires"
+                else "secret not found in Key Vault"
+            )
+            rows.append(f":warning: *{m['env']}* `{m['name']}` — {detail}")
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Monitored secrets with configuration issues:*\n" + "\n".join(rows),
+            },
+        })
+
+    if RUN_URL:
+        blocks.append({
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": f"<{RUN_URL}|View workflow run>"}],
+        })
+
+    return blocks
+
+
+def mention_for(alerted: list[dict], missing: list[dict]) -> str:
+    tiers = {f["tier"] for f in alerted}
+    if 3 in tiers:
+        return "<!channel>"
+    if 2 in tiers or missing:
+        return "<!here>"
+    return ""
+
+
+def build_payload(alerted: list[dict], missing: list[dict], header_suffix: str = "") -> dict:
+    blocks = build_blocks(alerted, missing, header_suffix=header_suffix)
+    mention = mention_for(alerted, missing)
+    if mention:
+        blocks.insert(1, {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": mention},
+        })
+    return {
+        "channel": CHANNEL_PLACEHOLDER,
+        "text": f"Key Vault secret expiry{header_suffix or ' alert'}",
+        "blocks": blocks,
+    }
+
+
+def write_payload(path: str, payload: dict) -> None:
+    pathlib.Path(path).write_text(json.dumps(payload, indent=2))
+
+
+def render_step_summary(expiry_findings: list[dict], missing: list[dict], envs: list[str]) -> str:
+    lines: list[str] = []
+    lines.append("# Key Vault secret expiry — daily check\n")
+    lines.append(f"Checked envs: {', '.join(envs) if envs else '(none)'}\n")
+
+    with_expires = [f for f in expiry_findings if f["expires"]]
+    lines.append("## Secrets with `attributes.expires` set\n")
+    if not with_expires:
+        lines.append("_None found._\n")
+    else:
+        lines.append("| Env | Secret | Expires (UTC) | Days left | Status |")
+        lines.append("|---|---|---|---|---|")
+        for f in sorted(with_expires, key=lambda x: (x["days"], x["env"], x["name"])):
+            status = ""
+            if f["tier"] == 3:
+                status = ":red_circle: critical"
+            elif f["tier"] == 2:
+                status = ":large_orange_diamond: warning"
+            elif f["tier"] == 1:
+                status = ":large_yellow_circle: heads-up"
+            lines.append(
+                f"| {f['env']} | `{f['name']}` | {f['expires'][:10]} | {f['days']} | {status} |"
+            )
+        lines.append("")
+
+    lines.append("## Monitored secrets with configuration issues\n")
+    if not missing:
+        lines.append("_None._\n")
+    else:
+        lines.append("| Env | Secret | Issue |")
+        lines.append("|---|---|---|")
+        for m in sorted(missing, key=lambda x: (x["env"], x["name"])):
+            issue = (
+                "Missing `attributes.expires`"
+                if m["state"] == "no-expires"
+                else "Secret not present in Key Vault"
+            )
+            lines.append(f"| {m['env']} | `{m['name']}` | {issue} |")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    expiry_findings, missing, envs = collect_findings()
+
+    alerted = [f for f in expiry_findings if f["tier"] is not None]
+
+    def is_prod(env: str) -> bool:
+        return env == PROD_ENV
+
+    nonprod_alerted = [f for f in alerted if not is_prod(f["env"])]
+    prod_alerted = [f for f in alerted if is_prod(f["env"])]
+    prod_tier3 = [f for f in prod_alerted if f["tier"] == 3]
+    nonprod_missing = [m for m in missing if not is_prod(m["env"])]
+    prod_missing = [m for m in missing if is_prod(m["env"])]
+
+    if nonprod_alerted or nonprod_missing:
+        write_payload("slack-nonprod.json", build_payload(nonprod_alerted, nonprod_missing, header_suffix=" alert (non-prod)"))
+    if prod_alerted or prod_missing:
+        write_payload("slack-prod.json", build_payload(prod_alerted, prod_missing, header_suffix=" alert (prod)"))
+    if prod_tier3:
+        write_payload("slack-prod-critical.json", build_payload(prod_tier3, [], header_suffix=" — PROD CRITICAL"))
+
+    STEP_SUMMARY.write_text(render_step_summary(expiry_findings, missing, envs))
+
+    any_rule_tripped = bool(alerted or missing)
+    with STEP_OUTPUT.open("a") as out:
+        out.write(f"any_rule_tripped={'true' if any_rule_tripped else 'false'}\n")
+        out.write(f"have_nonprod_payload={'true' if (nonprod_alerted or nonprod_missing) else 'false'}\n")
+        out.write(f"have_prod_payload={'true' if (prod_alerted or prod_missing) else 'false'}\n")
+        out.write(f"have_prod_critical_payload={'true' if prod_tier3 else 'false'}\n")
+
+    print(f"Findings: {len(alerted)} expiring, {len(missing)} configuration issues across envs {envs}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-keyvault-expiry.py
+++ b/.github/scripts/check-keyvault-expiry.py
@@ -36,6 +36,7 @@ import yaml
 MONITORED_FILE = pathlib.Path(os.environ["MONITORED_SECRETS_FILE"])
 SECRETS_DIR = pathlib.Path(os.environ["SECRETS_DIR"])
 RUN_URL = os.environ.get("GITHUB_RUN_URL", "")
+RUNBOOK_URL = os.environ.get("RUNBOOK_URL", "")
 STEP_SUMMARY = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
 STEP_OUTPUT = pathlib.Path(os.environ["GITHUB_OUTPUT"])
 
@@ -158,6 +159,17 @@ def build_blocks(alerted: list[dict], missing: list[dict], header_suffix: str = 
             },
         })
 
+    if RUNBOOK_URL:
+        blocks.append({
+            "type": "actions",
+            "elements": [{
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Open rotation runbook"},
+                "url": RUNBOOK_URL,
+                "style": "primary",
+            }],
+        })
+
     if RUN_URL:
         blocks.append({
             "type": "context",
@@ -199,6 +211,8 @@ def render_step_summary(expiry_findings: list[dict], missing: list[dict], envs: 
     lines: list[str] = []
     lines.append("# Key Vault secret expiry — daily check\n")
     lines.append(f"Checked envs: {', '.join(envs) if envs else '(none)'}\n")
+    if RUNBOOK_URL:
+        lines.append(f"Rotation runbook: {RUNBOOK_URL}\n")
 
     with_expires = [f for f in expiry_findings if f["expires"]]
     lines.append("## Secrets with `attributes.expires` set\n")

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,0 +1,13 @@
+# Locked dependencies for .github/scripts/check-keyvault-expiry.py.
+# Used with `pip install --require-hashes -r requirements.txt` so a compromised
+# PyPI cannot substitute a different wheel for the same version.
+#
+# Hashes cover linux x86_64 manylinux wheels for CPython 3.10 - 3.13 (the
+# runtimes likely to be present on github-hosted ubuntu-latest). Sdist is
+# intentionally excluded because the workflow uses --only-binary :all:.
+# To regenerate: curl -s https://pypi.org/pypi/pyyaml/<ver>/json | jq '.urls'
+pyyaml==6.0.2 \
+    --hash=sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed \
+    --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85 \
+    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+    --hash=sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5

--- a/.github/workflows/check-keyvault-secret-expiry.yml
+++ b/.github/workflows/check-keyvault-secret-expiry.yml
@@ -132,6 +132,7 @@ jobs:
           MONITORED_SECRETS_FILE: .github/keyvault-expiry-monitored-secrets.yml
           SECRETS_DIR: secrets-by-env
           GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUNBOOK_URL: https://digdir.atlassian.net/wiki/x/QIDDAgE
         run: python3 .github/scripts/check-keyvault-expiry.py
 
       - name: Post Slack alert to non-prod channel

--- a/.github/workflows/check-keyvault-secret-expiry.yml
+++ b/.github/workflows/check-keyvault-secret-expiry.yml
@@ -19,13 +19,12 @@ on:
         default: 'test,yt01,staging,prod'
         type: string
 
-permissions:
-  contents: read
-
 jobs:
   prepare:
     name: Prepare env list
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       envs: ${{ steps.parse.outputs.envs }}
     steps:
@@ -124,7 +123,8 @@ jobs:
           merge-multiple: true
 
       - name: Install PyYAML
-        run: pip install --quiet pyyaml
+        run: |
+          pip install --quiet --only-binary :all: pyyaml==6.0.2
 
       - name: Compute alerts and step summary
         id: compute

--- a/.github/workflows/check-keyvault-secret-expiry.yml
+++ b/.github/workflows/check-keyvault-secret-expiry.yml
@@ -105,8 +105,11 @@ jobs:
           fi
           VAULT=$(jq -r '.[0]' <<<"$VAULTS_JSON")
           echo "Found vault $VAULT in $RG"
+          # --include-managed covers secrets that back Key Vault certificates;
+          # without it those secrets are silently excluded from the listing.
           az keyvault secret list \
             --vault-name "$VAULT" \
+            --include-managed true \
             --query "[?attributes.enabled].{name:name, expires:attributes.expires}" \
             -o json > "secrets-${ENVIRONMENT}.json"
           COUNT=$(jq length "secrets-${ENVIRONMENT}.json")

--- a/.github/workflows/check-keyvault-secret-expiry.yml
+++ b/.github/workflows/check-keyvault-secret-expiry.yml
@@ -37,10 +37,21 @@ jobs:
           INPUT_RAW: ${{ inputs.environments || 'test,yt01,staging,prod' }}
         run: |
           set -euo pipefail
+          ALLOWED='["test","yt01","staging","prod"]'
           ENVS=$(printf '%s' "$INPUT_RAW" \
-            | jq -Rnc 'inputs | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')
+            | jq -Rnc 'inputs
+                | split(",")
+                | map(ascii_downcase | gsub("^\\s+|\\s+$"; ""))
+                | map(select(length > 0))
+                | unique')
           if [ "$ENVS" = "[]" ] || [ -z "$ENVS" ]; then
             echo "::error::No environments to check (input was: '$INPUT_RAW')"
+            exit 1
+          fi
+          INVALID=$(jq -rc --argjson allowed "$ALLOWED" \
+            '[.[] | select(($allowed | index(.)) == null)]' <<<"$ENVS")
+          if [ "$INVALID" != "[]" ]; then
+            echo "::error::Invalid env(s): $INVALID. Allowed: $ALLOWED"
             exit 1
           fi
           echo "envs=$ENVS" >> "$GITHUB_OUTPUT"
@@ -65,6 +76,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Azure login
         uses: ./.github/actions/azure-login
@@ -79,11 +92,18 @@ jobs:
         run: |
           set -euo pipefail
           RG="dp-be-${ENVIRONMENT}-rg"
-          VAULT=$(az keyvault list -g "$RG" --query "[0].name" -o tsv)
-          if [ -z "$VAULT" ]; then
+          VAULTS_JSON=$(az keyvault list -g "$RG" --query "[].name" -o json)
+          VAULT_COUNT=$(jq 'length' <<<"$VAULTS_JSON")
+          if [ "$VAULT_COUNT" -eq 0 ]; then
             echo "::error::No Key Vault found in resource group $RG"
             exit 1
           fi
+          if [ "$VAULT_COUNT" -gt 1 ]; then
+            NAMES=$(jq -r 'join(", ")' <<<"$VAULTS_JSON")
+            echo "::error::Expected exactly one Key Vault in $RG, found $VAULT_COUNT: $NAMES"
+            exit 1
+          fi
+          VAULT=$(jq -r '.[0]' <<<"$VAULTS_JSON")
           echo "Found vault $VAULT in $RG"
           az keyvault secret list \
             --vault-name "$VAULT" \
@@ -103,7 +123,11 @@ jobs:
 
   aggregate:
     name: Aggregate findings and alert
-    needs: list-secrets
+    needs: [prepare, list-secrets]
+    # Run even when one or more matrix legs fail, so healthy envs still get
+    # alerts and the step summary surfaces which envs were skipped. Skip only
+    # if the workflow was cancelled.
+    if: ${{ !cancelled() && needs.prepare.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -114,6 +138,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download per-env secrets JSON
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -131,6 +157,7 @@ jobs:
         env:
           MONITORED_SECRETS_FILE: .github/keyvault-expiry-monitored-secrets.yml
           SECRETS_DIR: secrets-by-env
+          EXPECTED_ENVS_JSON: ${{ needs.prepare.outputs.envs }}
           GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUNBOOK_URL: https://digdir.atlassian.net/wiki/x/QIDDAgE
         run: python3 .github/scripts/check-keyvault-expiry.py
@@ -171,5 +198,5 @@ jobs:
       - name: Fail run if any rule was tripped
         if: steps.compute.outputs.any_rule_tripped == 'true'
         run: |
-          echo "::warning::One or more secrets are approaching expiry or missing required expiry metadata. See step summary."
+          echo "::warning::Found expiring secrets, missing required expiry metadata, or one or more matrix legs failed. See step summary."
           exit 1

--- a/.github/workflows/check-keyvault-secret-expiry.yml
+++ b/.github/workflows/check-keyvault-secret-expiry.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Install PyYAML
         run: |
-          pip install --quiet --only-binary :all: pyyaml==6.0.2
+          pip install --quiet --require-hashes --only-binary :all: -r .github/scripts/requirements.txt
 
       - name: Compute alerts and step summary
         id: compute

--- a/.github/workflows/check-keyvault-secret-expiry.yml
+++ b/.github/workflows/check-keyvault-secret-expiry.yml
@@ -1,0 +1,174 @@
+name: Check Key Vault secret expiry
+
+# Daily check that any Key Vault secret with `attributes.expires` set isn't about to
+# expire. Routes findings to env-tier Slack channels. See:
+#   - .github/scripts/check-keyvault-expiry.py for the rule logic
+#   - .github/keyvault-expiry-monitored-secrets.yml for the missing-expires allow-list
+
+on:
+  schedule:
+    # 07:00 UTC -> 08:00 Oslo in winter (CET), 09:00 Oslo in summer (CEST).
+    # GitHub Actions cron is UTC-only, so we accept the DST drift; either time
+    # lands at the start of a Norwegian workday.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      environments:
+        description: "Comma-separated envs (any of: test, yt01, staging, prod). Default: all."
+        required: false
+        default: 'test,yt01,staging,prod'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Prepare env list
+    runs-on: ubuntu-latest
+    outputs:
+      envs: ${{ steps.parse.outputs.envs }}
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - id: parse
+        env:
+          INPUT_RAW: ${{ inputs.environments || 'test,yt01,staging,prod' }}
+        run: |
+          set -euo pipefail
+          ENVS=$(printf '%s' "$INPUT_RAW" \
+            | jq -Rnc 'inputs | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')
+          if [ "$ENVS" = "[]" ] || [ -z "$ENVS" ]; then
+            echo "::error::No environments to check (input was: '$INPUT_RAW')"
+            exit 1
+          fi
+          echo "envs=$ENVS" >> "$GITHUB_OUTPUT"
+          echo "Will check envs: $ENVS"
+
+  list-secrets:
+    name: List secrets (${{ matrix.environment }})
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJson(needs.prepare.outputs.envs) }}
+    environment: ${{ matrix.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Azure login
+        uses: ./.github/actions/azure-login
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: List secrets with metadata
+        env:
+          ENVIRONMENT: ${{ matrix.environment }}
+        run: |
+          set -euo pipefail
+          RG="dp-be-${ENVIRONMENT}-rg"
+          VAULT=$(az keyvault list -g "$RG" --query "[0].name" -o tsv)
+          if [ -z "$VAULT" ]; then
+            echo "::error::No Key Vault found in resource group $RG"
+            exit 1
+          fi
+          echo "Found vault $VAULT in $RG"
+          az keyvault secret list \
+            --vault-name "$VAULT" \
+            --query "[?attributes.enabled].{name:name, expires:attributes.expires}" \
+            -o json > "secrets-${ENVIRONMENT}.json"
+          COUNT=$(jq length "secrets-${ENVIRONMENT}.json")
+          WITH_EXPIRES=$(jq '[.[] | select(.expires != null)] | length' "secrets-${ENVIRONMENT}.json")
+          echo "Enabled secrets: $COUNT (with expires set: $WITH_EXPIRES)"
+
+      - name: Upload secrets JSON
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: secrets-${{ matrix.environment }}
+          path: secrets-${{ matrix.environment }}.json
+          retention-days: 1
+          if-no-files-found: error
+
+  aggregate:
+    name: Aggregate findings and alert
+    needs: list-secrets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download per-env secrets JSON
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: secrets-by-env
+          pattern: secrets-*
+          merge-multiple: true
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      - name: Compute alerts and step summary
+        id: compute
+        env:
+          MONITORED_SECRETS_FILE: .github/keyvault-expiry-monitored-secrets.yml
+          SECRETS_DIR: secrets-by-env
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: python3 .github/scripts/check-keyvault-expiry.py
+
+      - name: Post Slack alert to non-prod channel
+        if: steps.compute.outputs.have_nonprod_payload == 'true'
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-templated: true
+          payload-file-path: ./slack-nonprod.json
+        env:
+          CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_KEYVAULT_ALERTS }}
+
+      - name: Post Slack alert to prod channel
+        if: steps.compute.outputs.have_prod_payload == 'true'
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-templated: true
+          payload-file-path: ./slack-prod.json
+        env:
+          CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_KEYVAULT_ALERTS_PROD }}
+
+      - name: Post Slack alert to prod-critical channel
+        if: steps.compute.outputs.have_prod_critical_payload == 'true'
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-templated: true
+          payload-file-path: ./slack-prod-critical.json
+        env:
+          CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_KEYVAULT_ALERTS_PROD_CRITICAL }}
+
+      - name: Fail run if any rule was tripped
+        if: steps.compute.outputs.any_rule_tripped == 'true'
+        run: |
+          echo "::warning::One or more secrets are approaching expiry or missing required expiry metadata. See step summary."
+          exit 1


### PR DESCRIPTION
## Summary

- Adds a daily GitHub Actions workflow that checks each env's Key Vault for secrets whose `attributes.expires` is within 30 days, plus a "missing expires" rule for an allow-listed set of monitored secrets
- Routes findings to env-tier Slack channels (`#dialogporten-alerts`, `#dialogporten-alerts-prod`, `#dialogporten-alerts-prod-critical`) with `@here` / `@channel` escalation
- Public step summary lists every secret with an expiry across all envs (vault names omitted) and links to the rotation runbook

## Background

Triggered by the 2026-05-26 staging Maskinporten JWK expiry, which produced 11k+ `invalid_grant` exceptions before being noticed. We had the right convention (`Attributes.Expires` on rotatable secrets) but nothing watched the timestamp. Convention is updated to `Attributes.Expires = real expiry date` and this workflow nags us 30 / 7 / 1 days out. See plan in conversation history for details.

## Prereqs (already done)

- `SLACK_BOT_TOKEN` (existing repo secret, reused — Dialogporten Slack app added to the three target channels)
- `SLACK_CHANNEL_ID_KEYVAULT_ALERTS` → `#dialogporten-alerts`
- `SLACK_CHANNEL_ID_KEYVAULT_ALERTS_PROD` → `#dialogporten-alerts-prod`
- `SLACK_CHANNEL_ID_KEYVAULT_ALERTS_PROD_CRITICAL` → `#dialogporten-alerts-prod-critical`

## Tier routing

| Tier | Trigger | Non-prod | Prod |
|---|---|---|---|
| 1 | 8–30 days left | post, no mention | post, no mention |
| 2 | 2–7 days left | post + `@here` | post + `@here` |
| 3 | ≤1 day left (incl. expired) | post + `@channel` | post + `@channel`, also cross-post to prod-critical |

Missing-expires (allow-listed secret with no `attributes.expires`) posts `@here` regardless of tier.

## Related Issue(s)

- #4009 

## Follow-ups

- After merge, manually dispatch the workflow against `test` first to verify the GH OIDC deployer has Key Vault Reader access. If `az keyvault secret list` 403s, a follow-up PR will add the Bicep role grant module
- Team needs to update `Attributes.Expires` on existing rotatable secrets to the real expiry date (previously was "1 month earlier" by convention)

## Test plan

- [ ] After merge: workflow_dispatch from Actions UI for `test` env only — confirms KV Reader works
- [ ] workflow_dispatch for all four envs — confirm step summary renders without vault names and no spurious findings
- [ ] If the Maskinporten JWK doesn't exist in test/yt01, expect a phantom "missing" alert — tune allow-list if noisy
- [ ] Force-fire an alert by setting a synthetic short-expiry secret in a non-prod KV to verify Slack routing and runbook button (user-driven; agent does not mutate vaults)