### PR TITLE
docs: document secret expiry and Maskinporten rotation convention

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -138,3 +138,24 @@ There are two conventions, one that targets a specific environment, and one "any
 
 ## 4.2. How to
 Instruct your friendly secrets manager to modify the desired key value pair in the source key vault before merging your pull request to the main branch.
+
+## 4.3. Secret expiry and rotation
+Expiring external secrets (Maskinporten JWKs, certificates, vendor keys) are monitored by the daily `Check Key Vault secret expiry` workflow (`.github/workflows/check-keyvault-secret-expiry.yml`). It reads `attributes.expires` on the **source** key vault secrets and alerts to Slack as expiry approaches (30 / 7 / 1 days out), plus a full overview digest on the 1st of each month.
+
+Conventions:
+
+- **Set `attributes.expires` on the source secret to the credential's actual expiry date** (a Maskinporten key's `valid_until` from Samarbeidsportalen, or a certificate's `notAfter`). The workflow warns ahead of expiry on its own, so enter the real date rather than an earlier reminder date.
+- **Set the date only on the source secret.** `copySecrets.bicep` copies a secret's value into each environment key vault but not its attributes, so the environment-vault copies have no expiry date by design. Only the source secrets are monitored; leave the environment-vault copies as they are.
+- **Watch-listed secrets must have an expiry.** Any secret named in `.github/keyvault-expiry-monitored-secrets.yml` is required to have `attributes.expires` set; if one is missing it, the workflow flags it in Slack.
+
+### Maskinporten clients
+There are two Maskinporten clients: one shared by `test`, `yt01` and `staging` (via the non-prod source key vault), and one for `prod`. A client can hold several registered JWKs at once; the JWT `kid` header in the signed assertion tells Maskinporten which registered key to validate against. This is what makes a no-downtime rotation possible: register the new key alongside the old one, switch over, then remove the old one (see below).
+
+### Rotating a Maskinporten JWK
+1. Obtain the new key and register its JWK on the Maskinporten client. Keep the old key registered until the new one is verified (overlap window).
+2. Update the source secret value and set `attributes.expires` to the new key's `valid_until`.
+3. Deploy the affected environment(s) so `copySecrets` propagates the new value, then restart the apps so they reload the key (it is read at startup via an app-config Key Vault reference).
+4. Verify the apps authenticate with the new key: no `invalid_grant`, and a successful Maskinporten token call visible in Application Insights.
+5. Deregister the old key from the client once nothing uses it.
+
+See the rotation runbook for step-by-step detail: <https://digdir.atlassian.net/wiki/x/QIDDAgE>

--- a/docs/Infrastructure.md
+++ b/docs/Infrastructure.md
@@ -128,7 +128,7 @@ The resources refer to a `source key vault` in order to fetch the necessary secr
 
 Use the following steps:
 
-- Ensure a `source key vault` exists for the new environment. Either create a new key vault or use an existing key vault. Currently, two key vaults exist for our environments. One in the test subscription used by Test and Staging, and one in our Production subscription, which Production uses. Ensure you add the necessary secrets that should be used by the new environment. Read here to learn about secret convention [Configuration Guide](Configuration.md). Ensure also that the key vault has the following enabled: `Azure Resource Manager for template deployment`.
+- Ensure a `source key vault` exists for the new environment. Either create a new key vault or use an existing key vault. Currently, two key vaults exist for our environments. One in the test subscription used by Test, yt01 and Staging, and one in our Production subscription, which Production uses. Ensure you add the necessary secrets that should be used by the new environment. Read here to learn about secret convention [Configuration Guide](Configuration.md). Ensure also that the key vault has the following enabled: `Azure Resource Manager for template deployment`.
 
 - Ensure that the service principal used by the GitHub Entra Application has role assignments for `Key Vault Secrets User` and `Contributor` (the Contributor role should be inherited).
 


### PR DESCRIPTION
## Summary

Documents the secret-expiry monitoring and Maskinporten rotation conventions that the expiry workflow (#4040) and the pinned monthly digest (#4057) put in place.

- New **Configuration.md §4.3 (Secret expiry and rotation):**
  - `attributes.expires` on the **source** secret holds the credential's actual expiry; the workflow derives its own early warnings, so there is no need to enter an earlier date.
  - Env-vault copies carry no expiry by design (copySecrets copies the value, not the attributes); only source secrets are monitored.
  - The two-Maskinporten-client topology (one shared by test/yt01/staging, one for prod) and how the `kid` enables no-downtime rotation.
  - A 5-step JWK rotation procedure, linking the detailed runbook.
- **Infrastructure.md:** corrects the line listing the non-prod source-vault consumers to include `yt01` (it previously named only Test and Staging).

Written to be followed by someone who hasn't done this before.

Related to #4012, #4040, #4057.