### PR TITLE
fix: serialize non-public FusionCache value types to L2/Redis

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -34,6 +34,7 @@ using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogS
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearch.EndUser.Selection;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories.DialogSearch.EndUser.Strategies;
 using HotChocolate.Subscriptions;
+using MessagePack.Resolvers;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using StackExchange.Redis;
@@ -161,7 +162,7 @@ public static class InfrastructureExtensions
             // Feature Metrics
             .AddScoped<IFeatureMetricServiceResourceCache, FeatureMetricServiceResourceCache>();
 
-        services.AddFusionCacheNeueccMessagePackSerializer();
+        services.AddFusionCacheNeueccMessagePackSerializer(ContractlessStandardResolverAllowPrivate.Options);
         services.AddStackExchangeRedisCache(opt => opt.Configuration = infrastructureSettings.Redis.ConnectionString);
         services.AddFusionCacheStackExchangeRedisBackplane(opt => opt.Configuration = infrastructureSettings.Redis.ConnectionString);
 


### PR DESCRIPTION
## What

Configures the FusionCache MessagePack serializer with
`ContractlessStandardResolverAllowPrivate` instead of the default
`ContractlessStandardResolver`.

## Why

Since 1.116.0 the per-language `AccessManagementMetadata` cache entries
(`access-management-metadata:nb/:nn/:en`) have failed every distributed-cache
(L2/Redis) write with a `MessagePackSerializationException`. The cached value
type `LocalizedAccessManagementMetadata` is a private nested record, and the
default resolver generates its formatter into a separate dynamic assembly that
cannot implement `IMessagePackFormatter<T>` for a non-public `T`
(`TypeLoadException: ... attempting to implement an inaccessible interface`).

The allow-private resolver is the same resolver chain and wire format, but
permits the generated formatter to access non-public types, so the cache DTOs
can stay private. This was degraded-not-broken in prod: L1 (in-memory) kept
serving, but L2/Redis sharing was disabled for this metadata and the failure
was logged on every cache write.

## Verification

- After deploy, confirm the `access-management-metadata:*` serialization
  traces stop in dp-be App Insights.

Related to #4070, #4022, #3998.