### PR TITLE
trivial(webapi): correct Scalar API reference OpenAPI document path behind APIM

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -169,11 +169,14 @@ static void BuildAndRun(string[] args)
         .MapControllers();
 
     var dialogPrefix = builder.Environment.IsDevelopment() ? "" : "/dialogporten";
-    var openApiDocumentPath = dialogPrefix + "/swagger/{documentName}/swagger.json";
 
     app.MapScalarApiReference("/scalar", options => options
         .WithTitle("Dialogporten API")
-        .WithOpenApiRoutePattern(openApiDocumentPath)
+        // Unlike the Swagger UI, Scalar resolves a relative document URL against the origin plus
+        // the base path it auto-detects (window.location.pathname minus the server request path).
+        // Behind APIM that base path is already "/dialogporten", so the route pattern must NOT
+        // include the prefix here, or it would be applied twice (e.g. /dialogporten/dialogporten/...).
+        .WithOpenApiRoutePattern("/swagger/{documentName}/swagger.json")
         .AddDocument("v1", "Dialogporten")
         .AddDocument("v1.enduser", "Dialogporten EndUser")
         .AddDocument("v1.serviceowner", "Dialogporten ServiceOwner")
@@ -256,7 +259,7 @@ static void BuildAndRun(string[] args)
             // Hide schemas view
             uiConfig.DefaultModelsExpandDepth = -1;
             // We have to add dialogporten here to get the correct base url for swagger.json in the APIM. Should not be done for development
-            uiConfig.DocumentPath = openApiDocumentPath;
+            uiConfig.DocumentPath = dialogPrefix + "/swagger/{documentName}/swagger.json";
         })
         .UseFeatureMetrics();
 


### PR DESCRIPTION
## Description

The Scalar API reference UI (added in #4054) failed to load any OpenAPI document when deployed to Azure ("Document '...' could not be loaded"), while the Swagger UI kept working. The cause: Scalar's `WithOpenApiRoutePattern` was sharing the same prefixed path as the NSwag Swagger UI, but Scalar auto-detects the reverse-proxy base path (`window.location.pathname` minus the server request path) and resolves relative document URLs against it — so behind APIM the `/dialogporten` prefix was applied twice (`/dialogporten/dialogporten/swagger/...`), producing a 404. This change gives Scalar an unprefixed route pattern (it supplies `/dialogporten` itself at runtime) while keeping the explicit prefix on the Swagger UI's `DocumentPath`, which genuinely needs it. Verified the WebApi builds clean; the deployed APIM behavior should be confirmed in AT23 after deploy.

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)