### PR TITLE
trivial(infra): bump prod Postgres storage from 10TB to 16TB

### DIFF
--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -48,7 +48,7 @@ param postgresConfiguration = {
     tier: 'MemoryOptimized'
   }
   storage: {
-    storageSizeGB: 10000
+    storageSizeGB: 16000
     type: 'PremiumV2_LRS'
     iops: 24000
     throughput: 1200


### PR DESCRIPTION
## Summary
- Scale prod Postgres storage from 10000 GB to 16000 GB in `prod.bicepparam` to match the manual resize performed tonight.
- Without this change, the next infra deploy would attempt to revert the server back to 10 TB.

## Notes
- Only `prod.bicepparam` is updated; staging, test, and yt01 stay at their current sizes.
- IOPS (24000) and throughput (1200 MB/s) are unchanged. PremiumV2_LRS lets these be tuned independently of size, so we can bump them later if write/IO pressure grows with the larger dataset.
- No application code is affected.

## Test plan
- [ ] CI bicep build/lint passes
- [ ] After merge: confirm the next prod infra deploy is a no-op for storage (server already at 16 TB from tonight's manual resize)