### PR TITLE
feat(infra): pin the monthly Key Vault expiry digest in Slack

### DIFF
--- a/.github/scripts/post-pin-digest.sh
+++ b/.github/scripts/post-pin-digest.sh
@@ -21,8 +21,8 @@ DIGEST_PREFIX="Key Vault secret expiry digest"
 # 1) Post the digest (inject the real channel id into the payload).
 payload=$(jq --arg ch "$CHANNEL_ID" '.channel = $ch' "$PAYLOAD_FILE")
 resp=$(curl -sS -X POST "$API/chat.postMessage" "${AUTH[@]}" "${JSON[@]}" --data "$payload")
-if [ "$(jq -r '.ok' <<<"$resp")" != "true" ]; then
-  echo "::error::chat.postMessage failed: $(jq -r '.error // .' <<<"$resp")"
+if [[ "$(jq -r '.ok' <<<"$resp")" != "true" ]]; then
+  echo "::error::chat.postMessage failed: $(jq -r '.error // .' <<<"$resp")" >&2
   exit 1
 fi
 new_ts=$(jq -r '.ts' <<<"$resp")
@@ -31,15 +31,15 @@ echo "Posted digest ts=$new_ts to channel $CHANNEL_ID"
 # 2) Pin the new digest.
 resp=$(curl -sS -X POST "$API/pins.add" "${AUTH[@]}" "${JSON[@]}" \
   --data "$(jq -n --arg ch "$CHANNEL_ID" --arg ts "$new_ts" '{channel:$ch, timestamp:$ts}')")
-if [ "$(jq -r '.ok' <<<"$resp")" != "true" ]; then
+if [[ "$(jq -r '.ok' <<<"$resp")" != "true" ]]; then
   # already_pinned is harmless; anything else is worth surfacing but not fatal.
-  echo "::warning::pins.add: $(jq -r '.error // .' <<<"$resp")"
+  echo "::warning::pins.add: $(jq -r '.error // .' <<<"$resp")" >&2
 fi
 
 # 3) Unpin previous digests from this bot (keep the one just pinned).
 pins=$(curl -sS "$API/pins.list" "${AUTH[@]}" -G --data-urlencode "channel=$CHANNEL_ID")
-if [ "$(jq -r '.ok' <<<"$pins")" != "true" ]; then
-  echo "::warning::pins.list failed, skipping cleanup: $(jq -r '.error // .' <<<"$pins")"
+if [[ "$(jq -r '.ok' <<<"$pins")" != "true" ]]; then
+  echo "::warning::pins.list failed, skipping cleanup: $(jq -r '.error // .' <<<"$pins")" >&2
   exit 0
 fi
 
@@ -49,7 +49,7 @@ jq -r --arg keep "$new_ts" --arg prefix "$DIGEST_PREFIX" '
   | select((.text // "") | startswith($prefix))
   | select(.ts != $keep)
   | .ts' <<<"$pins" | while read -r ts; do
-    [ -n "$ts" ] || continue
+    [[ -n "$ts" ]] || continue
     r=$(curl -sS -X POST "$API/pins.remove" "${AUTH[@]}" "${JSON[@]}" \
       --data "$(jq -n --arg ch "$CHANNEL_ID" --arg ts "$ts" '{channel:$ch, timestamp:$ts}')")
     echo "Unpinned previous digest ts=$ts ok=$(jq -r '.ok' <<<"$r")"

--- a/.github/scripts/post-pin-digest.sh
+++ b/.github/scripts/post-pin-digest.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Post the monthly Key Vault expiry digest to Slack, pin it, and unpin the previous
+# digest from this bot so only the latest stays pinned.
+#
+# Inputs (env):
+#   SLACK_BOT_TOKEN   bot token with chat:write, pins:write, pins:read
+#   CHANNEL_ID        target channel id
+# Args:
+#   $1                path to the digest payload JSON (its .channel is overwritten with CHANNEL_ID)
+#
+# Safety: only ever unpins messages that are BOTH authored by a bot AND whose text starts with
+# the digest header, and never the message just pinned. Human-pinned content is left untouched.
+set -euo pipefail
+
+PAYLOAD_FILE="$1"
+API="https://slack.com/api"
+AUTH=(-H "Authorization: Bearer ${SLACK_BOT_TOKEN}")
+JSON=(-H "Content-type: application/json; charset=utf-8")
+DIGEST_PREFIX="Key Vault secret expiry digest"
+
+# 1) Post the digest (inject the real channel id into the payload).
+payload=$(jq --arg ch "$CHANNEL_ID" '.channel = $ch' "$PAYLOAD_FILE")
+resp=$(curl -sS -X POST "$API/chat.postMessage" "${AUTH[@]}" "${JSON[@]}" --data "$payload")
+if [ "$(jq -r '.ok' <<<"$resp")" != "true" ]; then
+  echo "::error::chat.postMessage failed: $(jq -r '.error // .' <<<"$resp")"
+  exit 1
+fi
+new_ts=$(jq -r '.ts' <<<"$resp")
+echo "Posted digest ts=$new_ts to channel $CHANNEL_ID"
+
+# 2) Pin the new digest.
+resp=$(curl -sS -X POST "$API/pins.add" "${AUTH[@]}" "${JSON[@]}" \
+  --data "$(jq -n --arg ch "$CHANNEL_ID" --arg ts "$new_ts" '{channel:$ch, timestamp:$ts}')")
+if [ "$(jq -r '.ok' <<<"$resp")" != "true" ]; then
+  # already_pinned is harmless; anything else is worth surfacing but not fatal.
+  echo "::warning::pins.add: $(jq -r '.error // .' <<<"$resp")"
+fi
+
+# 3) Unpin previous digests from this bot (keep the one just pinned).
+pins=$(curl -sS "$API/pins.list" "${AUTH[@]}" -G --data-urlencode "channel=$CHANNEL_ID")
+if [ "$(jq -r '.ok' <<<"$pins")" != "true" ]; then
+  echo "::warning::pins.list failed, skipping cleanup: $(jq -r '.error // .' <<<"$pins")"
+  exit 0
+fi
+
+jq -r --arg keep "$new_ts" --arg prefix "$DIGEST_PREFIX" '
+  .items[]? | select(.type == "message") | .message
+  | select(.bot_id != null)
+  | select((.text // "") | startswith($prefix))
+  | select(.ts != $keep)
+  | .ts' <<<"$pins" | while read -r ts; do
+    [ -n "$ts" ] || continue
+    r=$(curl -sS -X POST "$API/pins.remove" "${AUTH[@]}" "${JSON[@]}" \
+      --data "$(jq -n --arg ch "$CHANNEL_ID" --arg ts "$ts" '{channel:$ch, timestamp:$ts}')")
+    echo "Unpinned previous digest ts=$ts ok=$(jq -r '.ok' <<<"$r")"
+  done

--- a/.github/workflows/check-keyvault-secret-expiry.yml
+++ b/.github/workflows/check-keyvault-secret-expiry.yml
@@ -210,27 +210,19 @@ jobs:
         env:
           CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_KEYVAULT_ALERTS_PROD_CRITICAL }}
 
-      - name: Post monthly digest to non-prod channel
+      - name: Post & pin monthly digest to non-prod channel
         if: steps.compute.outputs.have_nonprod_digest == 'true'
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload-templated: true
-          payload-file-path: ./slack-nonprod-digest.json
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_KEYVAULT_ALERTS }}
+        run: bash .github/scripts/post-pin-digest.sh ./slack-nonprod-digest.json
 
-      - name: Post monthly digest to prod channel
+      - name: Post & pin monthly digest to prod channel
         if: steps.compute.outputs.have_prod_digest == 'true'
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload-templated: true
-          payload-file-path: ./slack-prod-digest.json
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_KEYVAULT_ALERTS_PROD }}
+        run: bash .github/scripts/post-pin-digest.sh ./slack-prod-digest.json
 
       - name: Fail run if any rule was tripped
         if: steps.compute.outputs.any_rule_tripped == 'true'


### PR DESCRIPTION
## Summary

Builds on the monthly digest (#4040): the digest is now **pinned** in its Slack channel so the latest "how are secret expirations looking" overview is always one click away, and a new digest **replaces** the previous one (only the latest stays pinned).

## How

Posting + pinning moved into `.github/scripts/post-pin-digest.sh`, which:
1. posts the digest (and captures its `ts`),
2. `pins.add` the new message,
3. `pins.list` the channel and `pins.remove` earlier digests from this bot.

The cleanup filter only matches messages that are **both** bot-authored **and** start with the digest header, and never the message just pinned — so human-pinned content is never touched. If the Slack scopes are ever missing, pinning degrades to a warning and the digest still posts; it never fails the run.

## Slack app requirement

Needs `pins:write` + `pins:read` (bot token scopes), already added and reinstalled. Verified the bot token value was unchanged by the reinstall, so no secret rotation was needed.

## Testing

Dispatched against the test channel (`#dialogporten-poc`) with `send_digest=true`:
- Run 1: digest posted and pinned.
- Run 2: new digest posted and pinned, previous one unpinned (`Unpinned previous digest … ok=true`), confirmed visually — the pin moved to the new version.

Related to #4012, #4040.