### PR TITLE
feat: add opt-in endpoint/resolver output compression

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/Common/EnableResponseCompressionTypeInterceptor.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Common/EnableResponseCompressionTypeInterceptor.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using Digdir.Library.Utils.AspNet;
+using HotChocolate.Configuration;
+using HotChocolate.Language;
+using HotChocolate.Resolvers;
+using HotChocolate.Types.Descriptors.Definitions;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Digdir.Domain.Dialogporten.GraphQL.Common;
+
+/// <summary>
+/// Walks each object field at schema-build time and, for resolvers decorated with
+/// <see cref="EnableResponseCompressionAttribute"/>, appends a field middleware that sets
+/// <see cref="IHttpsCompressionFeature.Mode"/> to <see cref="HttpsCompressionMode.Compress"/> so the
+/// globally registered ResponseCompression middleware compresses the response over HTTPS. No
+/// runtime reflection — attribute lookup happens once during schema build.
+/// </summary>
+internal sealed class EnableResponseCompressionTypeInterceptor : TypeInterceptor
+{
+    public override void OnBeforeRegisterDependencies(
+        ITypeDiscoveryContext discoveryContext,
+        DefinitionBase definition)
+    {
+        if (definition is not ObjectTypeDefinition objectTypeDefinition)
+        {
+            return;
+        }
+
+        foreach (var field in objectTypeDefinition.Fields)
+        {
+            var member = field.ResolverMember ?? field.Member;
+            if (member?.GetCustomAttribute<EnableResponseCompressionAttribute>() is null)
+            {
+                continue;
+            }
+
+            field.MiddlewareDefinitions.Add(new FieldMiddlewareDefinition(
+                next => async context =>
+                {
+                    // Belt-and-braces: response compression only applies to read responses.
+                    // Skip if a decorated resolver is ever invoked under a mutation/subscription.
+                    if (context.Operation.Definition.Operation == OperationType.Query)
+                    {
+                        var httpContext = context.Services.GetRequiredService<IHttpContextAccessor>().HttpContext;
+                        if (httpContext?.Features.Get<IHttpsCompressionFeature>() is { } feature)
+                        {
+                            feature.Mode = HttpsCompressionMode.Compress;
+                        }
+                    }
+                    await next(context).ConfigureAwait(false);
+                }));
+        }
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Digdir.Domain.Dialogporten.GraphQL.csproj
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Digdir.Domain.Dialogporten.GraphQL.csproj
@@ -21,4 +21,8 @@
         <ProjectReference Include="..\Digdir.Library.Utils.AspNet\Digdir.Library.Utils.AspNet.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="Digdir.Domain.Dialogporten.GraphQl.Unit.Tests" />
+    </ItemGroup>
+
 </Project>

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/ServiceResourceMetadataQueries.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/ServiceResourceMetadataQueries.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Metadata.ServiceResources.Queries.Get;
+using Digdir.Library.Utils.AspNet;
 using MediatR;
 using static Digdir.Domain.Dialogporten.GraphQL.Common.Constants;
 using ServiceResourceMetadataModel = Digdir.Domain.Dialogporten.GraphQL.EndUser.ServiceResourceMetadata.ServiceResourceMetadata;
@@ -9,6 +10,7 @@ namespace Digdir.Domain.Dialogporten.GraphQL.EndUser;
 
 public partial class Queries
 {
+    [EnableResponseCompression]
     public async Task<ServiceResourceMetadataModel> GetServiceResources(
         [Service] ISender mediator,
         [Service] IMapper mapper,

--- a/src/Digdir.Domain.Dialogporten.GraphQL/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Program.cs
@@ -109,6 +109,9 @@ static void BuildAndRun(string[] args)
         // Graph QL
         .AddDialogportenGraphQl()
 
+        // Response compression (opt-in per resolver via [EnableResponseCompression])
+        .AddDialogportenResponseCompression()
+
         // Add controllers
         .AddControllers()
             .Services
@@ -162,6 +165,8 @@ static void BuildAndRun(string[] args)
     var app = builder.Build();
 
     app.UseCors();
+    // Must precede MapGraphQL so HotChocolate's response body stream is wrapped before write.
+    app.UseResponseCompression();
     app.MapAspNetHealthChecks()
         .UseMaintenanceMode()
         .UseJwtSchemeSelector()

--- a/src/Digdir.Domain.Dialogporten.GraphQL/ServiceCollectionExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ public static class ServiceCollectionExtensions
         .AddTransient<ActivityEnricher, DialogportenGqlActivityEnricher>()
         .AddGraphQLServer()
         .AddHttpRequestInterceptor<DialogportenHttpRequestInterceptor>()
+        .TryAddTypeInterceptor<EnableResponseCompressionTypeInterceptor>()
         .ModifyCostOptions(o => o.ApplyCostDefaults = false)
         // This assumes that subscriptions have been set up by the infrastructure
         .AddSubscriptionType<Subscriptions>()

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Extensions/ResponseCompressionEndpointFilterExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Extensions/ResponseCompressionEndpointFilterExtensions.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using Digdir.Library.Utils.AspNet;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Common.Extensions;
+
+internal static class ResponseCompressionEndpointFilterExtensions
+{
+    /// <summary>
+    /// If any public instance method on <paramref name="endpointType"/> carries
+    /// <see cref="EnableResponseCompressionAttribute"/>, attaches an endpoint filter that opts the
+    /// response in to compression over HTTPS by setting <see cref="IHttpsCompressionFeature.Mode"/>.
+    /// </summary>
+    public static RouteHandlerBuilder AddResponseCompressionHintIfMarked(
+        this RouteHandlerBuilder routeHandlerBuilder, Type endpointType)
+    {
+        var marked = endpointType
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Any(m => m.GetCustomAttribute<EnableResponseCompressionAttribute>() is not null);
+
+        if (!marked)
+        {
+            return routeHandlerBuilder;
+        }
+
+        routeHandlerBuilder.AddEndpointFilter((ctx, next) =>
+        {
+            if (ctx.HttpContext.Features.Get<IHttpsCompressionFeature>() is { } feature)
+            {
+                feature.Mode = HttpsCompressionMode.Compress;
+            }
+            return next(ctx);
+        });
+        return routeHandlerBuilder;
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/Metadata/ServiceResources/Get/GetServiceResourceMetadataEndpoint.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/Metadata/ServiceResources/Get/GetServiceResourceMetadataEndpoint.cs
@@ -2,8 +2,10 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Metadata.ServiceResources.Queries.Get;
 using Digdir.Domain.Dialogporten.WebApi.Common;
 using Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.Common.Extensions;
+using Digdir.Library.Utils.AspNet;
 using FastEndpoints;
 using MediatR;
+using Constants = Digdir.Domain.Dialogporten.WebApi.Common.Constants;
 
 namespace Digdir.Domain.Dialogporten.WebApi.Endpoints.V1.Metadata.ServiceResources.Get;
 
@@ -28,6 +30,7 @@ public sealed class GetServiceResourceMetadataEndpoint
         Description(b => b.ProducesOneOf<GetServiceResourceMetadataDto>(StatusCodes.Status200OK));
     }
 
+    [EnableResponseCompression]
     public override async Task HandleAsync(GetServiceResourceMetadataRequest req, CancellationToken ct)
     {
         var result = await _sender.Send(new GetServiceResourceMetadataQuery

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -115,6 +115,7 @@ static void BuildAndRun(string[] args)
             ServiceLifetime.Transient, includeInternalTypes: true)
         .AddAzureAppConfiguration()
         .AddEndpointsApiExplorer()
+        .AddDialogportenResponseCompression()
         .AddFastEndpoints()
         .SwaggerDocument(x =>
         {
@@ -166,8 +167,11 @@ static void BuildAndRun(string[] args)
     app.MapAspNetHealthChecks()
         .MapControllers();
 
-    app.UseHttpsRedirection()
-        .UseDefaultExceptionHandler()
+    app.UseHttpsRedirection();
+    // Wraps the response body before any downstream middleware writes. Must precede
+    // UseDefaultExceptionHandler so problem+json error bodies on opted-in endpoints are compressed too.
+    app.UseResponseCompression();
+    app.UseDefaultExceptionHandler()
         .UseMaintenanceMode()
         .UseJwtSchemeSelector()
         .UseAuthentication()
@@ -183,8 +187,9 @@ static void BuildAndRun(string[] args)
             x.Versioning.DefaultVersion = 1;
             x.Endpoints.Configurator = endpointDefinition =>
             {
-                endpointDefinition.Description(routeHandlerBuilder
-                    => routeHandlerBuilder.Add(endpointBuilder =>
+                endpointDefinition.Description(routeHandlerBuilder =>
+                {
+                    routeHandlerBuilder.Add(endpointBuilder =>
                     {
                         endpointBuilder.Metadata.Add(
                             new EndpointNameMetadata(
@@ -196,7 +201,10 @@ static void BuildAndRun(string[] args)
                         {
                             endpointBuilder.Metadata.Add(operationIdAttr);
                         }
-                    }));
+                    });
+
+                    routeHandlerBuilder.AddResponseCompressionHintIfMarked(endpointDefinition.EndpointType);
+                });
             };
             x.Serializer.Options.RespectNullableAnnotations = true;
             x.Serializer.Options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;

--- a/src/Digdir.Library.Utils.AspNet/Digdir.Library.Utils.AspNet.csproj
+++ b/src/Digdir.Library.Utils.AspNet/Digdir.Library.Utils.AspNet.csproj
@@ -6,10 +6,15 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!-- Microsoft.AspNetCore.ResponseCompression (used by ResponseCompressionExtensions) ships
+             only through the ASP.NET Core shared framework; there is no standalone NuGet for it. -->
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Azure.Identity" Version="1.21.0" />
         <PackageReference Include="HotChocolate.Diagnostics" Version="15.1.16" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.1" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0"/>
         <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />

--- a/src/Digdir.Library.Utils.AspNet/EnableResponseCompressionAttribute.cs
+++ b/src/Digdir.Library.Utils.AspNet/EnableResponseCompressionAttribute.cs
@@ -1,0 +1,10 @@
+namespace Digdir.Library.Utils.AspNet;
+
+/// <summary>
+/// Marks an endpoint (FastEndpoints) or resolver (HotChocolate) as eligible for response compression
+/// over HTTPS. Each host wires its own discovery: WebApi via a FastEndpoints endpoint filter that sets
+/// <see cref="Microsoft.AspNetCore.Http.Features.IHttpsCompressionFeature.Mode"/>; GraphQL via a
+/// HotChocolate type interceptor that prepends a field middleware doing the same.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+public sealed class EnableResponseCompressionAttribute : Attribute;

--- a/src/Digdir.Library.Utils.AspNet/ResponseCompressionExtensions.cs
+++ b/src/Digdir.Library.Utils.AspNet/ResponseCompressionExtensions.cs
@@ -1,0 +1,35 @@
+using System.IO.Compression;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Digdir.Library.Utils.AspNet;
+
+public static class ResponseCompressionExtensions
+{
+    public static IServiceCollection AddDialogportenResponseCompression(this IServiceCollection services)
+    {
+        services.Configure<BrotliCompressionProviderOptions>(o => o.Level = CompressionLevel.Fastest);
+        services.Configure<GzipCompressionProviderOptions>(o => o.Level = CompressionLevel.Fastest);
+
+        services.AddResponseCompression(o =>
+        {
+            // Off-by-default for HTTPS; endpoints/resolvers opt in by applying
+            // [EnableResponseCompression], which causes IHttpsCompressionFeature.Mode to be set
+            // to Compress before the response body is written. Targeted surfaces return public,
+            // non-user-specific data, so BREACH/CRIME side-channels do not apply.
+            o.EnableForHttps = false;
+            o.Providers.Add<BrotliCompressionProvider>();
+            o.Providers.Add<GzipCompressionProvider>();
+            o.MimeTypes =
+            [
+                "application/json",
+                "application/problem+json",
+                // GraphQL-over-HTTP spec; HotChocolate emits this when clients send the matching
+                // Accept header (modern Apollo and graphql-fetch implementations do).
+                "application/graphql-response+json",
+            ];
+        });
+        return services;
+    }
+}

--- a/src/Digdir.Library.Utils.AspNet/packages.lock.json
+++ b/src/Digdir.Library.Utils.AspNet/packages.lock.json
@@ -66,20 +66,6 @@
           "Microsoft.Extensions.Configuration.AzureAppConfiguration": "8.5.0"
         }
       },
-      "Microsoft.Extensions.Http": {
-        "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "/9LU/KWJOrtZJB9ymPjcARDyjp679BvBA/aSncv2Kt84WlSKz767HtxHg8EFsu8n21BMLZi+5XxlkKbLwfn4iA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Diagnostics": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
       "Npgsql.OpenTelemetry": {
         "type": "Direct",
         "requested": "[10.0.2, )",
@@ -96,8 +82,6 @@
         "resolved": "1.15.3",
         "contentHash": "N0i6WjPoHPbZyms1ugbDIFAJFuGlpeExJMU/+XSL0lQRUkg/D0utFkDoLXf8Z1km5B+xVZ2GyMXXiX8qdeNmPg==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "1.15.3"
         }
       },
@@ -169,13 +153,6 @@
         "resolved": "10.0.1",
         "contentHash": "8rBC3rvIPuTat66JmvlEk2Yfl/vQysJNYwyuq0Gzn2IXucRGM9qitQFS82qwbtpco86zFAWTYG2tvtckuCHXiA==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Caching.Memory": "10.0.2",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Http": "10.0.2",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Options": "10.0.2",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2",
           "Microsoft.IdentityModel.Tokens": "8.15.0",
           "System.IdentityModel.Tokens.Jwt": "8.15.0"
         }
@@ -188,10 +165,7 @@
       "AspNetCore.HealthChecks.UI.Core": {
         "type": "Transitive",
         "resolved": "9.0.0",
-        "contentHash": "TVriy4hgYnhfqz6NAzv8qe62Q8wf82iKUL6WV9selqeFZTq1ILi39Sic6sFQegRysvAVcnxKP/vY8z9Fk8x6XQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11"
-        }
+        "contentHash": "TVriy4hgYnhfqz6NAzv8qe62Q8wf82iKUL6WV9selqeFZTq1ILi39Sic6sFQegRysvAVcnxKP/vY8z9Fk8x6XQ=="
       },
       "AsyncKeyedLock": {
         "type": "Transitive",
@@ -201,10 +175,7 @@
       "AutoMapper": {
         "type": "Transitive",
         "resolved": "14.0.0",
-        "contentHash": "OC+1neAPM4oCCqQj3g2GJ2shziNNhOkxmNB9cVS8jtx4JbgmRzLcUOxB9Tsz6cVPHugdkHgCaCrTjjSI0Z5sCQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Options": "8.0.0"
-        }
+        "contentHash": "OC+1neAPM4oCCqQj3g2GJ2shziNNhOkxmNB9cVS8jtx4JbgmRzLcUOxB9Tsz6cVPHugdkHgCaCrTjjSI0Z5sCQ=="
       },
       "Azure.Core": {
         "type": "Transitive",
@@ -212,8 +183,6 @@
         "contentHash": "m6hHbx1q9+GCBZ5A9ykzFylPdTwscX2APH7PlnqV+yu+DH3RRtuIDJMRqdU17cMyinv0hCPofpegoyQ6qWPW7g==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
           "Microsoft.Identity.Client": "4.83.1",
           "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
           "System.ClientModel": "1.10.0",
@@ -332,8 +301,7 @@
         "resolved": "12.1.1",
         "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
         "dependencies": {
-          "FluentValidation": "12.1.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+          "FluentValidation": "12.1.1"
         }
       },
       "Google.Protobuf": {
@@ -346,9 +314,7 @@
         "resolved": "15.1.16",
         "contentHash": "Q8yE0BQ4BCtBo6BYfp9UluKeN8uCRJmkqUURYgwPy6+Ohaz20C1bdvhxLV8frlT46I4HpLjIzynT7nU95Z0axQ==",
         "dependencies": {
-          "GreenDonut.Abstractions": "15.1.16",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.2",
-          "Microsoft.Extensions.ObjectPool": "9.0.2"
+          "GreenDonut.Abstractions": "15.1.16"
         }
       },
       "GreenDonut.Abstractions": {
@@ -389,8 +355,7 @@
         "resolved": "2.70.0",
         "contentHash": "xNv0FFCVJa5S1beUtye82WFCxKThuE1jbN8DO1x1Rj8VSIWXLBUmfSID5a1fGzsU2R/EMfwPoWclJ2RMfQuGXw==",
         "dependencies": {
-          "Grpc.Net.Common": "2.70.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+          "Grpc.Net.Common": "2.70.0"
         }
       },
       "Grpc.Net.Common": {
@@ -467,8 +432,7 @@
           "HotChocolate.Fetching": "15.1.16",
           "HotChocolate.Types": "15.1.16",
           "HotChocolate.Utilities.DependencyInjection": "15.1.16",
-          "HotChocolate.Validation": "15.1.16",
-          "Microsoft.Extensions.DependencyInjection": "9.0.2"
+          "HotChocolate.Validation": "15.1.16"
         }
       },
       "HotChocolate.Execution.Abstractions": {
@@ -476,8 +440,7 @@
         "resolved": "15.1.16",
         "contentHash": "0OhQayNTfdZxw4oD7lPqiqvV+yHBO1M3xLMNfxvn+WXxNf5rnT8aMM4Z4Bj9j5wk0q87fiLVG1jfTd0P1b6WrQ==",
         "dependencies": {
-          "HotChocolate.Abstractions": "15.1.16",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.2"
+          "HotChocolate.Abstractions": "15.1.16"
         }
       },
       "HotChocolate.Execution.Projections": {
@@ -519,10 +482,7 @@
       "HotChocolate.Language.SyntaxTree": {
         "type": "Transitive",
         "resolved": "15.1.16",
-        "contentHash": "ocyfnClIllgYHbmSLowKoQk7M620iSIy3ZRLkusVhUGJ0877Y5l9qdBy2jsczNct/OkR1pPSGs0FvKTedIgcgA==",
-        "dependencies": {
-          "Microsoft.Extensions.ObjectPool": "9.0.2"
-        }
+        "contentHash": "ocyfnClIllgYHbmSLowKoQk7M620iSIy3ZRLkusVhUGJ0877Y5l9qdBy2jsczNct/OkR1pPSGs0FvKTedIgcgA=="
       },
       "HotChocolate.Language.Utf8": {
         "type": "Transitive",
@@ -572,8 +532,7 @@
         "contentHash": "/znJTx/WF4mNqMob1jMc7RGqFCjYBAuN3kjXKYOO8zwQzie+480H/s6cHDOMnf+XMr35WnLL3tX5ku4M/kQRHA==",
         "dependencies": {
           "HotChocolate.Execution.Abstractions": "15.1.16",
-          "HotChocolate.Subscriptions": "15.1.16",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.2"
+          "HotChocolate.Subscriptions": "15.1.16"
         }
       },
       "HotChocolate.Subscriptions.Redis": {
@@ -583,7 +542,6 @@
         "dependencies": {
           "HotChocolate.Execution.Abstractions": "15.1.16",
           "HotChocolate.Subscriptions": "15.1.16",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.2",
           "StackExchange.Redis": "2.6.80"
         }
       },
@@ -601,9 +559,7 @@
           "HotChocolate.Abstractions": "15.1.16",
           "HotChocolate.Features": "15.1.16",
           "HotChocolate.Types.Shared": "15.1.16",
-          "HotChocolate.Utilities": "15.1.16",
-          "Microsoft.Extensions.DependencyInjection": "9.0.2",
-          "Microsoft.Extensions.ObjectPool": "9.0.2"
+          "HotChocolate.Utilities": "15.1.16"
         }
       },
       "HotChocolate.Types.CursorPagination": {
@@ -669,27 +625,19 @@
       "HotChocolate.Utilities": {
         "type": "Transitive",
         "resolved": "15.1.16",
-        "contentHash": "/fM1uMU6UhEGh49NwxIKt12sDlO2Re6xRgf1M9gp7L/zFjC4pGvQgAqBjiyvTbgTNR3GWuWvdfnZ52qSsCndNQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.2"
-        }
+        "contentHash": "/fM1uMU6UhEGh49NwxIKt12sDlO2Re6xRgf1M9gp7L/zFjC4pGvQgAqBjiyvTbgTNR3GWuWvdfnZ52qSsCndNQ=="
       },
       "HotChocolate.Utilities.DependencyInjection": {
         "type": "Transitive",
         "resolved": "15.1.16",
-        "contentHash": "k5VOxLjFfuerpjRJPJoay4qLouBux7xogCCAqip9shgXHJUyQtKh/pwFDbnGNdsCI+Ik97SV8vGBtAlkrPj3RQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "9.0.2"
-        }
+        "contentHash": "k5VOxLjFfuerpjRJPJoay4qLouBux7xogCCAqip9shgXHJUyQtKh/pwFDbnGNdsCI+Ik97SV8vGBtAlkrPj3RQ=="
       },
       "HotChocolate.Validation": {
         "type": "Transitive",
         "resolved": "15.1.16",
         "contentHash": "HrYNTdG4j2yXW8rJzGkvbnNSZpjIndR8SDPlXfYE7rn48aJLxSEKJ2Us7AdwmIwCMHSnoYsVV1jz0XAUze3nsw==",
         "dependencies": {
-          "HotChocolate.Types": "15.1.16",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.2",
-          "Microsoft.Extensions.Options": "9.0.2"
+          "HotChocolate.Types": "15.1.16"
         }
       },
       "HtmlAgilityPack": {
@@ -707,12 +655,7 @@
         "resolved": "8.5.7",
         "contentHash": "ZMJAhl7EHBhHvH1c/Jc6FZdV2sNgf5DETfxVq1Wm7i0By6o8LvrVQakBAvC7GK2ZHMJB2kmeD5YM3JPSGvT3HA==",
         "dependencies": {
-          "MassTransit.Abstractions": "8.5.7",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.0",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "MassTransit.Abstractions": "8.5.7"
         }
       },
       "MassTransit.Abstractions": {
@@ -736,8 +679,7 @@
         "contentHash": "ZOx5WseH83PXk/We2c0gWT8+4f0Z27kP0yU2mLq8CSlq9xa+Ke61exu7Th2wjgZCMGSjwtdHlBHMJNZnyQg1vA==",
         "dependencies": {
           "MassTransit": "8.5.7",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
-          "Microsoft.Extensions.Caching.Memory": "10.0.0"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.0"
         }
       },
       "MediatR": {
@@ -745,8 +687,7 @@
         "resolved": "12.5.0",
         "contentHash": "vqm2H8/nqL5NAJHPhsG1JOPwfkmbVrPyh4svdoRzu+uZh6Ex7PRoHBGsLYC0/RWCEJFqD1ohHNpteQvql9OktA==",
         "dependencies": {
-          "MediatR.Contracts": "[2.0.1, 3.0.0)",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0"
+          "MediatR.Contracts": "[2.0.1, 3.0.0)"
         }
       },
       "MediatR.Contracts": {
@@ -808,9 +749,7 @@
         "contentHash": "EJx+fIBMgBlgD+ublKCn+GTOJkw3UqV7xOjYWBRVdUYyIm8UfvAsmSOPFiIInsWTHyMEYUJ9gCJY1jwX+6UB7w==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Abstractions": "10.0.8",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.8",
-          "Microsoft.Extensions.Caching.Memory": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8"
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.8"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
@@ -828,10 +767,7 @@
         "resolved": "10.0.8",
         "contentHash": "UU3diAD2wwZveye2rnrwaF/wvJ9tm5iL2fuY9TTap6/iGQK1OO29M1BzXZRlRPVH/dByt5w/pISBSFtyR7hTqw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.8",
-          "Microsoft.Extensions.Caching.Memory": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "Microsoft.Extensions.Azure": {
@@ -840,34 +776,7 @@
         "contentHash": "3sIvazPesPdEn5t2yT+pwVWKm1LyN/LB31Wh52giRNf2ckcKmaxW2KOA5uNZHSaqABhMDPAYGMeGBFQreZ7uUg==",
         "dependencies": {
           "Azure.Core": "1.46.2",
-          "Azure.Identity": "1.13.1",
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Logging": "8.0.1",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
-          "Microsoft.Extensions.Options": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Caching.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "EoK2TwVR1daxmfXUPnvIYZSk5XQjHe45sGekox4kvMt88KQZQhDVzYW5Na5+oNwTuRpE48hipyGJg12F1Tm70w==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Caching.Memory": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "sYMYQjNprfqPTryuLNnr0/AOtnhlfuZ0ZxyOV0d3AXOEL8j9KV0EbelpZYyIatT2hJiaSGO9XGr5YDRsh22OfQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Azure.Identity": "1.13.1"
         }
       },
       "Microsoft.Extensions.Caching.StackExchangeRedis": {
@@ -875,27 +784,7 @@
         "resolved": "10.0.8",
         "contentHash": "fle9ns3q2kk63vt/wHFtLw1U9kiEbM42vTk2Sar8VBjiGJFkXAgm0QEKFx15YMHkJIPRVdknWaovpvgGEgn10g==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
           "StackExchange.Redis": "2.7.27"
-        }
-      },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "I63esIFbL3h5pSt7gXpXOlmcwDmYBUoYNEglKfDPFUqtYvSV84f2l28hO2lfVXsV0wdlplgAM7IVz16matapSg==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
       "Microsoft.Extensions.Configuration.AzureAppConfiguration": {
@@ -908,199 +797,20 @@
           "Azure.Security.KeyVault.Secrets": "4.8.0",
           "DnsClient": "1.7.0",
           "Microsoft.Bcl.HashCode": "6.0.0",
-          "Microsoft.Extensions.Azure": "1.12.0",
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.19",
-          "Microsoft.Extensions.Logging": "8.0.1"
+          "Microsoft.Extensions.Azure": "1.12.0"
         }
-      },
-      "Microsoft.Extensions.Configuration.Binder": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Configuration.CommandLine": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "nQXq1a4MiInYh+0VF9fguxAl06q2ftmOyYQ+5e933s4rk57xjgkbTjUdFUySzjrcrvDeWsSqlZB+TE8+TbM2HA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "bVGqctAfPGfTxJvNp8pMshtvpsUj6r6JkeiCNVIGVYO5gBxuxdN0Lbr25kEvE/zXdctkEc44g8HssnPgDnFGVA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Configuration.FileExtensions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "1g9mzuu8gIHkjYb0jLxOTQVl/QDG5nn0b0JzgT/gbgNKr6gXZzxOHRAsdYRc1eDApB7LdHR8uK5vQrNjIQdRrQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Json": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "KLtAZ6A38s1pIfCO2ns6aG14NNGMYNZ4PBYfFK4M+R4A+xuSc6oklhqDcpHZxvDpyBWeFtR5C8iQBw2ng8tUHQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Configuration.UserSecrets": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "6XTfFOnf27WY8kEeZkTZ4YNn0t+imgvdQ0YaAdR4vgURKATo9bCaVJ1KB71IOJAQtJP7Elb53VHlTNXg2CtSsA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Json": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "daf62xHIrq8pnE709hgaZZN9tSam9TGGepWe1+bE6V3GEuVwJiMs6ib+38lfMCyAJAHiX0vapxBhsuMSV7U+cg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "10.0.0",
         "contentHash": "RFYJR7APio/BiqdQunRq6DB+nDB6nc2qhHr77mlvZ0q0BT8PubMXN7XicmfzCbrDE/dzhBnUKBRXLTcqUiZDGg=="
       },
-      "Microsoft.Extensions.Diagnostics": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "uduyw9d3Fi+sbredO5drA1S44AQS2FRNFyn72UmB2vmQIO1qaXprpp1U/2lYhYi8yFdVERfY9sy/pxw/qPOU9w==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "+f4C5g78QCGNyxzUfrTYsB7qYx06Zca0e88s3qFlea9/lQhgPImYdNprlgzl1uHhRU3fVHLfmbijayU2sJEZ6w==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "IlXZUZIA9b99yQURc8jOLmmS6GD42vj6t+LqWs6Dd+naggObSbEXDw8DU8DUu2tL8CnyG96F4pDLhjd7BmZPAQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "0j06qq5I1YGSIi4M86UaVITBprvn3bTWKmQiLDNEqnZ2d+UxaFb+tVqemxVzr5lkr6GTR83ExUfSIpCnBaTZFA=="
-      },
       "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
         "type": "Transitive",
         "resolved": "10.0.8",
         "contentHash": "VyjlpOHGpT9xoNFKNd/27FBF4eBimMcCCIfMxkeju/8uUnugwsxHfzZX2iP+ilYeoYB4HeT5gAoswTIKD6SYJw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.8",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.8",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.FileProviders.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "U+oquaPxFdY8lYeEIWO/AD7jDIl9sPW6aVWMQRHU/pZ/SWpLcOrAj2fcLe1HwXl4sYw1ONI56K/eELT3xr4RRQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.FileProviders.Physical": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "GkPvQe6IdidLu6Q3Lw6+B8NJpW8feW8czZ5mBKt5rXM/x8MvZfEp5WvAsjznzDGd23chIDrW0b2mmt+ScnEgiw==",
-        "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileSystemGlobbing": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.FileSystemGlobbing": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "IUQet3SY51xIFcFZKtAB6a54/Zdxs7T3SQ84kJtOD6yeXfZgiOMksACWD5qtTmXGQGFH4QYGBOT0KIO8Uy/dJw=="
-      },
-      "Microsoft.Extensions.Hosting": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "VfEyM2BipThcSd0GG/FS2ZPCVCTiosVq2zLKEDsfeMIg78sOVZPEmS7CgWlb+dqTlgXvLSL4OG2q6sM4xRhHNg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
-          "Microsoft.Extensions.Configuration.CommandLine": "10.0.8",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.8",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Json": "10.0.8",
-          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Diagnostics": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.8",
-          "Microsoft.Extensions.Logging.Console": "10.0.8",
-          "Microsoft.Extensions.Logging.Debug": "10.0.8",
-          "Microsoft.Extensions.Logging.EventLog": "10.0.8",
-          "Microsoft.Extensions.Logging.EventSource": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "MoOWFPT88/pDfmWpbU9PydKRX/rJFQkliowE/L9wbQcl94IicUphb5BFgepkWiDkYYxPnuEqjN4buzOGW4vJpQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.8"
         }
       },
       "Microsoft.Extensions.Http.Polly": {
@@ -1108,120 +818,9 @@
         "resolved": "10.0.8",
         "contentHash": "XXYEV1G6ILrK7F3zwjQxxbYKZba79NUz7cgy1wEjctcxNHI5i8YI5eOCkPhcZ//vvuT8vd+GdNBfPdYDOPCL1A==",
         "dependencies": {
-          "Microsoft.Extensions.Http": "10.0.8",
           "Polly": "7.2.4",
           "Polly.Extensions.Http": "3.0.0"
         }
-      },
-      "Microsoft.Extensions.Logging": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "K60JhWC2hN/Gi7TP68tBxSzk5ACWOs7lkmPzsfA8Bcf/IXTajujt2ORMf9rSMk1bsng6Lv4Y3fuxp3bm1+15ug==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "fdVadZmsC8jRP0KvKy8mO8f6GV/HyBvElfcSxEhd+5FM5boAw/01iSaCto5G3G37ApJira4A3pNaVvBv8cUiLQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "rxSLTO7xTbcC3DuEJHNEijBr8g14Jj62zQ+DeFu68bsoTYoU8jLcMhc1735PV21bESXsATlL5LsfaWH71FOWAg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.Console": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "6cv53sHsPnFS56PJw8X4GbNcjeX1KGyFJRxJWvxOgK63cnqeSB1k1eRwjUdkse0tBhwlH6qc9EOYDlan+CYTuw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.Debug": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "4HW3M1lGHHDwEYcDZHRNptBQ48LCI2yW+XV4vuxdfQUqafTpVT8j9RqAsez08krZKhIiaArWu8iQq5uRKZ9Ffg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.EventLog": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "kK/C3SLIoGrcZvddYQw4eMm6YaROiSYBO7YgUR5Hdv5l+GIjBmbvQK5cST2FqjeubiAOPqFEimBT2N/8wVI+3A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "System.Diagnostics.EventLog": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Logging.EventSource": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "HX2M0MgzwQM8jpLe3AYAEMd0YsUfOP5RgGrDuk+Ki9n7HSuMbvLm9TEV3qRI3Pg9aqxc56GfgK/KdMRBhfWwKw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.ObjectPool": {
-        "type": "Transitive",
-        "resolved": "9.0.2",
-        "contentHash": "nWx7uY6lfkmtpyC2dGc0IxtrZZs/LnLCQHw3YYQucbqWj8a27U/dZ+eh72O3ZiolqLzzLkVzoC+w/M8dZwxRTw=="
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "VBD+131DpTNCNDfA4kIyKTiCySvJGNhwibdWBSdFRu7GMfXLXcXODkgA+KStKbbhzraLglZWUN4nXyHgW4JIRA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "VOapXeO3lhBH0zYoyAH7tjapuo4V5pTHlevPpiSHueEquAajqd5nF0mttm+h/uE/exwAEuM5s26SzOJtletE3w==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "OBPo4nYhMyIbtueoC10CBm6AGAbo/A9IV8QQ/6ryZS7VvmqpGT7hunazeHLxFawRzn3oLOq4jhqhpBX4tfswWQ=="
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
@@ -1266,7 +865,6 @@
         "resolved": "8.15.0",
         "contentHash": "zUE9ysJXBtXlHHRtcRK3Sp8NzdCI1z/BRDTXJQ2TvBoI0ENRtnufYIep0O5TSCJRJGDwwuLTUx+l/bEYZUxpCA==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
           "Microsoft.IdentityModel.Logging": "8.15.0"
         }
       },
@@ -1278,10 +876,7 @@
       "Npgsql": {
         "type": "Transitive",
         "resolved": "10.0.2",
-        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
-        "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
-        }
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg=="
       },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "Transitive",
@@ -1321,7 +916,6 @@
         "resolved": "1.15.3",
         "contentHash": "SYn0lqYDwLMWhv/zlNGsQcl2yX++yTumanX46bmOZE/ZDOd1WjPBO2kZaZgKLEZTZk48pavIFGJ6vOvxXgWVFQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "OpenTelemetry.Api": "1.15.3"
         }
       },
@@ -1330,7 +924,6 @@
         "resolved": "1.15.3",
         "contentHash": "u8n/W8yIlqv0BXZmvId1iVaeWXG42tGKdTkuLYg5g57Y/r9CeUNzqtrSHNdG5IoO8iPX79w3v+WsbAHgUQbfeg==",
         "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "OpenTelemetry": "1.15.3"
         }
       },
@@ -1347,8 +940,6 @@
         "resolved": "1.15.1",
         "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
         }
       },
@@ -1357,8 +948,6 @@
         "resolved": "1.15.2",
         "contentHash": "pRB84YJEXD121kygc6CtcF46dtLuTKIjphA2SJye32G4g2Xl3epkCrOcPCOAg4WDagCdMGa16Ge6PPVzFJZsAQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
         }
       },
@@ -1403,7 +992,6 @@
         "resolved": "7.0.0",
         "contentHash": "wHWaroody48jnlLoq/REwUltIFLxplXyHTP+sttrc8P7+jkiVqf38afDidJNv4qgD/6zz2NKOYg06xLZ1bG7wQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "Microsoft.Extensions.DependencyModel": "10.0.0"
         }
       },
@@ -1417,9 +1005,6 @@
         "resolved": "10.0.0",
         "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
           "Serilog": "4.3.0",
           "Serilog.Extensions.Logging": "10.0.0"
         }
@@ -1429,7 +1014,6 @@
         "resolved": "10.0.0",
         "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
         "dependencies": {
-          "Microsoft.Extensions.Logging": "10.0.0",
           "Serilog": "4.2.0"
         }
       },
@@ -1446,7 +1030,6 @@
         "resolved": "10.0.0",
         "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
           "Microsoft.Extensions.DependencyModel": "10.0.0",
           "Serilog": "4.3.0"
         }
@@ -1480,7 +1063,6 @@
         "resolved": "2.10.1",
         "contentHash": "se08WZvD42H3bV4XBW07pupTiE2/72qStKyi/lRqqcijksFWfRtwLTuhFtZ4OX19f4+we/2qruFZBXYJBFc8PQ==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.8",
           "System.IO.Hashing": "9.0.10"
         }
@@ -1490,16 +1072,8 @@
         "resolved": "1.10.0",
         "contentHash": "lBEWs54F5Y5pZ9hC+8z4S/X76957ex+DPk7WecRHlbIHtrPfbRMMlOgI3iDn4Jpb3bSxvBnKaaHoD59auFjlBA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
           "System.Memory.Data": "10.0.3"
         }
-      },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "+Ro7WgIom+BDNH+YhTuZKL6QJ0ctfOpTyfUG/h3aU5KwXt3OaNf0wYWrTvoBUj+34Dy5V8dN9yCco1hAJQ4txw=="
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
@@ -1536,10 +1110,7 @@
       "ZiggyCreatures.FusionCache": {
         "type": "Transitive",
         "resolved": "2.6.0",
-        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
-        "dependencies": {
-          "Microsoft.Extensions.Caching.Memory": "10.0.1"
-        }
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
       },
       "ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis": {
         "type": "Transitive",
@@ -1578,8 +1149,6 @@
           "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
           "HtmlAgilityPack": "[1.12.4, )",
           "MediatR": "[12.5.0, )",
-          "Microsoft.Extensions.Hosting": "[10.0.8, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
           "Npgsql": "[10.0.2, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
@@ -1592,8 +1161,7 @@
         "type": "Project",
         "dependencies": {
           "DeterministicGuids": "[1.0.11, )",
-          "Digdir.Library.Entity.Abstractions": "[1.0.0, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )"
+          "Digdir.Library.Entity.Abstractions": "[1.0.0, )"
         }
       },
       "digdir.domain.dialogporten.infrastructure": {
@@ -1609,10 +1177,7 @@
           "MassTransit.Azure.ServiceBus.Core": "[8.5.7, 9.0.0)",
           "MassTransit.EntityFrameworkCore": "[8.5.7, 9.0.0)",
           "Microsoft.Extensions.Caching.StackExchangeRedis": "[10.0.8, )",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[10.0.8, )",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.0.8, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.8, )",
           "Npgsql": "[10.0.2, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/EnableResponseCompressionInterceptorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/EnableResponseCompressionInterceptorTests.cs
@@ -1,0 +1,99 @@
+using AwesomeAssertions;
+using Digdir.Domain.Dialogporten.GraphQL.Common;
+using Digdir.Library.Utils.AspNet;
+using HotChocolate;
+using HotChocolate.Execution;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Digdir.Domain.Dialogporten.GraphQl.Unit.Tests;
+
+public class EnableResponseCompressionInterceptorTests
+{
+    [Fact]
+    public async Task Decorated_resolver_sets_HttpsCompression_mode_to_Compress()
+    {
+        var (executor, feature) = await BuildExecutorAsync();
+
+        var result = await executor.ExecuteAsync("{ marked }", TestContext.Current.CancellationToken);
+
+        result.ExpectOperationResult().Errors.Should().BeNullOrEmpty();
+        feature.Mode.Should().Be(HttpsCompressionMode.Compress);
+    }
+
+    [Fact]
+    public async Task Undecorated_resolver_leaves_HttpsCompression_mode_at_default()
+    {
+        var (executor, feature) = await BuildExecutorAsync();
+
+        var result = await executor.ExecuteAsync("{ plain }", TestContext.Current.CancellationToken);
+
+        result.ExpectOperationResult().Errors.Should().BeNullOrEmpty();
+        feature.Mode.Should().Be(HttpsCompressionMode.Default);
+    }
+
+    [Fact]
+    public async Task Decorated_mutation_does_not_set_HttpsCompression_mode()
+    {
+        var (executor, feature) = await BuildExecutorAsync(withMutation: true);
+
+        var result = await executor.ExecuteAsync("mutation { markedMutation }", TestContext.Current.CancellationToken);
+
+        result.ExpectOperationResult().Errors.Should().BeNullOrEmpty();
+        feature.Mode.Should().Be(HttpsCompressionMode.Default);
+    }
+
+    private static async Task<(IRequestExecutor Executor, FakeHttpsCompressionFeature Feature)> BuildExecutorAsync(
+        bool withMutation = false)
+    {
+        var httpContext = new DefaultHttpContext();
+        var feature = new FakeHttpsCompressionFeature();
+        httpContext.Features.Set<IHttpsCompressionFeature>(feature);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IHttpContextAccessor>(new StubHttpContextAccessor(httpContext));
+        var builder = services
+            .AddGraphQLServer()
+            .AddQueryType<TestQuery>()
+            .TryAddTypeInterceptor<EnableResponseCompressionTypeInterceptor>();
+        if (withMutation)
+        {
+            builder.AddMutationType<TestMutation>();
+        }
+
+        var provider = services.BuildServiceProvider();
+        var executor = await provider.GetRequiredService<IRequestExecutorResolver>()
+            .GetRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        return (executor, feature);
+    }
+
+    private sealed class FakeHttpsCompressionFeature : IHttpsCompressionFeature
+    {
+        public HttpsCompressionMode Mode { get; set; } = HttpsCompressionMode.Default;
+    }
+
+    private sealed class StubHttpContextAccessor(HttpContext httpContext) : IHttpContextAccessor
+    {
+        public HttpContext? HttpContext { get; set; } = httpContext;
+    }
+}
+
+public sealed class TestQuery
+{
+#pragma warning disable CA1822 // Resolver methods must be instance members so HotChocolate binds them as fields.
+    [EnableResponseCompression]
+    public string Marked() => "ok";
+
+    public string Plain() => "ok";
+#pragma warning restore CA1822
+}
+
+public sealed class TestMutation
+{
+#pragma warning disable CA1822
+    [EnableResponseCompression]
+    public string MarkedMutation() => "ok";
+#pragma warning restore CA1822
+}

--- a/tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests/ServiceResourceCompressionTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.WebApi.Unit.Tests/ServiceResourceCompressionTests.cs
@@ -1,0 +1,134 @@
+using System.IO.Compression;
+using System.Net;
+using AwesomeAssertions;
+using Digdir.Domain.Dialogporten.WebApi.Common.Extensions;
+using Digdir.Library.Utils.AspNet;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Unit.Tests;
+
+/// <summary>
+/// Exercises the WebApi opt-in pipeline end-to-end: the attribute-scanning helper
+/// (<see cref="ResponseCompressionEndpointFilterExtensions"/>) attaches an endpoint filter to a
+/// decorated endpoint, and the globally registered ResponseCompression middleware sees the resulting
+/// <c>IHttpsCompressionFeature.Mode = Compress</c> at body-write time.
+/// </summary>
+public class ServiceResourceCompressionTests
+{
+    private const string CompressedPath = "/compressed";
+    private const string PlainPath = "/plain";
+
+    private static readonly string Payload = "{\"items\":[" + string.Join(",",
+        Enumerable.Range(0, 200).Select(i =>
+            $"{{\"id\":{i},\"name\":\"resource-{i}\",\"desc\":\"lorem ipsum dolor sit amet consectetur\"}}"))
+        + "]}";
+
+    private static TestServer CreateServer()
+    {
+        var builder = new HostBuilder().ConfigureWebHost(webHost => webHost
+            .UseTestServer()
+            .ConfigureServices(services =>
+            {
+                services.AddRouting();
+                services.AddDialogportenResponseCompression();
+            })
+            .Configure(app =>
+            {
+                // ResponseCompression only honors IHttpsCompressionFeature.Mode on HTTPS requests
+                // (EnableForHttps is false). TestServer defaults to http; spoof the scheme so tests
+                // exercise the production opt-in behavior.
+                app.Use((context, next) =>
+                {
+                    context.Request.Scheme = "https";
+                    return next();
+                });
+                app.UseResponseCompression();
+                app.UseRouting();
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapGet(CompressedPath, () => Results.Content(Payload, "application/json"))
+                        .AddResponseCompressionHintIfMarked(typeof(MarkedHandler));
+
+                    endpoints.MapGet(PlainPath, () => Results.Content(Payload, "application/json"))
+                        .AddResponseCompressionHintIfMarked(typeof(UnmarkedHandler));
+                });
+            }));
+        return builder.Start().GetTestServer();
+    }
+
+    [Theory]
+    [InlineData("br, gzip", "br")]
+    [InlineData("br", "br")]
+    [InlineData("gzip", "gzip")]
+    public async Task Compresses_response_when_endpoint_is_marked_and_AcceptEncoding_matches(
+        string acceptEncoding, string expectedEncoding)
+    {
+        using var server = CreateServer();
+        using var client = server.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, CompressedPath);
+        request.Headers.TryAddWithoutValidation("Accept-Encoding", acceptEncoding);
+
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentEncoding.Should().ContainSingle().Which.Should().Be(expectedEncoding);
+
+        var raw = await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken);
+        raw.Length.Should().BeLessThan(Payload.Length);
+
+        using Stream decompressed = expectedEncoding == "br"
+            ? new BrotliStream(new MemoryStream(raw), CompressionMode.Decompress)
+            : new GZipStream(new MemoryStream(raw), CompressionMode.Decompress);
+        using var reader = new StreamReader(decompressed);
+        var decoded = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+        decoded.Should().Be(Payload);
+    }
+
+    [Fact]
+    public async Task Does_not_compress_when_no_AcceptEncoding_header()
+    {
+        using var server = CreateServer();
+        using var client = server.CreateClient();
+
+        var response = await client.GetAsync(CompressedPath, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentEncoding.Should().BeEmpty();
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken)).Should().Be(Payload);
+    }
+
+    [Fact]
+    public async Task Does_not_compress_when_endpoint_type_is_unmarked()
+    {
+        using var server = CreateServer();
+        using var client = server.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, PlainPath);
+        request.Headers.TryAddWithoutValidation("Accept-Encoding", "br, gzip");
+
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentEncoding.Should().BeEmpty();
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken)).Should().Be(Payload);
+    }
+
+    // Test-only stand-ins for FastEndpoints endpoint classes; only their reflected method-level
+    // attribute matters to ResponseCompressionEndpointFilterExtensions.
+#pragma warning disable CA1822 // Instance methods so the helper's BindingFlags.Instance scan finds them.
+    private sealed class MarkedHandler
+    {
+        [EnableResponseCompression]
+        public void HandleAsync() { }
+    }
+
+    private sealed class UnmarkedHandler
+    {
+        public void HandleAsync() { }
+    }
+#pragma warning restore CA1822
+}


### PR DESCRIPTION
## Description

- New [EnableResponseCompression] attribute (Digdir.Library.Utils.AspNet) — a plain marker placed on the method that produces the response.
- New shared AddDialogportenResponseCompression() registers Brotli + Gzip at CompressionLevel.Fastest, with EnableForHttps = false so compression is strictly opt-in per response. MIME allowlist covers application/json, application/problem+json, and application/graphql-response+json.
- WebApi opt-in: FastEndpoints' Endpoints.Configurator invokes AddResponseCompressionHintIfMarked(...), which scans the endpoint type and attaches an endpoint filter setting IHttpsCompressionFeature.Mode = Compress. GetServiceResourceMetadataEndpoint.HandleAsync is decorated.
- GraphQL opt-in: HotChocolate EnableResponseCompressionTypeInterceptor walks each ObjectFieldDefinition once at schema build and appends a field middleware on decorated resolvers; the middleware also gates on OperationType.Query so mutations/subscriptions can never silently activate compression. GetServiceResources is decorated.
- Both hosts register app.UseResponseCompression() globally.
- Digdir.Library.Utils.AspNet.csproj gains <FrameworkReference Include="Microsoft.AspNetCore.App" /> (commented) — Microsoft.AspNetCore.ResponseCompression ships only via the shared framework. The now-redundant Microsoft.Extensions.Http explicit pin is dropped (covered transitively).

## Related Issue(s)

- #4048 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 

