### PR TITLE
chore(deps): bump Refit to 10.2.0 and remove NUGET_CERT_REVOCATION_MODE workaround

### DIFF
--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -71,12 +71,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
-    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
-    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
-    env:
-      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/dispatch-purge-e2e-test-data.yml
+++ b/.github/workflows/dispatch-purge-e2e-test-data.yml
@@ -25,12 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
-    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
-    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
-    env:
-      NUGET_CERT_REVOCATION_MODE: offline
     strategy:
       matrix:
         environment: >-

--- a/.github/workflows/workflow-build-and-test.yml
+++ b/.github/workflows/workflow-build-and-test.yml
@@ -9,12 +9,6 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
-    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
-    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
-    env:
-      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/workflow-publish-nuget.yml
+++ b/.github/workflows/workflow-publish-nuget.yml
@@ -32,12 +32,6 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
-    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
-    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
-    env:
-      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/workflow-run-graphql-e2e-tests.yml
+++ b/.github/workflows/workflow-run-graphql-e2e-tests.yml
@@ -22,12 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
-    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
-    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
-    env:
-      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/workflow-run-webapi-e2e-tests.yml
+++ b/.github/workflows/workflow-run-webapi-e2e-tests.yml
@@ -22,12 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # TEMP workaround for reactiveui/refit#2114: Refit 10.1.6's signing cert (CN=Glenn Watson)
-    # was revoked upstream 2026-06-02, making Linux `dotnet restore` fail with NU3012. Offline
-    # revocation mode keeps signature/chain verification but skips the live CRL check. Remove
-    # once Refit republishes 10.1.x with a valid signature. Revert tracked in #4049.
-    env:
-      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/src/Digdir.Library.Dialogporten.WebApiClient.Common/Digdir.Library.Dialogporten.WebApiClient.Common.csproj
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.Common/Digdir.Library.Dialogporten.WebApiClient.Common.csproj
@@ -14,8 +14,8 @@
         <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
         <PackageReference Include="NSec.Cryptography" Version="25.4.0" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
-        <PackageReference Include="Refit" Version="10.1.6" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
+        <PackageReference Include="Refit" Version="10.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Digdir.Library.Dialogporten.WebApiClient.Common/packages.lock.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.Common/packages.lock.json
@@ -43,18 +43,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "libsodium": {
@@ -287,18 +287,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "libsodium": {
@@ -538,18 +538,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "libsodium": {

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser/Digdir.Library.Dialogporten.WebApiClient.EndUser.csproj
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser/Digdir.Library.Dialogporten.WebApiClient.EndUser.csproj
@@ -55,8 +55,8 @@
         <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
         <PackageReference Include="NSec.Cryptography" Version="25.4.0"/>
-        <PackageReference Include="Refit" Version="10.1.6" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
+        <PackageReference Include="Refit" Version="10.2.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
         <PackageReference Include="Refitter.SourceGenerator" Version="1.7.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser/packages.lock.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser/packages.lock.json
@@ -43,18 +43,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Refitter.SourceGenerator": {
@@ -287,8 +287,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     },
@@ -334,18 +334,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Refitter.SourceGenerator": {
@@ -585,8 +585,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     },
@@ -632,18 +632,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Refitter.SourceGenerator": {
@@ -883,8 +883,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     }

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.csproj
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.csproj
@@ -55,8 +55,8 @@
         <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
         <PackageReference Include="NSec.Cryptography" Version="25.4.0"/>
-        <PackageReference Include="Refit" Version="10.1.6" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
+        <PackageReference Include="Refit" Version="10.2.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
         <PackageReference Include="Refitter.SourceGenerator" Version="1.7.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/packages.lock.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/packages.lock.json
@@ -43,18 +43,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Refitter.SourceGenerator": {
@@ -287,8 +287,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     },
@@ -334,18 +334,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Refitter.SourceGenerator": {
@@ -585,8 +585,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     },
@@ -632,18 +632,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Refitter.SourceGenerator": {
@@ -883,8 +883,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     }

--- a/src/Digdir.Library.Dialogporten.WebApiClient.WebApiSample/packages.lock.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.WebApiSample/packages.lock.json
@@ -69,15 +69,15 @@
       },
       "Refit": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {
@@ -94,8 +94,8 @@
         "dependencies": {
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       },
       "Altinn.ApiClients.Dialogporten.Common": {
@@ -103,8 +103,8 @@
         "dependencies": {
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     }

--- a/src/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj
+++ b/src/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj
@@ -55,8 +55,8 @@
         <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
         <PackageReference Include="NSec.Cryptography" Version="25.4.0"/>
-        <PackageReference Include="Refit" Version="10.1.6" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
+        <PackageReference Include="Refit" Version="10.2.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
         <PackageReference Include="Refitter.SourceGenerator" Version="1.7.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Digdir.Library.Dialogporten.WebApiClient/packages.lock.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient/packages.lock.json
@@ -43,18 +43,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Refitter.SourceGenerator": {
@@ -287,8 +287,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     },
@@ -334,18 +334,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Refitter.SourceGenerator": {
@@ -585,8 +585,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     },
@@ -632,18 +632,18 @@
       },
       "Refit": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Direct",
-        "requested": "[10.1.6, )",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "requested": "[10.2.0, )",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Refitter.SourceGenerator": {
@@ -883,8 +883,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     }

--- a/tests/Digdir.Domain.Dialogporten.Architecture.Tests/packages.lock.json
+++ b/tests/Digdir.Domain.Dialogporten.Architecture.Tests/packages.lock.json
@@ -1906,16 +1906,16 @@
       },
       "Refit": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "ScottBrady.IdentityModel": {
@@ -2315,8 +2315,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       },
       "Altinn.ApiClients.Dialogporten.EndUser": {
@@ -2325,8 +2325,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       },
       "digdir.domain.dialogporten.application": {
@@ -2521,7 +2521,6 @@
           "HotChocolate.Diagnostics": "[15.1.16, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[3.1.1, )",
           "Microsoft.Azure.AppConfiguration.AspNetCore": "[8.5.0, )",
-          "Microsoft.Extensions.Http": "[10.0.8, )",
           "Npgsql.OpenTelemetry": "[10.0.2, )",
           "OpenTelemetry": "[1.15.3, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",

--- a/tests/Digdir.Domain.Dialogporten.E2E.Cleanup.Tests/packages.lock.json
+++ b/tests/Digdir.Domain.Dialogporten.E2E.Cleanup.Tests/packages.lock.json
@@ -632,16 +632,16 @@
       },
       "Refit": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Scrutor": {
@@ -768,8 +768,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       },
       "digdir.domain.dialogporten.application": {

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/packages.lock.json
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/packages.lock.json
@@ -707,16 +707,16 @@
       },
       "Refit": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Scrutor": {
@@ -879,8 +879,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       },
       "digdir.domain.dialogporten.application": {

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/packages.lock.json
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/packages.lock.json
@@ -636,16 +636,16 @@
       },
       "Refit": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Scrutor": {
@@ -772,8 +772,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       },
       "Altinn.ApiClients.Dialogporten.EndUser": {
@@ -782,8 +782,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       },
       "digdir.domain.dialogporten.application": {

--- a/tests/Digdir.Library.Dialogporten.E2E.Common/packages.lock.json
+++ b/tests/Digdir.Library.Dialogporten.E2E.Common/packages.lock.json
@@ -651,16 +651,16 @@
       },
       "Refit": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "Scrutor": {
@@ -774,8 +774,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       },
       "digdir.domain.dialogporten.application": {

--- a/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/packages.lock.json
+++ b/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/packages.lock.json
@@ -335,16 +335,16 @@
       },
       "Refit": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "j82mHFcXJpiJiaLqQgiikmLAu+oYKcIM8ZafipX2s2b2soOS0OGN+Oc+BXkhsG8x6j2M1J23Eac3068yOKLPFA=="
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
       },
       "Refit.HttpClientFactory": {
         "type": "Transitive",
-        "resolved": "10.1.6",
-        "contentHash": "brVgMXHX2pp6pMji7tJijygbMwxccIy2vSsPurPmOZ7jSChBjYpiT9bBbJkBDc0hhnNyzvLkkbx0uiHhJuTTEQ==",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
         "dependencies": {
           "Microsoft.Extensions.Http": "9.0.3",
-          "Refit": "10.1.6"
+          "Refit": "10.2.0"
         }
       },
       "System.Diagnostics.EventLog": {
@@ -434,8 +434,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       },
       "Altinn.ApiClients.Dialogporten.Common": {
@@ -444,8 +444,8 @@
           "Altinn.ApiClients.Maskinporten": "[10.0.1, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
           "NSec.Cryptography": "[25.4.0, )",
-          "Refit": "[10.1.6, )",
-          "Refit.HttpClientFactory": "[10.1.6, )"
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
         }
       }
     }


### PR DESCRIPTION
Bumps Refit + Refit.HttpClientFactory 10.1.6 -> 10.2.0 across the WebApiClient projects and removes the temporary `NUGET_CERT_REVOCATION_MODE=offline` workaround from the six workflows.

Refit 10.1.6's signing cert was revoked upstream; the maintainer re-released the same code as 10.2.0 with a valid Certum signature (10.1.6 and the breaking 10.1.7 are now unlisted). Since the dependency restores cleanly under full revocation checking again, the offline workaround is no longer needed, and this restores full revocation checks across all CI.

Also fixes restore failures for downstream consumers of the published SDK packages (`Altinn.ApiClients.Dialogporten`, `.EndUser`, `.ServiceOwner`).

Background and revert tracking: Related to #4049.

## Verification
- Confirmed 10.2.0 is a clean re-release of 10.1.6: identical IL across all 8 assemblies (only versioning metadata differs), signed by the same identity with the new Certum cert, restores under full online revocation in a fresh Linux container.
- WebApiClient builds and all 16 unit tests pass.
- Locked-mode restore passes; lock-file changes scoped to Refit only.
