### PR TITLE
trivial(infra): Grant Key Vault Reader to the GH OIDC deployer principal

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -137,6 +137,17 @@ module environmentKeyVault '../modules/keyvault/create.bicep' = {
   }
 }
 
+// Grant the GitHub OIDC deployer principal Key Vault Reader so the
+// check-keyvault-secret-expiry workflow can list secret metadata.
+module keyVaultReaderForDeployer '../modules/keyvault/addKvReaderRoles.bicep' = {
+  scope: resourceGroup
+  name: 'keyVaultReaderForDeployer'
+  params: {
+    keyvaultName: environmentKeyVault.outputs.name
+    principalId: deployer().objectId
+  }
+}
+
 module appConfiguration '../modules/appConfiguration/create.bicep' = {
   scope: resourceGroup
   name: 'appConfiguration'

--- a/.azure/modules/keyvault/addKvReaderRoles.bicep
+++ b/.azure/modules/keyvault/addKvReaderRoles.bicep
@@ -1,0 +1,25 @@
+@description('The name of the Key Vault')
+param keyvaultName string
+
+@description('Principal ID to assign the Key Vault Reader role to')
+param principalId string
+
+resource keyvault 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+  name: keyvaultName
+}
+
+@description('Built-in Key Vault Reader role. Grants management-plane read on the vault including Microsoft.KeyVault/vaults/secrets/readMetadata/action (list secret names + attributes without values), needed by the keyvault-expiry check workflow. See https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/security#key-vault-reader')
+resource keyVaultReaderRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  name: '21090545-7ca7-4776-b22c-e363652d74d2'
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: keyvault
+  name: guid(keyvault.id, principalId, keyVaultReaderRoleDefinition.id)
+  properties: {
+    roleDefinitionId: keyVaultReaderRoleDefinition.id
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new Bicep module `.azure/modules/keyvault/addKvReaderRoles.bicep` that grants the built-in **Key Vault Reader** role (`21090545-7ca7-4776-b22c-e363652d74d2`) to a given principal on the env Key Vault
- Wires it into `.azure/infrastructure/main.bicep` with `deployer().objectId` so each env's GH OIDC federated identity automatically picks itself up at deploy time (same pattern used for the postgres administrator grant)

## Background

PR #4012 shipped the daily `check-keyvault-secret-expiry` workflow. The first dispatched run against `test` returned:

```
ERROR: (Forbidden) Caller is not authorized to perform action on resource.
Caller: appid=***;oid=84805870-1289-4375-9ff7-37cf82fb1419 (= test env's deployer)
Action: 'Microsoft.KeyVault/vaults/secrets/readMetadata/action'
Assignment: (not found)
Inner error: { "code": "ForbiddenByRbac" }
```

The deployer principal had no role on the Key Vault at all. The existing `addReaderRoles.bicep` module grants **Key Vault Secrets User** to container app identities — that role can read secret *values* but not list secret *metadata*. The workflow needs `readMetadata/action`, which is included in the management-plane **Key Vault Reader** role.

This role is metadata-only — no access to secret values.

## Rollout

| Env | Trigger | Notes |
|---|---|---|
| `test` | Opening this PR → `ci-cd-pull-request.yml` | First env where we can verify |
| `staging` | Merge to main → `ci-cd-staging.yml` | Auto |
| `yt01` | Manual `dispatch-infrastructure.yml` | Not part of merge-to-main |
| `prod` | Next release-please tag → `ci-cd-prod.yml` | Auto on release |

## Test plan

- [ ] PR build deploys to test
- [ ] Re-dispatch `Check Key Vault secret expiry` against `test` — `az keyvault secret list` should now succeed and the matrix leg should turn green
- [ ] After merge: same dispatch against `staging` once main-deploy completes
- [ ] Manually dispatch infra for `yt01` and then verify expiry workflow against it
- [ ] After next release: verify prod