### PR TITLE
trivial(infra): Increase graphql and web-api-eu resources to 1 CPU / 2Gi (test + staging)

### DIFF
--- a/.azure/applications/graphql/staging.bicepparam
+++ b/.azure/applications/graphql/staging.bicepparam
@@ -8,6 +8,11 @@ param whitelistedIPs = [
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
+param resources = {
+    cpu: 1
+    memory: '2Gi'
+}
+
 param otelTraceSamplerRatio = '0.05'
 
 // secrets

--- a/.azure/applications/graphql/test.bicepparam
+++ b/.azure/applications/graphql/test.bicepparam
@@ -9,6 +9,11 @@ param whitelistedIPs = [
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
+param resources = {
+    cpu: 1
+    memory: '2Gi'
+}
+
 param otelTraceSamplerRatio = '1'
 
 // secrets

--- a/.azure/applications/web-api-eu/staging.bicepparam
+++ b/.azure/applications/web-api-eu/staging.bicepparam
@@ -8,6 +8,11 @@ param whitelistedIPs = [
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
+param resources = {
+    cpu: 1
+    memory: '2Gi'
+}
+
 param otelTraceSamplerRatio = '0.05'
 
 // secrets

--- a/.azure/applications/web-api-eu/test.bicepparam
+++ b/.azure/applications/web-api-eu/test.bicepparam
@@ -9,6 +9,11 @@ param whitelistedIPs = [
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
+param resources = {
+    cpu: 1
+    memory: '2Gi'
+}
+
 param otelTraceSamplerRatio = '1'
 
 // secrets


### PR DESCRIPTION
Set explicit `resources` (`cpu: 1`, `memory: '2Gi'`) for graphql and web-api-eu in **test and staging**, matching web-api-so.

Both omitted `resources`, so Azure defaulted to 0.5 CPU / 1Gi. The idle footprint (~900 MiB) sits above the 70% memory scale threshold, pinning the apps at maxReplicas regardless of traffic (staging graphql sat at 10, web-api-eu at 8; test graphql at ~6). That makes deploys run far more replicas than needed (old + new revisions concurrently), saturating the single-core Basic Redis and timing out the revision health check. At 2Gi the footprint drops to ~40%, so they scale on actual load.

Net effect is a resource (and cost) **decrease**, since the apps fall back toward 1 replica instead of staying pinned near max.

prod and yt01 already run 2 CPU / 4Gi and are unaffected.