### PR TITLE
fix: don't match dates to visibleFrom unless in future

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/DialogEntity.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Dialogs/Entities/DialogEntity.cs
@@ -118,10 +118,9 @@ public sealed class DialogEntity :
     {
         _domainEvents.Add(new DialogCreatedDomainEvent(Id, ServiceResource, Party, Process, PrecedingProcess));
 
-        // We need to set UpdatedAt and CreatedAt to VisibleFrom to simulate it coming into existence at that time.
-        // This makes sure that sorting on UpdatedAt/ContentUpdatedAt works as expected, including
-        // polling on UpdatedSince in the API.
-        if (VisibleFrom is { } visibleFrom)
+        // We only backdate the aggregate when the dialog becomes visible in the future.
+        // Historic dialogs may have VisibleFrom in the past and should keep their actual creation timestamps.
+        if (VisibleFrom is { } visibleFrom && visibleFrom > utcNow)
         {
             UpdatedAt = visibleFrom;
             CreatedAt = visibleFrom;

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogTests.cs
@@ -196,25 +196,49 @@ public class CreateDialogTests : ApplicationCollectionFixture
     }
 
     [Fact]
-    public Task Past_VisibleFrom_Should_Not_Backdate_Timestamps_On_Create()
+    public Task Past_VisibleFrom_Should_Not_Control_Default_Timestamps_On_Create()
     {
-        var fixedUtcNow = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
-        var visibleFrom = fixedUtcNow.AddDays(-3);
+        var utcNow = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+        var visibleFrom = utcNow.AddDays(-7);
 
         return FlowBuilder.For(Application)
-            .OverrideUtc(fixedUtcNow)
+            .OverrideUtc(utcNow)
             .AsAdminUser()
             .CreateSimpleDialog((x, _) => x.Dto.VisibleFrom = visibleFrom)
             .GetServiceOwnerDialog()
             .ExecuteAndAssert<DialogDto>(dialog =>
             {
-                dialog.VisibleFrom.Should().BeCloseTo(visibleFrom, TimeSpan.FromSeconds(1));
-                dialog.CreatedAt.Should().BeCloseTo(fixedUtcNow, TimeSpan.FromSeconds(1));
-                dialog.UpdatedAt.Should().BeCloseTo(fixedUtcNow, TimeSpan.FromSeconds(1));
-                dialog.ContentUpdatedAt.Should().BeCloseTo(fixedUtcNow, TimeSpan.FromSeconds(1));
-                dialog.CreatedAt.Should().NotBe(dialog.VisibleFrom);
-                dialog.UpdatedAt.Should().NotBe(dialog.VisibleFrom);
-                dialog.ContentUpdatedAt.Should().NotBe(dialog.VisibleFrom);
+                dialog.VisibleFrom.Should().Be(visibleFrom);
+                dialog.CreatedAt.Should().Be(utcNow);
+                dialog.UpdatedAt.Should().Be(utcNow);
+                dialog.ContentUpdatedAt.Should().Be(utcNow);
+            });
+    }
+
+    [Fact]
+    public Task Past_VisibleFrom_Should_Not_Control_Supplied_Timestamps_On_Create()
+    {
+        var utcNow = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+        var visibleFrom = utcNow.AddDays(-7);
+        var createdAt = utcNow.AddDays(-3);
+        var updatedAt = utcNow.AddDays(-1);
+
+        return FlowBuilder.For(Application)
+            .OverrideUtc(utcNow)
+            .AsAdminUser()
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.VisibleFrom = visibleFrom;
+                x.Dto.CreatedAt = createdAt;
+                x.Dto.UpdatedAt = updatedAt;
+            })
+            .GetServiceOwnerDialog()
+            .ExecuteAndAssert<DialogDto>(dialog =>
+            {
+                dialog.VisibleFrom.Should().Be(visibleFrom);
+                dialog.CreatedAt.Should().Be(createdAt);
+                dialog.UpdatedAt.Should().Be(updatedAt);
+                dialog.ContentUpdatedAt.Should().Be(updatedAt);
             });
     }
 

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogTests.cs
@@ -196,6 +196,29 @@ public class CreateDialogTests : ApplicationCollectionFixture
     }
 
     [Fact]
+    public Task Past_VisibleFrom_Should_Not_Backdate_Timestamps_On_Create()
+    {
+        var fixedUtcNow = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var visibleFrom = fixedUtcNow.AddDays(-3);
+
+        return FlowBuilder.For(Application)
+            .OverrideUtc(fixedUtcNow)
+            .AsAdminUser()
+            .CreateSimpleDialog((x, _) => x.Dto.VisibleFrom = visibleFrom)
+            .GetServiceOwnerDialog()
+            .ExecuteAndAssert<DialogDto>(dialog =>
+            {
+                dialog.VisibleFrom.Should().BeCloseTo(visibleFrom, TimeSpan.FromSeconds(1));
+                dialog.CreatedAt.Should().BeCloseTo(fixedUtcNow, TimeSpan.FromSeconds(1));
+                dialog.UpdatedAt.Should().BeCloseTo(fixedUtcNow, TimeSpan.FromSeconds(1));
+                dialog.ContentUpdatedAt.Should().BeCloseTo(fixedUtcNow, TimeSpan.FromSeconds(1));
+                dialog.CreatedAt.Should().NotBe(dialog.VisibleFrom);
+                dialog.UpdatedAt.Should().NotBe(dialog.VisibleFrom);
+                dialog.ContentUpdatedAt.Should().NotBe(dialog.VisibleFrom);
+            });
+    }
+
+    [Fact]
     public Task Cannot_Create_DueAt_Before_VisibleFrom_Without_Admin_Scope()
     {
         var visibleFrom = DateTimeOffset.UtcNow.AddDays(10);


### PR DESCRIPTION
## Description

Fixes an error where CreatedAt/UpdatedAt was unconditionally set to VisibleFrom if set, even if it was in the past

## Related Issue(s)

- #4023 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 
