### PR TITLE
fix: return 403 instead of 404 for unauthorized enduser get dialog

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -203,7 +203,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
 
             if (!listAuthorizationResult)
             {
-                return new EntityNotFound<DialogEntity>(request.DialogId);
+                return new Forbidden("Forbidden");
             }
         }
 

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Digdir.Domain.Dialogporten.Application.Common.Authorization;
+using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
@@ -12,12 +13,14 @@ using Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.Commo
 using Digdir.Domain.Dialogporten.Domain;
 using Digdir.Domain.Dialogporten.Domain.Actors;
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.ResourceRegistry;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
 using static Digdir.Domain.Dialogporten.Application.Common.ResourceRegistry.Constants;
 using static Digdir.Domain.Dialogporten.Application.Integration.Tests.Common.Common;
 using Constants = Digdir.Domain.Dialogporten.Application.Common.Authorization.Constants;
@@ -95,6 +98,24 @@ public class GetDialogTests(DialogApplication application) : ApplicationCollecti
                 x.Content.MainContentReference!.Value.Should().AllSatisfy(x =>
                     x.Value.Should().Be(Constants.UnauthorizedUri.ToString()));
             });
+
+    [Fact]
+    public Task Get_Dialog_Should_Return_Forbidden_When_No_Access_To_Main_Resource_And_No_List_Authorization() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog()
+            .ConfigureAltinnAuthorization(altinnAuthorization =>
+            {
+                // No authorized actions => no access to the main resource
+                altinnAuthorization
+                    .GetDialogDetailsAuthorization(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+                    .Returns(new DialogDetailsAuthorizationResult { AuthorizedAltinnActions = [] });
+                // And no access via the list authorization either
+                altinnAuthorization
+                    .HasListAuthorizationForDialog(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+                    .Returns(false);
+            })
+            .GetEndUserDialog()
+            .ExecuteAndAssert<Forbidden>();
 
     [Fact]
     public Task Get_Dialog_Should_Include_GuiAction_Url_When_Read_Access_To_Main_Resource() =>

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
@@ -144,6 +144,22 @@ public class GetDialogTests(WebApiE2EFixture fixture) : E2ETestBase<WebApiE2EFix
         response.Error!.Content.Should().Contain(Constants.AltinnAuthLevelTooLow);
     }
 
+    [E2EFact]
+    public async Task Should_Return_Forbidden_When_EndUser_Has_No_Access_To_Dialog()
+    {
+        // Arrange
+        // Create a dialog for a party the default end user does not represent, so the end user
+        // has neither read access to the main resource nor list authorization for the dialog.
+        var unauthorizedParty = $"{NorwegianPersonIdentifier.PrefixWithSeparator}08895699684";
+        var dialogId = await Fixture.ServiceownerApi.CreateSimpleDialogAsync(x => x.Party = unauthorizedParty);
+
+        // Act
+        var response = await Fixture.EndUserApi.GetDialog(dialogId);
+
+        // Assert
+        response.ShouldHaveStatusCode(HttpStatusCode.Forbidden);
+    }
+
     [E2EFact(SkipOnEnvironments = ["yt01"])]
     public async Task Get_Dialog_Verify_Snapshot()
     {


### PR DESCRIPTION
## Description

Changes the end-user get dialog handler to return `Forbidden` (403) instead of `EntityNotFound` (404) when the user has neither read access to the main resource nor list authorization for the dialog. The genuine "dialog does not exist" case still returns 404. Added an Application integration test (deterministic, mocked authorization) and a WebAPI E2E test (creates a dialog for a party the default end user does not represent) covering the new behavior.

## Related Issue(s)

- #4044 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)