### PR TITLE
chore(infra): bump Key Vault API versions

### DIFF
--- a/.azure/applications/graphql/main.bicep
+++ b/.azure/applications/graphql/main.bicep
@@ -134,7 +134,7 @@ param scale Scale = {
   ]
 }
 
-resource environmentKeyVaultResource 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+resource environmentKeyVaultResource 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: environmentKeyVaultName
 }
 

--- a/.azure/applications/service/main.bicep
+++ b/.azure/applications/service/main.bicep
@@ -139,7 +139,7 @@ var containerAppEnvVars = [
   }
 ]
 
-resource environmentKeyVaultResource 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+resource environmentKeyVaultResource 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: environmentKeyVaultName
 }
 

--- a/.azure/applications/web-api-eu/main.bicep
+++ b/.azure/applications/web-api-eu/main.bicep
@@ -138,7 +138,7 @@ param scale Scale = {
   ]
 }
 
-resource environmentKeyVaultResource 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+resource environmentKeyVaultResource 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: environmentKeyVaultName
 }
 

--- a/.azure/applications/web-api-so/main.bicep
+++ b/.azure/applications/web-api-so/main.bicep
@@ -107,7 +107,7 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-
   tags: tags
 }
 
-resource environmentKeyVaultResource 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+resource environmentKeyVaultResource 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: environmentKeyVaultName
 }
 

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -200,7 +200,7 @@ module vnet '../modules/vnet/main.bicep' = {
 // Create references to existing resources
 // #######################################
 
-resource srcKeyVaultResource 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+resource srcKeyVaultResource 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: secrets.sourceKeyVaultName
   scope: az.resourceGroup(secrets.sourceKeyVaultSubscriptionId, secrets.sourceKeyVaultResourceGroup)
 }

--- a/.azure/modules/keyvault/addReaderRoles.bicep
+++ b/.azure/modules/keyvault/addReaderRoles.bicep
@@ -4,7 +4,7 @@ param keyvaultName string
 @description('Array of principal IDs to assign the Key Vault Secrets User role to')
 param principalIds array
 
-resource keyvault 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+resource keyvault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: keyvaultName
 }
 

--- a/.azure/modules/keyvault/copySecrets.bicep
+++ b/.azure/modules/keyvault/copySecrets.bicep
@@ -44,7 +44,7 @@ var keys = map(filteredKeysBySecretPrefix, key => {
   appConfigKey: replace(replace(key, secretPrefix, ''), '--', ':')
 })
 
-resource srcKeyVaultResource 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+resource srcKeyVaultResource 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: srcKeyVaultName
   scope: resourceGroup(srcKeyVaultSubId, srcKeyVaultRGNName)
 }

--- a/.azure/modules/keyvault/create.bicep
+++ b/.azure/modules/keyvault/create.bicep
@@ -18,7 +18,7 @@ param sku Sku
 
 var keyVaultName = take('${namePrefix}-kv-${uniqueString(resourceGroup().id)}', 24)
 
-resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' = {
   name: keyVaultName
   location: location
   properties: {

--- a/.azure/modules/keyvault/upsertSecret.bicep
+++ b/.azure/modules/keyvault/upsertSecret.bicep
@@ -4,7 +4,7 @@ param tags object
 @secure()
 param secretValue string
 
-resource secret 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = {
+resource secret 'Microsoft.KeyVault/vaults/secrets@2026-02-01' = {
   name: '${destKeyVaultName}/${secretName}'
   properties: {
     value: secretValue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bumps `Microsoft.KeyVault/vaults` Bicep resource API versions from `2024-11-01` to `2026-02-01` across Key Vault modules, infrastructure, and application deployments.
Bumps `Microsoft.KeyVault/vaults/secrets` to `2026-02-01` in `upsertSecret.bicep` after verifying Microsoft now lists `2026-02-01` as the current stable version.
No resource properties or declarations were changed beyond API-version strings.

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

Manual verification: reviewed `git diff`, `git diff origin/main...`, and Microsoft Learn resource/change-log pages; skipped .NET build/tests because only Bicep files changed.

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
