### PR TITLE
fix: disable cache/partyfilter for email users

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/ApplicationSettings.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/ApplicationSettings.cs
@@ -18,6 +18,8 @@ public sealed class FeatureToggle
     public bool UsePartyResourcePruning { get; init; }
     public bool UseAltinnAutoAuthorizedPartiesQueryParameters { get; init; }
     public bool EnablePartyFiltersForSystemUsers { get; init; }
+    public bool EnablePartyFiltersForEmailUsers { get; init; }
+    public bool EnablePartyCacheForEmailUsers { get; init; }
     public bool UseCorrectPersonNameOrdering { get; init; }
 }
 

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -166,14 +166,28 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
             authorizedPartiesRequest.PartyFilter.Clear();
         }
 
+        // Party filtering for SI users is mostly useless, as it very often is just one or two
+        // parties. Disable by default to reduce cache cardinality.
+        if (authorizedPartiesRequest.PartyIdentifier is IdportenEmailUserIdentifier
+            && !_applicationSettings.CurrentValue.FeatureToggle.EnablePartyFiltersForEmailUsers)
+        {
+            authorizedPartiesRequest.PartyFilter.Clear();
+        }
+
         AuthorizedPartiesResult authorizedParties;
         using (_logger.TimeOperation(nameof(GetAuthorizedParties)))
         {
-            authorizedParties = await _partiesCache.GetOrSetAsync(
-                authorizedPartiesRequest.GenerateCacheKey(),
-                async token => await PerformAuthorizedPartiesRequest(authorizedPartiesRequest, token),
-                token: cancellationToken
-            );
+            // Party cache for SI users is problematic due to merging of legacy SI users and e-mail users,
+            // since this flow assumes that the user is immediately able to load the updated party list. The
+            // list is cheap to generate in AM, so we pay the cost of doing this lookup for all SI user requests
+            authorizedParties = authorizedPartiesRequest.PartyIdentifier is IdportenEmailUserIdentifier
+                && !_applicationSettings.CurrentValue.FeatureToggle.EnablePartyCacheForEmailUsers
+                ? await PerformAuthorizedPartiesRequest(authorizedPartiesRequest, cancellationToken)
+                : await _partiesCache.GetOrSetAsync(
+                    authorizedPartiesRequest.GenerateCacheKey(),
+                    async token => await PerformAuthorizedPartiesRequest(authorizedPartiesRequest, token),
+                    token: cancellationToken
+                );
         }
 
         return flatten ? authorizedParties.Flatten() : authorizedParties;

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Authorization/AltinnAuthorizationClientTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Authorization/AltinnAuthorizationClientTests.cs
@@ -121,6 +121,87 @@ public class AltinnAuthorizationClientTests(DialogApplication application) : App
         }
     }
 
+    [Theory]
+    [InlineData(false, 0)]
+    [InlineData(true, 1)]
+    public async Task GetAuthorizedPartiesForLookup_Should_Respect_EmailUser_PartyFilter_FeatureToggle(
+        bool enablePartyFiltersForEmailUsers,
+        int expectedPartyFilterCount)
+    {
+        // Arrange
+        var handler = new CapturingHttpMessageHandler(EmailUserAuthorizedPartiesResponse);
+        var client = CreateAltinnAuthorizationClient(
+            handler,
+            new FeatureToggle
+            {
+                EnablePartyFiltersForEmailUsers = enablePartyFiltersForEmailUsers
+            });
+
+        const string party = "urn:altinn:organization:identifier-no:991825827";
+
+        // Act
+        await client.GetAuthorizedPartiesForLookup(
+            CreateEmailUserIdentifier(),
+            [party],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        handler.RequestContent.Should().NotBeNull();
+        var requestJson = JsonNode.Parse(handler.RequestContent!)!;
+        var partyFilter = requestJson["partyFilter"]!.AsArray();
+        partyFilter.Count.Should().Be(expectedPartyFilterCount);
+    }
+
+    [Theory]
+    [InlineData(false, 2)] // cache bypassed → one upstream request per call
+    [InlineData(true, 1)]  // cached → second call served from cache
+    public async Task GetAuthorizedParties_Should_Respect_EmailUser_PartyCache_FeatureToggle(
+        bool enablePartyCacheForEmailUsers,
+        int expectedUpstreamRequestCount)
+    {
+        // Arrange
+        var handler = new CapturingHttpMessageHandler(EmailUserAuthorizedPartiesResponse);
+        var client = CreateAltinnAuthorizationClient(
+            handler,
+            new FeatureToggle
+            {
+                EnablePartyCacheForEmailUsers = enablePartyCacheForEmailUsers
+            },
+            useRealPartiesCache: true);
+
+        var emailUser = CreateEmailUserIdentifier();
+
+        // Act
+        await client.GetAuthorizedParties(emailUser, cancellationToken: TestContext.Current.CancellationToken);
+        await client.GetAuthorizedParties(emailUser, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        handler.RequestCount.Should().Be(expectedUpstreamRequestCount);
+    }
+
+    [Fact]
+    public async Task GetAuthorizedParties_Should_Use_PartyCache_For_Other_Users_When_EmailUser_PartyCache_Is_Disabled()
+    {
+        // Arrange
+        var handler = new CapturingHttpMessageHandler();
+        var client = CreateAltinnAuthorizationClient(
+            handler,
+            new FeatureToggle
+            {
+                EnablePartyCacheForEmailUsers = false
+            },
+            useRealPartiesCache: true);
+
+        var systemUser = CreateSystemUserIdentifier();
+
+        // Act
+        await client.GetAuthorizedParties(systemUser, cancellationToken: TestContext.Current.CancellationToken);
+        await client.GetAuthorizedParties(systemUser, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        handler.RequestCount.Should().Be(1);
+    }
+
     private static AltinnAuthorizationClient CreateAltinnAuthorizationClient(
         string userAuthLevel, DialogDbContext db)
     {
@@ -151,10 +232,13 @@ public class AltinnAuthorizationClientTests(DialogApplication application) : App
 
     private static AltinnAuthorizationClient CreateAltinnAuthorizationClient(
         HttpMessageHandler handler,
-        FeatureToggle featureToggle)
+        FeatureToggle featureToggle,
+        bool useRealPartiesCache = false)
     {
         var cacheProvider = Substitute.For<IFusionCacheProvider>();
-        cacheProvider.GetCache(Arg.Any<string>()).Returns(_ => new NullFusionCache(Options.Create(new FusionCacheOptions())));
+        cacheProvider.GetCache(Arg.Any<string>()).Returns(_ => useRealPartiesCache
+            ? new FusionCache(new FusionCacheOptions())
+            : new NullFusionCache(Options.Create(new FusionCacheOptions())));
 
         var user = Substitute.For<IUser>();
         user.GetPrincipal().Returns(TestUsers.FromDefault().Build());
@@ -179,6 +263,38 @@ public class AltinnAuthorizationClientTests(DialogApplication application) : App
         );
     }
 
+    // A non-empty response is required for email users without party filters; an empty
+    // authorized parties list is treated as an upstream error for non-system users
+    private const string EmailUserAuthorizedPartiesResponse =
+        """
+        [{
+            "name": "Test User",
+            "organizationNumber": "",
+            "emailId": "test@example.com",
+            "partyId": 1,
+            "partyUuid": "0290a7cd-9651-4775-8a47-edbb1bbb8a37",
+            "type": "SelfIdentified",
+            "isDeleted": false,
+            "onlyHierarchyElementWithNoAccess": false,
+            "authorizedAccessPackages": [],
+            "authorizedResources": [],
+            "authorizedRoles": [],
+            "authorizedInstances": [],
+            "subunits": []
+        }]
+        """;
+
+    private static IPartyIdentifier CreateEmailUserIdentifier()
+    {
+        var parsed = IdportenEmailUserIdentifier.TryParse(
+            $"{IdportenEmailUserIdentifier.PrefixWithSeparator}test@example.com",
+            out var emailUserIdentifier);
+        parsed.Should().BeTrue();
+        emailUserIdentifier.Should().NotBeNull();
+
+        return emailUserIdentifier;
+    }
+
     private static IPartyIdentifier CreateSystemUserIdentifier()
     {
         var parsed = SystemUserIdentifier.TryParse(
@@ -190,20 +306,22 @@ public class AltinnAuthorizationClientTests(DialogApplication application) : App
         return systemUserIdentifier;
     }
 
-    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+    private sealed class CapturingHttpMessageHandler(string responseContent = "[]") : HttpMessageHandler
     {
         public string? RequestContent { get; private set; }
+        public int RequestCount { get; private set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            RequestCount++;
             request.Content.Should().NotBeNull();
             RequestContent = await request.Content.ReadAsStringAsync(cancellationToken);
 
             return new(HttpStatusCode.OK)
             {
-                Content = new StringContent("[]")
+                Content = new StringContent(responseContent)
             };
         }
     }


### PR DESCRIPTION
## Description

This disables (by default, can be feature toggled) party cache and AM party filtering for SI-users

## Related Issue(s)

- #4095

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 
