### PR TITLE
trivial(infra): monitor secret expiry on source key vaults

### DIFF
--- a/.github/keyvault-expiry-monitored-secrets.yml
+++ b/.github/keyvault-expiry-monitored-secrets.yml
@@ -1,9 +1,16 @@
-# Secrets listed here MUST have `attributes.expires` set in every environment's Key Vault.
-# A missing expiry on a monitored secret triggers a configuration-error Slack alert.
+# Secrets listed here MUST have `attributes.expires` set in each source Key Vault
+# (the non-prod source serving test/yt01/staging, and the prod source). A missing
+# expiry on a monitored secret triggers a configuration-error Slack alert.
 # Add an entry when introducing a new rotatable credential (JWK, cert, vendor API key, etc.).
 #
-# This list does NOT control which secrets are checked for upcoming expiry — every secret
-# with `attributes.expires` set is checked. This list only flags secrets where a missing
-# expiry would itself be a problem.
+# Entries are canonical secret keys, matched against source-vault secret names by suffix,
+# so an entry like `Infrastructure--Maskinporten--EncodedJwk` matches the prefixed source
+# name `dialogporten--any--Infrastructure--Maskinporten--EncodedJwk` (and the
+# `dialogporten--<env>--` variants) without listing the prefix here. See
+# docs/Configuration.md for the source-vault naming convention.
+#
+# This list does NOT control which secrets are checked for upcoming expiry — every source
+# secret with `attributes.expires` set is checked. This list only flags secrets where a
+# missing expiry would itself be a problem.
 required_expires:
   - Infrastructure--Maskinporten--EncodedJwk

--- a/.github/scripts/check-keyvault-expiry.py
+++ b/.github/scripts/check-keyvault-expiry.py
@@ -15,8 +15,11 @@ Reads:
 Writes:
   - slack-{nonprod,prod,prod-critical}.json: chat.postMessage payloads, one per channel
     that has something to report.
+  - slack-{nonprod,prod}-digest.json: a full overview of every tracked secret expiry (no
+    @mention), written when $SEND_DIGEST is true or it's the 1st of the month. Informational
+    only — does not affect the run's pass/fail.
   - $GITHUB_STEP_SUMMARY: markdown table (tier, secret, expires, days left).
-  - $GITHUB_OUTPUT: `any_rule_tripped` + per-channel `have_*_payload` flags.
+  - $GITHUB_OUTPUT: `any_rule_tripped` + per-channel `have_*_payload` / `have_*_digest` flags.
 
 Per-finding routing by days until expiry: 8-30 -> no mention; 2-7 -> @here;
 <=1 or expired -> @channel (prod also cross-posts to the prod-critical channel).
@@ -38,6 +41,7 @@ MONITORED_FILE = pathlib.Path(os.environ["MONITORED_SECRETS_FILE"])
 SECRETS_DIR = pathlib.Path(os.environ["SECRETS_DIR"])
 RUN_URL = os.environ.get("GITHUB_RUN_URL", "")
 RUNBOOK_URL = os.environ.get("RUNBOOK_URL", "")
+SEND_DIGEST = os.environ.get("SEND_DIGEST", "").lower() == "true"
 EXPECTED_TIERS = json.loads(os.environ.get("EXPECTED_TIERS_JSON", "[]"))
 STEP_SUMMARY = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
 STEP_OUTPUT = pathlib.Path(os.environ["GITHUB_OUTPUT"])
@@ -72,6 +76,32 @@ def days_phrase(days: int) -> str:
 
 def tier_icon(tier: int) -> str:
     return {1: ":large_yellow_circle:", 2: ":large_orange_diamond:", 3: ":red_circle:"}[tier]
+
+
+def status_icon(days_left: int) -> str:
+    tier = classify_tier(days_left)
+    return tier_icon(tier) if tier is not None else ":large_green_circle:"
+
+
+def footer_blocks() -> list[dict]:
+    """Runbook button + workflow-run link, shared by alert and digest payloads."""
+    blocks: list[dict] = []
+    if RUNBOOK_URL:
+        blocks.append({
+            "type": "actions",
+            "elements": [{
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Open rotation runbook"},
+                "url": RUNBOOK_URL,
+                "style": "primary",
+            }],
+        })
+    if RUN_URL:
+        blocks.append({
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": f"<{RUN_URL}|View workflow run>"}],
+        })
+    return blocks
 
 
 def load_monitored() -> set[str]:
@@ -202,24 +232,31 @@ def build_blocks(
             },
         })
 
-    if RUNBOOK_URL:
-        blocks.append({
-            "type": "actions",
-            "elements": [{
-                "type": "button",
-                "text": {"type": "plain_text", "text": "Open rotation runbook"},
-                "url": RUNBOOK_URL,
-                "style": "primary",
-            }],
-        })
-
-    if RUN_URL:
-        blocks.append({
-            "type": "context",
-            "elements": [{"type": "mrkdwn", "text": f"<{RUN_URL}|View workflow run>"}],
-        })
-
+    blocks.extend(footer_blocks())
     return blocks
+
+
+def build_digest_payload(findings: list[dict], header_suffix: str = "") -> dict:
+    """Informational monthly overview: every tracked secret with an expiry, soonest first,
+    colour-coded by runway. No @mention; does not affect the run's pass/fail."""
+    rows = [
+        f"{status_icon(f['days'])} *{f['tier']}* `{f['name']}` "
+        f"— {days_phrase(f['days'])} (expires {f['expires'][:10]})"
+        for f in sorted(findings, key=lambda x: (x["days"], x["tier"], x["name"]))
+    ]
+    body = "\n".join(rows) if rows else "_No secrets with an expiry set._"
+    blocks = [
+        {"type": "header",
+         "text": {"type": "plain_text", "text": f"Key Vault secret expiry digest{header_suffix}"}},
+        {"type": "section",
+         "text": {"type": "mrkdwn", "text": f"Monthly overview of tracked secret expiries:\n{body}"}},
+    ]
+    blocks.extend(footer_blocks())
+    return {
+        "channel": CHANNEL_PLACEHOLDER,
+        "text": f"Key Vault secret expiry digest{header_suffix}",
+        "blocks": blocks,
+    }
 
 
 def mention_for(alerted: list[dict], missing: list[dict], missing_tiers: list[str]) -> str:
@@ -354,6 +391,18 @@ def main() -> int:
             build_payload(prod_tier3, [], [], header_suffix=" — PROD CRITICAL"),
         )
 
+    # Monthly digest: a full overview of every tracked expiry, sent on the 1st (or on demand
+    # via SEND_DIGEST). Independent of the alert rules — never flips the run to failed.
+    digest_mode = SEND_DIGEST or datetime.now(timezone.utc).day == 1
+    nonprod_findings = [f for f in expiry_findings if not is_prod(f["tier"])]
+    prod_findings = [f for f in expiry_findings if is_prod(f["tier"])]
+    have_nonprod_digest = digest_mode and bool(nonprod_findings)
+    have_prod_digest = digest_mode and bool(prod_findings)
+    if have_nonprod_digest:
+        write_payload("slack-nonprod-digest.json", build_digest_payload(nonprod_findings, " (non-prod)"))
+    if have_prod_digest:
+        write_payload("slack-prod-digest.json", build_digest_payload(prod_findings, " (prod)"))
+
     STEP_SUMMARY.write_text(render_step_summary(expiry_findings, missing, present_tiers, missing_tiers))
 
     any_rule_tripped = bool(alerted or missing or missing_tiers)
@@ -362,6 +411,8 @@ def main() -> int:
         out.write(f"have_nonprod_payload={'true' if (nonprod_alerted or nonprod_missing or nonprod_missing_tiers) else 'false'}\n")
         out.write(f"have_prod_payload={'true' if (prod_alerted or prod_missing or prod_missing_tiers) else 'false'}\n")
         out.write(f"have_prod_critical_payload={'true' if prod_tier3 else 'false'}\n")
+        out.write(f"have_nonprod_digest={'true' if have_nonprod_digest else 'false'}\n")
+        out.write(f"have_prod_digest={'true' if have_prod_digest else 'false'}\n")
 
     print(
         f"Findings: {len(alerted)} expiring, {len(missing)} configuration issues "

--- a/.github/scripts/check-keyvault-expiry.py
+++ b/.github/scripts/check-keyvault-expiry.py
@@ -1,25 +1,26 @@
-"""Aggregate Key Vault secret expiry findings across envs, emit Slack payloads and step summary.
+"""Report soon-to-expire secrets in the source Key Vaults, to Slack and the step summary.
+
+Secrets are rotated in two source vaults — one non-prod (serving test/yt01/staging) and
+one prod — and their expiry dates live there. This script checks those vaults, grouped as
+the `non-prod` and `prod` tiers.
 
 Reads:
-  - $MONITORED_SECRETS_FILE: YAML with `required_expires:` list of secret names that MUST have expires set.
-  - $SECRETS_DIR: directory containing one `secrets-<env>.json` per env, each a list of
-      {"name": "...", "expires": "ISO8601 or null"} for every ENABLED secret in that env's KV.
-  - $GITHUB_RUN_URL: link to current workflow run, embedded in Slack messages.
+  - $MONITORED_SECRETS_FILE: YAML `required_expires:` list of secrets that must have an
+    expiry set; a missing one is flagged as a config error.
+  - $SECRETS_DIR: one `secrets-<tier>.json` per tier, each a list of
+    {"name": ..., "expires": ISO8601 or null} for the enabled secrets in that tier's vault.
+  - $EXPECTED_TIERS_JSON: tiers the workflow meant to check (used to detect failed legs).
+  - $GITHUB_RUN_URL / $RUNBOOK_URL: links embedded in Slack messages.
 
 Writes:
-  - slack-nonprod.json / slack-prod.json / slack-prod-critical.json: payloads for the
-    Slack chat.postMessage step (only files for channels that have something to say).
-  - $GITHUB_STEP_SUMMARY: public-facing markdown summary (env + secret name + expires + days,
-    NO vault names).
-  - $GITHUB_OUTPUT: sets `any_rule_tripped=true|false` so the workflow can red-flag the run.
+  - slack-{nonprod,prod,prod-critical}.json: chat.postMessage payloads, one per channel
+    that has something to report.
+  - $GITHUB_STEP_SUMMARY: markdown table (tier, secret, expires, days left).
+  - $GITHUB_OUTPUT: `any_rule_tripped` + per-channel `have_*_payload` flags.
 
-Routing tiers (per finding):
-  - Tier 1: 8 <= days_left <= 30, no mention
-  - Tier 2: 2 <= days_left <= 7, @here
-  - Tier 3: days_left <= 1 (incl. expired), @channel; for prod, also cross-posts to the
-    prod-critical channel
-Configuration-error findings (a monitored secret missing or without expires) post at
-the @here level with no tier escalation.
+Per-finding routing by days until expiry: 8-30 -> no mention; 2-7 -> @here;
+<=1 or expired -> @channel (prod also cross-posts to the prod-critical channel).
+Config-error findings post at @here with no escalation.
 """
 
 from __future__ import annotations
@@ -37,13 +38,13 @@ MONITORED_FILE = pathlib.Path(os.environ["MONITORED_SECRETS_FILE"])
 SECRETS_DIR = pathlib.Path(os.environ["SECRETS_DIR"])
 RUN_URL = os.environ.get("GITHUB_RUN_URL", "")
 RUNBOOK_URL = os.environ.get("RUNBOOK_URL", "")
-EXPECTED_ENVS = json.loads(os.environ.get("EXPECTED_ENVS_JSON", "[]"))
+EXPECTED_TIERS = json.loads(os.environ.get("EXPECTED_TIERS_JSON", "[]"))
 STEP_SUMMARY = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
 STEP_OUTPUT = pathlib.Path(os.environ["GITHUB_OUTPUT"])
 
 CHANNEL_PLACEHOLDER = "${{ env.CHANNEL_ID }}"  # filled in by slack-github-action's payload-templated
 
-PROD_ENV = "prod"
+PROD_TIER = "prod"
 
 
 def parse_iso(value: str) -> datetime:
@@ -78,26 +79,30 @@ def load_monitored() -> set[str]:
     return set(data.get("required_expires", []) or [])
 
 
-def collect_findings() -> tuple[list[dict], list[dict], list[str]]:
-    """Returns (expiry_findings, missing_findings, present_envs).
+def matches_monitored(secret_name: str, canonical_key: str) -> bool:
+    """True if a source secret name is the canonical key, with or without the
+    `dialogporten--(any|<env>)--` source prefix. The `--` separator stops `Jwk`
+    from matching `EncodedJwk`."""
+    return secret_name == canonical_key or secret_name.endswith(f"--{canonical_key}")
 
-    `present_envs` is the list of envs whose `secrets-<env>.json` was actually
-    present in $SECRETS_DIR — distinct from $EXPECTED_ENVS_JSON, which is what
-    the prepare job said we should check. The difference is the set of envs
-    whose matrix leg failed to upload its artifact.
+
+def collect_findings() -> tuple[list[dict], list[dict], list[str]]:
+    """Scan every `secrets-<tier>.json` in $SECRETS_DIR.
+
+    Returns (expiry_findings, missing_findings, present_tiers), where present_tiers
+    lists the tiers that actually produced a file.
     """
     monitored = load_monitored()
     today = datetime.now(timezone.utc).date()
 
     expiry_findings: list[dict] = []
     missing_findings: list[dict] = []
-    envs: list[str] = []
+    tiers: list[str] = []
 
     for f in sorted(SECRETS_DIR.glob("secrets-*.json")):
-        env_name = f.stem[len("secrets-"):]
-        envs.append(env_name)
+        tier_name = f.stem[len("secrets-"):]
+        tiers.append(tier_name)
         secrets = json.loads(f.read_text())
-        by_name = {s["name"]: s for s in secrets}
 
         for s in secrets:
             if not s.get("expires"):
@@ -105,34 +110,37 @@ def collect_findings() -> tuple[list[dict], list[dict], list[str]]:
             days = (parse_iso(s["expires"]).date() - today).days
             tier = classify_tier(days)
             expiry_findings.append({
-                "env": env_name,
+                "tier": tier_name,
                 "name": s["name"],
                 "expires": s["expires"],
                 "days": days,
-                "tier": tier,
+                "alert_tier": tier,
             })
 
-        for required_name in sorted(monitored):
-            if required_name not in by_name:
+        for canonical_key in sorted(monitored):
+            matches = [s for s in secrets if matches_monitored(s["name"], canonical_key)]
+            if not matches:
                 missing_findings.append({
-                    "env": env_name,
-                    "name": required_name,
+                    "tier": tier_name,
+                    "name": canonical_key,
                     "state": "absent",
                 })
-            elif not by_name[required_name].get("expires"):
-                missing_findings.append({
-                    "env": env_name,
-                    "name": required_name,
-                    "state": "no-expires",
-                })
+                continue
+            for s in matches:
+                if not s.get("expires"):
+                    missing_findings.append({
+                        "tier": tier_name,
+                        "name": s["name"],
+                        "state": "no-expires",
+                    })
 
-    return expiry_findings, missing_findings, envs
+    return expiry_findings, missing_findings, tiers
 
 
 def build_blocks(
     alerted: list[dict],
     missing: list[dict],
-    missing_envs: list[str],
+    missing_tiers: list[str],
     header_suffix: str = "",
 ) -> list[dict]:
     blocks: list[dict] = [{
@@ -140,24 +148,24 @@ def build_blocks(
         "text": {"type": "plain_text", "text": f"Key Vault secret expiry{header_suffix}"},
     }]
 
-    if missing_envs:
+    if missing_tiers:
         blocks.append({
             "type": "section",
             "text": {
                 "type": "mrkdwn",
                 "text": (
                     ":rotating_light: *Data unavailable for: "
-                    f"{', '.join(missing_envs)}* — the matrix leg(s) for these envs failed. "
-                    "Findings below reflect only the envs that were checked successfully."
+                    f"{', '.join(missing_tiers)}* — the matrix leg(s) for these tiers failed. "
+                    "Findings below reflect only the tiers that were checked successfully."
                 ),
             },
         })
 
     if alerted:
         rows = []
-        for f in sorted(alerted, key=lambda x: (x["days"], x["env"], x["name"])):
+        for f in sorted(alerted, key=lambda x: (x["days"], x["tier"], x["name"])):
             rows.append(
-                f"{tier_icon(f['tier'])} *{f['env']}* `{f['name']}` "
+                f"{tier_icon(f['alert_tier'])} *{f['tier']}* `{f['name']}` "
                 f"— {days_phrase(f['days'])} (expires {f['expires'][:10]})"
             )
         blocks.append({
@@ -167,13 +175,13 @@ def build_blocks(
 
     if missing:
         rows = []
-        for m in sorted(missing, key=lambda x: (x["env"], x["name"])):
+        for m in sorted(missing, key=lambda x: (x["tier"], x["name"])):
             detail = (
                 "no `attributes.expires` set"
                 if m["state"] == "no-expires"
-                else "secret not found in Key Vault"
+                else "monitored secret not found in source vault"
             )
-            rows.append(f":warning: *{m['env']}* `{m['name']}` — {detail}")
+            rows.append(f":warning: *{m['tier']}* `{m['name']}` — {detail}")
         blocks.append({
             "type": "section",
             "text": {
@@ -202,11 +210,11 @@ def build_blocks(
     return blocks
 
 
-def mention_for(alerted: list[dict], missing: list[dict], missing_envs: list[str]) -> str:
-    tiers = {f["tier"] for f in alerted}
+def mention_for(alerted: list[dict], missing: list[dict], missing_tiers: list[str]) -> str:
+    tiers = {f["alert_tier"] for f in alerted}
     if 3 in tiers:
         return "<!channel>"
-    if 2 in tiers or missing or missing_envs:
+    if 2 in tiers or missing or missing_tiers:
         return "<!here>"
     return ""
 
@@ -214,11 +222,11 @@ def mention_for(alerted: list[dict], missing: list[dict], missing_envs: list[str
 def build_payload(
     alerted: list[dict],
     missing: list[dict],
-    missing_envs: list[str],
+    missing_tiers: list[str],
     header_suffix: str = "",
 ) -> dict:
-    blocks = build_blocks(alerted, missing, missing_envs, header_suffix=header_suffix)
-    mention = mention_for(alerted, missing, missing_envs)
+    blocks = build_blocks(alerted, missing, missing_tiers, header_suffix=header_suffix)
+    mention = mention_for(alerted, missing, missing_tiers)
     if mention:
         blocks.insert(1, {
             "type": "section",
@@ -238,37 +246,37 @@ def write_payload(path: str, payload: dict) -> None:
 def render_step_summary(
     expiry_findings: list[dict],
     missing: list[dict],
-    present_envs: list[str],
-    missing_envs: list[str],
+    present_tiers: list[str],
+    missing_tiers: list[str],
 ) -> str:
     lines: list[str] = []
     lines.append("# Key Vault secret expiry — daily check\n")
-    lines.append(f"Checked envs: {', '.join(present_envs) if present_envs else '(none)'}\n")
-    if missing_envs:
+    lines.append(f"Checked source tiers: {', '.join(present_tiers) if present_tiers else '(none)'}\n")
+    if missing_tiers:
         lines.append(
-            f":rotating_light: **Data unavailable for: {', '.join(missing_envs)}** "
-            "— matrix leg(s) for these envs failed; rerun or check workflow logs.\n"
+            f":rotating_light: **Data unavailable for: {', '.join(missing_tiers)}** "
+            "— matrix leg(s) for these tiers failed; rerun or check workflow logs.\n"
         )
     if RUNBOOK_URL:
         lines.append(f"Rotation runbook: {RUNBOOK_URL}\n")
 
     with_expires = [f for f in expiry_findings if f["expires"]]
-    lines.append("## Secrets with `attributes.expires` set\n")
+    lines.append("## Source secrets with `attributes.expires` set\n")
     if not with_expires:
         lines.append("_None found._\n")
     else:
-        lines.append("| Env | Secret | Expires (UTC) | Days left | Status |")
+        lines.append("| Tier | Secret | Expires (UTC) | Days left | Status |")
         lines.append("|---|---|---|---|---|")
-        for f in sorted(with_expires, key=lambda x: (x["days"], x["env"], x["name"])):
+        for f in sorted(with_expires, key=lambda x: (x["days"], x["tier"], x["name"])):
             status = ""
-            if f["tier"] == 3:
+            if f["alert_tier"] == 3:
                 status = ":red_circle: critical"
-            elif f["tier"] == 2:
+            elif f["alert_tier"] == 2:
                 status = ":large_orange_diamond: warning"
-            elif f["tier"] == 1:
+            elif f["alert_tier"] == 1:
                 status = ":large_yellow_circle: heads-up"
             lines.append(
-                f"| {f['env']} | `{f['name']}` | {f['expires'][:10]} | {f['days']} | {status} |"
+                f"| {f['tier']} | `{f['name']}` | {f['expires'][:10]} | {f['days']} | {status} |"
             )
         lines.append("")
 
@@ -276,55 +284,56 @@ def render_step_summary(
     if not missing:
         lines.append("_None._\n")
     else:
-        lines.append("| Env | Secret | Issue |")
+        lines.append("| Tier | Secret | Issue |")
         lines.append("|---|---|---|")
-        for m in sorted(missing, key=lambda x: (x["env"], x["name"])):
+        for m in sorted(missing, key=lambda x: (x["tier"], x["name"])):
             issue = (
                 "Missing `attributes.expires`"
                 if m["state"] == "no-expires"
-                else "Secret not present in Key Vault"
+                else "Not present in source vault"
             )
-            lines.append(f"| {m['env']} | `{m['name']}` | {issue} |")
+            lines.append(f"| {m['tier']} | `{m['name']}` | {issue} |")
         lines.append("")
 
     return "\n".join(lines)
 
 
 def main() -> int:
-    if not EXPECTED_ENVS:
+    if not EXPECTED_TIERS:
         raise RuntimeError(
-            "EXPECTED_ENVS_JSON is empty. The workflow's prepare job is supposed to "
-            "populate it with the envs to check; an empty list would silently "
+            "EXPECTED_TIERS_JSON is empty. The workflow's prepare job is supposed to "
+            "populate it with the tiers to check; an empty list would silently "
             "succeed with zero findings."
         )
 
-    expiry_findings, missing, present_envs = collect_findings()
-    missing_envs = sorted(set(EXPECTED_ENVS) - set(present_envs))
+    expiry_findings, missing, present_tiers = collect_findings()
+    # A tier we were asked to check but got no file for means its matrix leg failed.
+    missing_tiers = sorted(set(EXPECTED_TIERS) - set(present_tiers))
 
-    alerted = [f for f in expiry_findings if f["tier"] is not None]
+    alerted = [f for f in expiry_findings if f["alert_tier"] is not None]
 
-    def is_prod(env: str) -> bool:
-        return env == PROD_ENV
+    def is_prod(tier: str) -> bool:
+        return tier == PROD_TIER
 
-    nonprod_alerted = [f for f in alerted if not is_prod(f["env"])]
-    prod_alerted = [f for f in alerted if is_prod(f["env"])]
-    prod_tier3 = [f for f in prod_alerted if f["tier"] == 3]
-    nonprod_missing = [m for m in missing if not is_prod(m["env"])]
-    prod_missing = [m for m in missing if is_prod(m["env"])]
+    nonprod_alerted = [f for f in alerted if not is_prod(f["tier"])]
+    prod_alerted = [f for f in alerted if is_prod(f["tier"])]
+    prod_tier3 = [f for f in prod_alerted if f["alert_tier"] == 3]
+    nonprod_missing = [m for m in missing if not is_prod(m["tier"])]
+    prod_missing = [m for m in missing if is_prod(m["tier"])]
 
-    nonprod_missing_envs = [e for e in missing_envs if not is_prod(e)]
-    prod_missing_envs = [e for e in missing_envs if is_prod(e)]
+    nonprod_missing_tiers = [t for t in missing_tiers if not is_prod(t)]
+    prod_missing_tiers = [t for t in missing_tiers if is_prod(t)]
 
-    if nonprod_alerted or nonprod_missing or nonprod_missing_envs:
+    if nonprod_alerted or nonprod_missing or nonprod_missing_tiers:
         write_payload(
             "slack-nonprod.json",
-            build_payload(nonprod_alerted, nonprod_missing, nonprod_missing_envs,
+            build_payload(nonprod_alerted, nonprod_missing, nonprod_missing_tiers,
                           header_suffix=" alert (non-prod)"),
         )
-    if prod_alerted or prod_missing or prod_missing_envs:
+    if prod_alerted or prod_missing or prod_missing_tiers:
         write_payload(
             "slack-prod.json",
-            build_payload(prod_alerted, prod_missing, prod_missing_envs,
+            build_payload(prod_alerted, prod_missing, prod_missing_tiers,
                           header_suffix=" alert (prod)"),
         )
     if prod_tier3:
@@ -333,18 +342,18 @@ def main() -> int:
             build_payload(prod_tier3, [], [], header_suffix=" — PROD CRITICAL"),
         )
 
-    STEP_SUMMARY.write_text(render_step_summary(expiry_findings, missing, present_envs, missing_envs))
+    STEP_SUMMARY.write_text(render_step_summary(expiry_findings, missing, present_tiers, missing_tiers))
 
-    any_rule_tripped = bool(alerted or missing or missing_envs)
+    any_rule_tripped = bool(alerted or missing or missing_tiers)
     with STEP_OUTPUT.open("a") as out:
         out.write(f"any_rule_tripped={'true' if any_rule_tripped else 'false'}\n")
-        out.write(f"have_nonprod_payload={'true' if (nonprod_alerted or nonprod_missing or nonprod_missing_envs) else 'false'}\n")
-        out.write(f"have_prod_payload={'true' if (prod_alerted or prod_missing or prod_missing_envs) else 'false'}\n")
+        out.write(f"have_nonprod_payload={'true' if (nonprod_alerted or nonprod_missing or nonprod_missing_tiers) else 'false'}\n")
+        out.write(f"have_prod_payload={'true' if (prod_alerted or prod_missing or prod_missing_tiers) else 'false'}\n")
         out.write(f"have_prod_critical_payload={'true' if prod_tier3 else 'false'}\n")
 
     print(
         f"Findings: {len(alerted)} expiring, {len(missing)} configuration issues "
-        f"across present envs {present_envs}; missing envs: {missing_envs}"
+        f"across present tiers {present_tiers}; missing tiers: {missing_tiers}"
     )
     return 0
 

--- a/.github/scripts/check-keyvault-expiry.py
+++ b/.github/scripts/check-keyvault-expiry.py
@@ -80,10 +80,22 @@ def load_monitored() -> set[str]:
 
 
 def matches_monitored(secret_name: str, canonical_key: str) -> bool:
-    """True if a source secret name is the canonical key, with or without the
-    `dialogporten--(any|<env>)--` source prefix. The `--` separator stops `Jwk`
-    from matching `EncodedJwk`."""
-    return secret_name == canonical_key or secret_name.endswith(f"--{canonical_key}")
+    """True if a source secret is the monitored canonical key, optionally carrying a
+    single documented source prefix: `dialogporten--<env>--` or `dialogporten--any--`
+    (Configuration.md). Names with extra leading segments, or without the dialogporten
+    prefix, are rejected so an unrelated secret that merely ends with the key cannot
+    satisfy the rule."""
+    if secret_name == canonical_key:
+        return True
+    suffix = f"--{canonical_key}"
+    if not secret_name.endswith(suffix):
+        return False
+    prefix = secret_name[: -len(suffix)]
+    if not prefix.startswith("dialogporten--"):
+        return False
+    env = prefix[len("dialogporten--"):]
+    # the env segment must be exactly one `--`-delimited token (e.g. any, test, yt01)
+    return env != "" and "--" not in env
 
 
 def collect_findings() -> tuple[list[dict], list[dict], list[str]]:

--- a/.github/workflows/check-keyvault-secret-expiry.yml
+++ b/.github/workflows/check-keyvault-secret-expiry.yml
@@ -1,7 +1,11 @@
 name: Check Key Vault secret expiry
 
-# Daily check that any Key Vault secret with `attributes.expires` set isn't about to
-# expire. Routes findings to env-tier Slack channels. See:
+# Daily check that any source Key Vault secret with `attributes.expires` set isn't
+# about to expire. The team rotates secrets in the SOURCE key vaults (one per
+# subscription: a non-prod source serving test/yt01/staging, a prod source serving
+# prod); copySecrets.bicep propagates values into the env vaults on deploy. Expiry
+# is set on the source secrets at rotation time, so the source vault is the source
+# of truth we monitor here. See:
 #   - .github/scripts/check-keyvault-expiry.py for the rule logic
 #   - .github/keyvault-expiry-monitored-secrets.yml for the missing-expires allow-list
 
@@ -13,20 +17,21 @@ on:
     - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
-      environments:
-        description: "Comma-separated envs (any of: test, yt01, staging, prod). Default: all."
+      tiers:
+        description: "Comma-separated source tiers to check (any of: non-prod, prod). Default: both."
         required: false
-        default: 'test,yt01,staging,prod'
+        default: 'non-prod,prod'
         type: string
 
 jobs:
   prepare:
-    name: Prepare env list
+    name: Prepare tier list
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      envs: ${{ steps.parse.outputs.envs }}
+      tiers: ${{ steps.parse.outputs.tiers }}
+      matrix: ${{ steps.parse.outputs.matrix }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -34,38 +39,45 @@ jobs:
 
       - id: parse
         env:
-          INPUT_RAW: ${{ inputs.environments || 'test,yt01,staging,prod' }}
+          INPUT_RAW: ${{ inputs.tiers || 'non-prod,prod' }}
         run: |
           set -euo pipefail
-          ALLOWED='["test","yt01","staging","prod"]'
-          ENVS=$(printf '%s' "$INPUT_RAW" \
+          ALLOWED='["non-prod","prod"]'
+          TIERS=$(printf '%s' "$INPUT_RAW" \
             | jq -Rnc 'inputs
                 | split(",")
                 | map(ascii_downcase | gsub("^\\s+|\\s+$"; ""))
                 | map(select(length > 0))
                 | unique')
-          if [ "$ENVS" = "[]" ] || [ -z "$ENVS" ]; then
-            echo "::error::No environments to check (input was: '$INPUT_RAW')"
+          if [ "$TIERS" = "[]" ] || [ -z "$TIERS" ]; then
+            echo "::error::No tiers to check (input was: '$INPUT_RAW')"
             exit 1
           fi
           INVALID=$(jq -rc --argjson allowed "$ALLOWED" \
-            '[.[] | select(($allowed | index(.)) == null)]' <<<"$ENVS")
+            '[.[] | select(. as $t | ($allowed | index($t)) == null)]' <<<"$TIERS")
           if [ "$INVALID" != "[]" ]; then
-            echo "::error::Invalid env(s): $INVALID. Allowed: $ALLOWED"
+            echo "::error::Invalid tier(s): $INVALID. Allowed: $ALLOWED"
             exit 1
           fi
-          echo "envs=$ENVS" >> "$GITHUB_OUTPUT"
-          echo "Will check envs: $ENVS"
+          # Map each tier to the GitHub environment whose scoped secrets
+          # (AZURE_CLIENT_ID + AZURE_SOURCE_KEY_VAULT_*) point at that tier's
+          # source vault. test/yt01/staging all share the non-prod source vault;
+          # we use `test` since it is the most frequently deployed.
+          MATRIX=$(jq -cn --argjson tiers "$TIERS" '
+            {"non-prod": "test", "prod": "prod"} as $map
+            | { include: [ $tiers[] | { tier: ., ghenv: $map[.] } ] }')
+          echo "tiers=$TIERS" >> "$GITHUB_OUTPUT"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "Will check tiers: $TIERS"
 
   list-secrets:
-    name: List secrets (${{ matrix.environment }})
+    name: List source secrets (${{ matrix.tier }})
     needs: prepare
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        environment: ${{ fromJson(needs.prepare.outputs.envs) }}
-    environment: ${{ matrix.environment }}
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    environment: ${{ matrix.ghenv }}
     permissions:
       id-token: write
       contents: read
@@ -86,49 +98,43 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: List secrets with metadata
+      - name: List source vault secrets with metadata
         env:
-          ENVIRONMENT: ${{ matrix.environment }}
+          TIER: ${{ matrix.tier }}
+          SRC_VAULT: ${{ secrets.AZURE_SOURCE_KEY_VAULT_NAME }}
+          SRC_SUB: ${{ secrets.AZURE_SOURCE_KEY_VAULT_SUBSCRIPTION_ID }}
         run: |
           set -euo pipefail
-          RG="dp-be-${ENVIRONMENT}-rg"
-          VAULTS_JSON=$(az keyvault list -g "$RG" --query "[].name" -o json)
-          VAULT_COUNT=$(jq 'length' <<<"$VAULTS_JSON")
-          if [ "$VAULT_COUNT" -eq 0 ]; then
-            echo "::error::No Key Vault found in resource group $RG"
+          if [ -z "$SRC_VAULT" ] || [ -z "$SRC_SUB" ]; then
+            echo "::error::AZURE_SOURCE_KEY_VAULT_NAME / _SUBSCRIPTION_ID not set for this environment"
             exit 1
           fi
-          if [ "$VAULT_COUNT" -gt 1 ]; then
-            NAMES=$(jq -r 'join(", ")' <<<"$VAULTS_JSON")
-            echo "::error::Expected exactly one Key Vault in $RG, found $VAULT_COUNT: $NAMES"
-            exit 1
-          fi
-          VAULT=$(jq -r '.[0]' <<<"$VAULTS_JSON")
-          echo "Found vault $VAULT in $RG"
+          echo "Listing source vault $SRC_VAULT (sub $SRC_SUB) for tier $TIER"
           # --include-managed covers secrets that back Key Vault certificates;
           # without it those secrets are silently excluded from the listing.
           az keyvault secret list \
-            --vault-name "$VAULT" \
+            --vault-name "$SRC_VAULT" \
+            --subscription "$SRC_SUB" \
             --include-managed true \
             --query "[?attributes.enabled].{name:name, expires:attributes.expires}" \
-            -o json > "secrets-${ENVIRONMENT}.json"
-          COUNT=$(jq length "secrets-${ENVIRONMENT}.json")
-          WITH_EXPIRES=$(jq '[.[] | select(.expires != null)] | length' "secrets-${ENVIRONMENT}.json")
+            -o json > "secrets-${TIER}.json"
+          COUNT=$(jq length "secrets-${TIER}.json")
+          WITH_EXPIRES=$(jq '[.[] | select(.expires != null)] | length' "secrets-${TIER}.json")
           echo "Enabled secrets: $COUNT (with expires set: $WITH_EXPIRES)"
 
       - name: Upload secrets JSON
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: secrets-${{ matrix.environment }}
-          path: secrets-${{ matrix.environment }}.json
+          name: secrets-${{ matrix.tier }}
+          path: secrets-${{ matrix.tier }}.json
           retention-days: 1
           if-no-files-found: error
 
   aggregate:
     name: Aggregate findings and alert
     needs: [prepare, list-secrets]
-    # Run even when one or more matrix legs fail, so healthy envs still get
-    # alerts and the step summary surfaces which envs were skipped. Skip only
+    # Run even when one or more matrix legs fail, so a healthy tier still gets
+    # alerts and the step summary surfaces which tiers were skipped. Skip only
     # if the workflow was cancelled.
     if: ${{ !cancelled() && needs.prepare.result == 'success' }}
     runs-on: ubuntu-latest
@@ -144,10 +150,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download per-env secrets JSON
+      - name: Download per-tier secrets JSON
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: secrets-by-env
+          path: secrets-by-tier
           pattern: secrets-*
           merge-multiple: true
 
@@ -159,8 +165,8 @@ jobs:
         id: compute
         env:
           MONITORED_SECRETS_FILE: .github/keyvault-expiry-monitored-secrets.yml
-          SECRETS_DIR: secrets-by-env
-          EXPECTED_ENVS_JSON: ${{ needs.prepare.outputs.envs }}
+          SECRETS_DIR: secrets-by-tier
+          EXPECTED_TIERS_JSON: ${{ needs.prepare.outputs.tiers }}
           GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUNBOOK_URL: https://digdir.atlassian.net/wiki/x/QIDDAgE
         run: python3 .github/scripts/check-keyvault-expiry.py

--- a/.github/workflows/check-keyvault-secret-expiry.yml
+++ b/.github/workflows/check-keyvault-secret-expiry.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: 'non-prod,prod'
         type: string
+      send_digest:
+        description: "Also post the full expiry digest to Slack now (auto-posts on the 1st of each month)."
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   prepare:
@@ -169,6 +174,7 @@ jobs:
           EXPECTED_TIERS_JSON: ${{ needs.prepare.outputs.tiers }}
           GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUNBOOK_URL: https://digdir.atlassian.net/wiki/x/QIDDAgE
+          SEND_DIGEST: ${{ inputs.send_digest }}
         run: python3 .github/scripts/check-keyvault-expiry.py
 
       - name: Post Slack alert to non-prod channel
@@ -203,6 +209,28 @@ jobs:
           payload-file-path: ./slack-prod-critical.json
         env:
           CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_KEYVAULT_ALERTS_PROD_CRITICAL }}
+
+      - name: Post monthly digest to non-prod channel
+        if: steps.compute.outputs.have_nonprod_digest == 'true'
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-templated: true
+          payload-file-path: ./slack-nonprod-digest.json
+        env:
+          CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_KEYVAULT_ALERTS }}
+
+      - name: Post monthly digest to prod channel
+        if: steps.compute.outputs.have_prod_digest == 'true'
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-templated: true
+          payload-file-path: ./slack-prod-digest.json
+        env:
+          CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_KEYVAULT_ALERTS_PROD }}
 
       - name: Fail run if any rule was tripped
         if: steps.compute.outputs.any_rule_tripped == 'true'


### PR DESCRIPTION
## Summary

Repoints the daily Key Vault expiry check from the env vaults to the **source** key vaults, where the team actually sets `attributes.expires` on rotation.

Background: secrets are rotated in two source vaults (one non-prod serving test/yt01/staging, one prod serving prod). `copySecrets.bicep` copies values to the env vaults but not the `expires` metadata, so the env vaults were never a reliable place to check. The deployer principal already reads the source vaults (that's how `deploy-infra` lists keys), which is why the env-vault Key Vault Reader grant could be reverted in #4034.

## What changed

- **Matrix dimension is now a source tier** (`non-prod`, `prod`). Each tier maps to the GitHub environment whose scoped `AZURE_SOURCE_KEY_VAULT_*` secrets point at that tier's vault: `non-prod` -> `test` environment, `prod` -> `prod` environment. (test/yt01/staging share one non-prod source vault, so reading it via `test` covers all three.)
- **`check-keyvault-expiry.py`** reworked env -> tier. The monitored-secrets allow-list is matched against source secret names by suffix, so entries stay in canonical env-key form (`Infrastructure--Maskinporten--EncodedJwk`) and tolerate the `dialogporten--(any|<env>)--` source prefix.
- **Fixes a latent jq bug** in the input validation: `index(.)` after a `|` rebinds `.` to the allowed array, so invalid input was never actually rejected. Now validates `non-prod`/`prod` correctly.
- No Bicep changes; no new permissions.

## Tier routing (unchanged)

| Days left | Non-prod source | Prod source |
|---|---|---|
| 8-30 | post, no mention | post, no mention |
| 2-7 | post + @here | post + @here |
| <=1 / expired | post + @channel | post + @channel, plus cross-post to prod-critical |

Missing-expires (a monitored secret without an expiry in its source vault) posts @here.

## Test plan

- [ ] `workflow_dispatch` with `tiers=non-prod` from this branch -> confirm the source-vault read succeeds and the step summary renders
- [ ] `workflow_dispatch` with `tiers=prod` -> confirm the prod OIDC path works (watch for any prod-environment approval gate)
- [ ] Confirm no spurious missing-expires alert (assumes the Maskinporten JWK has an expiry set in both source vaults)

## Follow-up

- PR C will document the rotation convention in `docs/Configuration.md` and fix the stale `docs/Infrastructure.md` line that omits yt01 from the non-prod source vault.

Related to #4012, #4034.