### PR TITLE
fix: email party mapping, remove legacy/feide authentication

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/ApplicationSettings.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/ApplicationSettings.cs
@@ -19,9 +19,6 @@ public sealed class FeatureToggle
     public bool UseAltinnAutoAuthorizedPartiesQueryParameters { get; init; }
     public bool EnablePartyFiltersForSystemUsers { get; init; }
     public bool UseCorrectPersonNameOrdering { get; init; }
-    public bool UseAccessManagementForAltinnSelfIdentifiedUsers { get; init; }
-    public bool UseAccessManagementForIdportenEmailUsers { get; init; }
-    public bool UseAccessManagementForFeideUsers { get; init; }
 }
 
 public enum BadDataHandling

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -22,7 +22,6 @@ public static class ClaimsPrincipalExtensions
     public const string IdportenAuthLevelClaim = "acr";
     public const string IdportenAmrClaim = "amr";
     public const string AmrSelfRegisteredEmail = "Selfregistered-email";
-    public const string AmrSelfIdentified = "SelfIdentified";
     private const string AuthorizationDetailsClaim = "authorization_details";
     private const string AuthorizationDetailsType = "urn:altinn:systemuser";
     private const string AltinnAuthLevelClaim = "urn:altinn:authlevel";
@@ -181,18 +180,6 @@ public static class ClaimsPrincipalExtensions
         }
     }
 
-    private static bool TryGetSelfIdentifiedUsername(this ClaimsPrincipal claimsPrincipal,
-        [NotNullWhen(true)] out string? username)
-    {
-        username = claimsPrincipal.TryGetClaimValue(AltinnUsernameClaim, out username)
-            && claimsPrincipal.TryGetAmrClaimValues(out var amr) && amr is [AmrSelfIdentified]
-            ? username.ToLowerInvariant()
-            : null;
-
-        return username is not null;
-    }
-
-
     private static bool TryGetSelfIdentifiedUserEmail(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? email)
     {
         email = claimsPrincipal.TryGetClaimValue(IdportenEmailClaim, out email)
@@ -202,9 +189,6 @@ public static class ClaimsPrincipalExtensions
 
         return email is not null;
     }
-
-    public static bool TryGetFeideSubject(this ClaimsPrincipal claimsPrincipal, [NotNullWhen(true)] out string? subject)
-        => claimsPrincipal.TryGetClaimValue(FeideSubjectClaim, out subject);
 
     public static bool TryGetPartyUuid(this ClaimsPrincipal claimsPrincipal, out Guid partyUuid)
     {
@@ -300,10 +284,8 @@ public static class ClaimsPrincipalExtensions
     /// 1. Person (has pid claim)
     /// 2. System user (has authorization_details claim with type urn:altinn:systemuser)
     /// 3. Service owner (has consumer claim and service_owner scope)
-    /// 4. Feide user (has orgsub claim)
-    /// 5. Altinn self-identified user (has urn:altinn:username claim with SelfIdentified amr claim)
-    /// 6. Idporten self-registered user (has email claim with Selfregistered-email amr claim)
-    /// 7. Unknown (none of the above)
+    /// 4. Idporten self-registered user (has email claim with Selfregistered-email amr claim)
+    /// 5. Unknown (none of the above)
     /// </summary>
     /// <param name="claimsPrincipal"></param>
     /// <returns></returns>
@@ -326,16 +308,6 @@ public static class ClaimsPrincipalExtensions
             claimsPrincipal.TryGetConsumerOrgNumber(out externalId))
         {
             return (UserIdType.ServiceOwner, externalId);
-        }
-
-        if (claimsPrincipal.TryGetFeideSubject(out externalId))
-        {
-            return (UserIdType.FeideUser, externalId);
-        }
-
-        if (claimsPrincipal.TryGetSelfIdentifiedUsername(out externalId))
-        {
-            return (UserIdType.AltinnSelfIdentifiedUser, externalId);
         }
 
         if (claimsPrincipal.TryGetSelfIdentifiedUserEmail(out externalId))
@@ -363,12 +335,8 @@ public static class ClaimsPrincipalExtensions
             UserIdType.IdportenEmailIdentifiedUser
                 => IdportenEmailUserIdentifier.TryParse(externalId, out var email)
                     ? email : null,
-            UserIdType.AltinnSelfIdentifiedUser
-                => AltinnSelfIdentifiedUserIdentifier.TryParse(externalId, out var username)
-                    ? username : null,
-            UserIdType.FeideUser
-                => FeideUserIdentifier.TryParse(externalId, out var feideSubject)
-                    ? feideSubject : null,
+            UserIdType.AltinnSelfIdentifiedUser => null,
+            UserIdType.FeideUser => null,
             UserIdType.Unknown => null,
             UserIdType.ServiceOwner => null,
             _ => null

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IUserRegistry.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IUserRegistry.cs
@@ -71,10 +71,10 @@ public sealed class UserRegistry : IUserRegistry
         {
             UserIdType.Person
                 or UserIdType.ServiceOwnerOnBehalfOfPerson
-                or UserIdType.AltinnSelfIdentifiedUser
                 or UserIdType.IdportenEmailIdentifiedUser
-                or UserIdType.FeideUser
                 or UserIdType.SystemUser => await _partyNameRegistry.GetName(userId.ExternalIdWithPrefix, cancellationToken),
+            UserIdType.AltinnSelfIdentifiedUser => throw new UnreachableException(),
+            UserIdType.FeideUser => throw new UnreachableException(),
             UserIdType.Unknown => throw new UnreachableException(),
             UserIdType.ServiceOwner => throw new UnreachableException(),
             _ => throw new UnreachableException()

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -158,28 +158,6 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
         bool flatten,
         CancellationToken cancellationToken)
     {
-        // Self-identified/Feide users are not currently supported in the access management API, so we need to emulate it.
-        // Assume they can only represent themselves, and have no delegated rights.
-
-        // We currently do not have any support in the Register API to resolve the name of self-identified users,
-        // so we need to get this from the request context, which means this will ONLY work in end-user contexts
-        // where there is a end-user token available, ie. not in service owner contexts (using ?EndUserId=...) or
-        // service contexts.
-        switch (authorizedPartiesRequest.PartyIdentifier)
-        {
-            case IdportenEmailUserIdentifier
-                when !_applicationSettings.CurrentValue.FeatureToggle.UseAccessManagementForIdportenEmailUsers:
-            case AltinnSelfIdentifiedUserIdentifier
-                when !_applicationSettings.CurrentValue.FeatureToggle.UseAccessManagementForAltinnSelfIdentifiedUsers:
-            case FeideUserIdentifier
-                when !_applicationSettings.CurrentValue.FeatureToggle.UseAccessManagementForFeideUsers:
-                return GetSyntheticAuthorizedPartiesResultForSelfIdentifiedUser(authorizedPartiesRequest);
-
-            // ReSharper disable once RedundantEmptySwitchSection
-            default:
-                break;
-        }
-
         // Currently, access management is unable to properly leverage party filters on system users. Disable
         // filtering here to ensure better cache hit rate for system users iterating over many parties.
         if (authorizedPartiesRequest.PartyIdentifier is SystemUserIdentifier
@@ -199,28 +177,6 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
         }
 
         return flatten ? authorizedParties.Flatten() : authorizedParties;
-    }
-
-    private AuthorizedPartiesResult GetSyntheticAuthorizedPartiesResultForSelfIdentifiedUser(
-        AuthorizedPartiesRequest authorizedPartiesRequest)
-    {
-        var authorizedPartiesResultDto = new AuthorizedPartiesResultDto
-        {
-            PartyUuid = _user.GetPrincipal().TryGetPartyUuid(out var uuid) ? uuid : throw new UnreachableException("Expected party UUID to be present in current principal"),
-            PartyId = _user.GetPrincipal().TryGetPartyId(out var partyId) ? partyId : throw new UnreachableException("Expected party ID to be present in current principal"),
-            Name = authorizedPartiesRequest.PartyIdentifier.Id,
-            OrganizationNumber = "",
-            Type = AuthorizedPartiesHelper.PartyTypeSelfIdentified,
-            IsDeleted = false,
-            AuthorizedRoles = [AuthorizedPartiesHelper.SelfIdentifiedUserRoleCode],
-            OnlyHierarchyElementWithNoAccess = false,
-            AuthorizedResources = [],
-            AuthorizedAccessPackages = [],
-            AuthorizedInstances = [],
-            Subunits = []
-        };
-
-        return AuthorizedPartiesHelper.CreateAuthorizedPartiesResult([authorizedPartiesResultDto], authorizedPartiesRequest);
     }
 
     public async Task<bool> HasListAuthorizationForDialog(DialogEntity dialog, CancellationToken cancellationToken)

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesHelper.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesHelper.cs
@@ -6,7 +6,6 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.Authorization;
 internal static class AuthorizedPartiesHelper
 {
     public const string PartyTypeSelfIdentified = "SelfIdentified";
-    public const string SelfIdentifiedUserRoleCode = "seln";
 
     private const string PartyTypeOrganization = "Organization";
     private const string PartyTypePerson = "Person";
@@ -38,9 +37,7 @@ internal static class AuthorizedPartiesHelper
         {
             PartyTypeOrganization => NorwegianOrganizationIdentifier.PrefixWithSeparator + dto.OrganizationNumber,
             PartyTypePerson => NorwegianPersonIdentifier.PrefixWithSeparator + dto.PersonId,
-
-            // We need a hack here, as we only support scenarios where the self-identified user is the authenticated user.
-            PartyTypeSelfIdentified => authenticatedUser.PartyIdentifier.FullId,
+            PartyTypeSelfIdentified => GetSelfIdentifiedPartyUrn(dto),
             _ => throw new ArgumentOutOfRangeException(nameof(dto))
         };
 
@@ -60,7 +57,9 @@ internal static class AuthorizedPartiesHelper
             },
             IsDeleted = dto.IsDeleted,
             HasKeyRole = dto.AuthorizedRoles.Exists(role => KeyRoleCodes.Contains(role)),
-            IsCurrentEndUser = dto.PersonId == authenticatedUser.PartyIdentifier.Id || dto.Type == PartyTypeSelfIdentified,
+            IsCurrentEndUser = dto.Type == PartyTypeSelfIdentified
+                ? string.Equals(party, authenticatedUser.PartyIdentifier.FullId, StringComparison.OrdinalIgnoreCase)
+                : dto.PersonId == authenticatedUser.PartyIdentifier.Id,
             IsMainAdministrator = dto.AuthorizedRoles.Contains(MainAdministratorRoleCode),
             IsAccessManager = dto.AuthorizedRoles.Contains(AccessManagerRoleCode),
             HasOnlyAccessToSubParties = dto.OnlyHierarchyElementWithNoAccess,
@@ -75,6 +74,16 @@ internal static class AuthorizedPartiesHelper
                 }).ToList(),
             SubParties = dto.Subunits.Count > 0 ? dto.Subunits.Select(x => MapFromDto(x, authenticatedUser)).ToList() : null
         };
+    }
+
+    private static string GetSelfIdentifiedPartyUrn(AuthorizedPartiesResultDto dto)
+    {
+        // Access Management identifies idporten-email users via the emailId field.
+        // Other SelfIdentified parties (returned alongside an email user's authorized parties) are legacy
+        // self-identified users, addressed by their username (the Name field).
+        return dto.EmailId is not null
+            ? IdportenEmailUserIdentifier.PrefixWithSeparator + dto.EmailId.ToLowerInvariant()
+            : AltinnSelfIdentifiedUserIdentifier.PrefixWithSeparator + dto.Name.ToLowerInvariant();
     }
 
     private static List<string> GetPrefixedRolesAndAccessPackages(List<string> dtoAuthorizedRoles, List<string> dtoAuthorizedAccessPackages) =>

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesResultDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedPartiesResultDto.cs
@@ -5,6 +5,7 @@ internal sealed class AuthorizedPartiesResultDto
     public required string Name { get; set; }
     public required string OrganizationNumber { get; set; }
     public string? PersonId { get; set; }
+    public string? EmailId { get; set; }
     public string? DateOfBirth { get; set; }
     public required int PartyId { get; set; }
     public required Guid PartyUuid { get; set; }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/UserTypeValidationMiddleware.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Authentication/UserTypeValidationMiddleware.cs
@@ -14,7 +14,7 @@ public sealed class UserTypeValidationMiddleware
     private readonly ILogger<UserTypeValidationMiddleware> _logger;
     private static readonly Dictionary<string, List<UserType>> ValidUserTypesForPolicy = new()
     {
-        { Policy.EndUser, [UserType.Person, UserType.SystemUser, UserType.IdportenEmailIdentifiedUser, UserType.AltinnSelfIdentifiedUser, UserType.FeideUser] },
+        { Policy.EndUser, [UserType.Person, UserType.SystemUser, UserType.IdportenEmailIdentifiedUser] },
         { Policy.ServiceProvider, [UserType.ServiceOwner, UserType.ServiceOwnerOnBehalfOfPerson] },
         { Policy.ServiceProviderSearch, [UserType.ServiceOwner, UserType.ServiceOwnerOnBehalfOfPerson] },
         { Policy.ServiceProviderAdmin, [UserType.ServiceOwner] }

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/TestUser.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/TestUser.cs
@@ -23,7 +23,6 @@ public sealed class TestUser : IUser
 internal static class TestUsers
 {
     public static string DefaultPid => "22834498646";
-    private static string DefaultUserName => "UserName";
     private static string DefaultEmail => "TEST@TEST.NO";
     public static string DefaultParty => NorwegianPersonIdentifier.PrefixWithSeparator + DefaultPid;
 
@@ -64,13 +63,6 @@ internal static class TestUsers
             flowStep.AsUser(() => FromSelfIdentifiedUser()
                 .WithAmr(ClaimsPrincipalExtensions.AmrSelfRegisteredEmail)
                 .WithClaim(ClaimsPrincipalExtensions.IdportenEmailClaim, DefaultEmail)
-                .Configure(configure)
-                .Build());
-
-        public TFlowStep AsIntegrationLegacySIUser(Action<ClaimsPrincipalBuilder>? configure = null) =>
-            flowStep.AsUser(() => FromSelfIdentifiedUser()
-                .WithAmr(ClaimsPrincipalExtensions.AmrSelfIdentified)
-                .WithClaim(ClaimsPrincipalExtensions.AltinnUsernameClaim, DefaultUserName)
                 .Configure(configure)
                 .Build());
 

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogTests.cs
@@ -359,22 +359,6 @@ public class SearchDialogTests(DialogApplication application) : ApplicationColle
             .ExecuteAndAssert<PaginatedList<DialogDto>>(x =>
                 x.Items.Should().ContainSingle());
 
-    [Fact]
-    public Task Search_Dialogs_As_Legacy_SI_User() =>
-        // IntegrationLegacySIUser have this username: UserName
-        FlowBuilder.For(Application)
-            .CreateSimpleDialog((x, _) =>
-            {
-                x.Dto.Party = AltinnSelfIdentifiedUserIdentifier.PrefixWithSeparator + "USERNAME";
-            })
-            .AsIntegrationLegacySIUser()
-            .SearchEndUserDialogs(x =>
-            {
-                x.Party = [AltinnSelfIdentifiedUserIdentifier.PrefixWithSeparator + "uSeRnAmE"];
-            })
-            .ExecuteAndAssert<PaginatedList<DialogDto>>(x =>
-                x.Items.Should().ContainSingle());
-
     private static void ConfDialog(CreateDialogCommand command, Guid dialogId, DateTimeOffset createdAt)
     {
         command.Dto.Id = dialogId;

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DecisionRequestHelperTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DecisionRequestHelperTests.cs
@@ -152,37 +152,6 @@ public class DecisionRequestHelperTests
     }
 
     [Fact]
-    public void CreateDialogDetailsRequestShouldReturnCorrectRequestForAltinn2SiUser()
-    {
-        // Arrange
-        var request = CreateDialogDetailsAuthorizationRequest(
-            GetAsClaims(
-                ("urn:altinn:partyid", "1"),
-                ("urn:altinn:userid", "2"),
-                ("urn:altinn:username", "someusername"),
-                ("amr", "SelfIdentified")
-            ),
-            $"{AltinnSelfIdentifiedUserIdentifier.PrefixWithSeparator}someusername"
-        );
-
-        // Act
-        var result = DecisionRequestHelper.CreateDialogDetailsRequest(request);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.NotNull(result.Request);
-        Assert.NotNull(result.Request.Resource);
-
-        var accessResource = result.Request.Resource.First();
-        Assert.Contains(accessResource.Attribute, a => a.AttributeId == "urn:altinn:partyid" && a.Value == "1");
-
-        var accessSubject = result.Request.AccessSubject.First();
-        Assert.Equal("s1", accessSubject.Id);
-        Assert.Contains(accessSubject.Attribute, a => a.AttributeId == "urn:altinn:userid" && a.Value == "2");
-        Assert.Single(accessSubject.Attribute);
-    }
-
-    [Fact]
     public void CreateDialogDetailsRequestShouldReturnCorrectRequestForIdPortenEmailUser()
     {
         // Arrange
@@ -194,36 +163,6 @@ public class DecisionRequestHelperTests
                 ("amr", "Selfregistered-email")
             ),
             $"{IdportenEmailUserIdentifier.PrefixWithSeparator}foo@bar.com"
-        );
-
-        // Act
-        var result = DecisionRequestHelper.CreateDialogDetailsRequest(request);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.NotNull(result.Request);
-        Assert.NotNull(result.Request.Resource);
-
-        var accessResource = result.Request.Resource.First();
-        Assert.Contains(accessResource.Attribute, a => a.AttributeId == "urn:altinn:partyid" && a.Value == "1");
-
-        var accessSubject = result.Request.AccessSubject.First();
-        Assert.Equal("s1", accessSubject.Id);
-        Assert.Contains(accessSubject.Attribute, a => a.AttributeId == "urn:altinn:userid" && a.Value == "2");
-        Assert.Single(accessSubject.Attribute);
-    }
-
-    [Fact]
-    public void CreateDialogDetailsRequestShouldReturnCorrectRequestForFeideUser()
-    {
-        // Arrange
-        var request = CreateDialogDetailsAuthorizationRequest(
-            GetAsClaims(
-                ("urn:altinn:partyid", "1"),
-                ("urn:altinn:userid", "2"),
-                ("orgsub", "33a633c47ef2f656978f957532ce6d0de6f5e13f1e0618b37b4b2a70573e5551")
-            ),
-            $"{FeideUserIdentifier.PrefixWithSeparator}33a633c47ef2f656978f957532ce6d0de6f5e13f1e0618b37b4b2a70573e5551"
         );
 
         // Act


### PR DESCRIPTION
## Description

This removed synthetic party generation for self-identified users, as AM now supports e-mail users. This also removes 
* The option to authenticate as a legacy SI user ([this was already broken](https://digdir.slack.com/archives/C079ZFUSFMW/p1779350291612739?thread_ts=1778244263.792889&cid=C079ZFUSFMW), and will be fully removed after June 19th). 
* The option to authenticate as Feide users. This was a speculative, unused feature - these can currently not be externally adressed (no defined regime exists), and thus will not be able to see any dialogs (as there are none)
* Corresponding feature flags

## Related Issue(s)

- #4084 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated tests ~~added~~ removed 

