### PR TITLE
chore: bump Microsoft.Compute API version to 2025-11-01

### DIFF
--- a/.azure/modules/virtualMachine/main.bicep
+++ b/.azure/modules/virtualMachine/main.bicep
@@ -79,7 +79,7 @@ param sshPublicKey string
 @description('Enable Just-in-Time access for the virtual machine')
 param enableJit bool = false
 
-resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-11-01' = {
+resource virtualMachine 'Microsoft.Compute/virtualMachines@2025-11-01' = {
   name: name
   location: location
   zones: [
@@ -145,7 +145,7 @@ resource jitPolicy 'Microsoft.Security/locations/jitNetworkAccessPolicies@2020-0
   }
 }
 
-resource aadLoginExtension 'Microsoft.Compute/virtualMachines/extensions@2024-11-01' = {
+resource aadLoginExtension 'Microsoft.Compute/virtualMachines/extensions@2025-11-01' = {
   parent: virtualMachine
   name: 'AADSSHLoginForLinux'
   location: location


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bumps the API version for `Microsoft.Compute/virtualMachines` and `Microsoft.Compute/virtualMachines/extensions` from `2024-11-01` to `2025-11-01` in `.azure/modules/virtualMachine/main.bicep`. Only the API version strings changed; all existing properties were verified to still be valid in the new API version.

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)