### PR TITLE
trivial(infra):Add NUGET_CERT_REVOCATION_MODE=offline to unblock CI after Refit cert revocation

### DIFF
--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -71,6 +71,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
+    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
+    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
+    # once Refit republishes 10.1.x with a valid signature.
+    env:
+      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -74,7 +74,7 @@ jobs:
     # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
     # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
     # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature.
+    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
     env:
       NUGET_CERT_REVOCATION_MODE: offline
     steps:

--- a/.github/workflows/dispatch-purge-e2e-test-data.yml
+++ b/.github/workflows/dispatch-purge-e2e-test-data.yml
@@ -25,6 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
+    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
+    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
+    # once Refit republishes 10.1.x with a valid signature.
+    env:
+      NUGET_CERT_REVOCATION_MODE: offline
     strategy:
       matrix:
         environment: >-

--- a/.github/workflows/dispatch-purge-e2e-test-data.yml
+++ b/.github/workflows/dispatch-purge-e2e-test-data.yml
@@ -28,7 +28,7 @@ jobs:
     # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
     # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
     # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature.
+    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
     env:
       NUGET_CERT_REVOCATION_MODE: offline
     strategy:

--- a/.github/workflows/workflow-build-and-test.yml
+++ b/.github/workflows/workflow-build-and-test.yml
@@ -9,6 +9,12 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
+    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
+    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
+    # once Refit republishes 10.1.x with a valid signature.
+    env:
+      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/workflow-build-and-test.yml
+++ b/.github/workflows/workflow-build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
     # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
     # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature.
+    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
     env:
       NUGET_CERT_REVOCATION_MODE: offline
     steps:

--- a/.github/workflows/workflow-publish-nuget.yml
+++ b/.github/workflows/workflow-publish-nuget.yml
@@ -35,7 +35,7 @@ jobs:
     # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
     # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
     # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature.
+    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
     env:
       NUGET_CERT_REVOCATION_MODE: offline
     steps:

--- a/.github/workflows/workflow-publish-nuget.yml
+++ b/.github/workflows/workflow-publish-nuget.yml
@@ -32,6 +32,12 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
+    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
+    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
+    # once Refit republishes 10.1.x with a valid signature.
+    env:
+      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/workflow-run-graphql-e2e-tests.yml
+++ b/.github/workflows/workflow-run-graphql-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
     # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
     # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
     # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature.
+    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
     env:
       NUGET_CERT_REVOCATION_MODE: offline
     steps:

--- a/.github/workflows/workflow-run-graphql-e2e-tests.yml
+++ b/.github/workflows/workflow-run-graphql-e2e-tests.yml
@@ -22,6 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
+    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
+    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
+    # once Refit republishes 10.1.x with a valid signature.
+    env:
+      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/workflow-run-webapi-e2e-tests.yml
+++ b/.github/workflows/workflow-run-webapi-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
     # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
     # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
     # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature.
+    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
     env:
       NUGET_CERT_REVOCATION_MODE: offline
     steps:

--- a/.github/workflows/workflow-run-webapi-e2e-tests.yml
+++ b/.github/workflows/workflow-run-webapi-e2e-tests.yml
@@ -22,6 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
+    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
+    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
+    # once Refit republishes 10.1.x with a valid signature.
+    env:
+      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:


### PR DESCRIPTION
Adds job-level `env: NUGET_CERT_REVOCATION_MODE: offline` to the six workflows that `dotnet restore`/`test` Refit-dependent projects. Refit 10.1.6's signing cert was revoked upstream, making Linux restore fail with `NU3012` and blocking CI/releases. Background, full impact, and the revert task: Related to #4049.

`offline` mode keeps signature and chain verification and only skips the live CRL check, the minimal change to restore green CI.

## Verification
- Reproduced `NU3012` and confirmed the flag fixes it in `mcr.microsoft.com/dotnet/sdk:10.0` (fresh cache); the `nuget.config` config-key equivalent does not work.
- `actionlint` clean on all six files; `env` at correct job scope.
- Suggest a `workflow_dispatch` of the Purge workflow (env `test`) on this branch as a live check before merge.
