### PR TITLE
fix: handle content-less apionly dialogs

### DIFF
--- a/docs/schema/V1/openapi.v1.enduser.verified.json
+++ b/docs/schema/V1/openapi.v1.enduser.verified.json
@@ -1035,7 +1035,8 @@
         "additionalProperties": false,
         "properties": {
           "content": {
-            "description": "The content of the dialog in search results.",
+            "description": "The content of the dialog in search results. May be null for API-only dialogs, which are not required to have content.",
+            "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/DialogContentSummary"

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -1945,7 +1945,8 @@
         "additionalProperties": false,
         "properties": {
           "content": {
-            "description": "The content of the dialog in search results.",
+            "description": "The content of the dialog in search results. May be null for API-only dialogs, which are not required to have content.",
+            "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1EndUserDialogsQueriesSearch_Content"

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/DialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/DialogDto.cs
@@ -182,9 +182,9 @@ public sealed class DialogDto
     public DialogEndUserContextDto EndUserContext { get; set; } = null!;
 
     /// <summary>
-    /// The content of the dialog in search results.
+    /// The content of the dialog in search results. May be null for API-only dialogs, which are not required to have content.
     /// </summary>
-    public ContentDto Content { get; set; } = null!;
+    public ContentDto? Content { get; set; }
 }
 
 public sealed class ContentDto

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogQuery.cs
@@ -265,7 +265,7 @@ internal sealed class SearchDialogQueryHandler : IRequestHandler<SearchDialogQue
                     .Result[dialog.Id]
                     .SystemLabels.All(x => x != SystemLabel.Values.MarkedAsUnopened),
                 EndUserContext = endUserContextByDialogIdTask.Result[dialog.Id],
-                Content = contentByDialogIdTask.Result[dialog.Id],
+                Content = contentByDialogIdTask.Result.GetValueOrDefault(dialog.Id),
             };
         });
 

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Search/SearchDialogTests.cs
@@ -192,6 +192,26 @@ public class SearchDialogTests(DialogApplication application) : ApplicationColle
     }
 
     [Fact]
+    public Task Search_Should_Return_ApiOnly_Dialog_Without_Content() =>
+        // API-only dialogs are not required to have content, and are not excluded
+        // from end user search by default. The handler must not throw when content
+        // is missing for such a dialog. Regression test for KeyNotFoundException.
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.Dto.IsApiOnly = true;
+                x.Dto.Content = null;
+            })
+            .SearchEndUserDialogs((x, ctx) =>
+                x.Party = [ctx.GetParty()])
+            .ExecuteAndAssert<PaginatedList<DialogDto>>(x =>
+            {
+                var dialog = x.Items.Single();
+                dialog.IsApiOnly.Should().BeTrue();
+                dialog.Content.Should().BeNull();
+            });
+
+    [Fact]
     public Task Search_Should_Return_HasUnopenedContent_False_For_New_Simple_Dialogs() =>
         FlowBuilder.For(Application)
             .CreateSimpleDialog()


### PR DESCRIPTION
## Description

The end-user search endpoint (GET /api/v1/enduser/dialogs) throws KeyNotFoundException when a returned dialog is an API-only dialog with no content.

In SearchDialogQueryHandler.Handle, content is looked up per dialog with a throwing dictionary indexer:

Content = contentByDialogIdTask.Result[dialog.Id],

FetchContentByDialogId builds its dictionary with an INNER JOIN "DialogContent", so a dialog with no content rows is simply absent from the dictionary. Two facts combine to trigger the crash:

1. API-only dialogs may have no content — CreateDialogDtoValidator only validates Content when it's provided for API-only dialogs.
2. End-user search does not exclude API-only dialogs (ExcludeApiOnly defaults to false).

So when an end user searches a party that owns a content-less API-only dialog, the indexer misses and the entire result page fails with a 500.

This is a latent bug from the search rewrite that has been in prod for some time. The tell: the ServiceOwner search — built in the same rewrite — already handles this correctly with GetValueOrDefault(dialog.Id) and a nullable ContentDto? Content. Only the end-user side kept the throwing indexer and a non-nullable Content.

Fix

Aligned end-user search with the existing ServiceOwner pattern:
- SearchDialogQuery.cs — use contentByDialogIdTask.Result.GetValueOrDefault(dialog.Id) instead of the [dialog.Id] indexer.
- DialogDto.cs (EndUser search) — Content is now ContentDto? (nullable), with an updated doc comment.
- Regenerated OpenAPI snapshots (content gains nullable: true in the enduser search schema; serviceowner schema unchanged).

> ⚠️ API consumer note: This marks content as nullable in the public end-user search schema. Content-less API-only dialogs are now returned (with content: null) to end-user search, consistent with the single-GET endpoint and ServiceOwner search behavior. API-only dialogs were already not excluded from end-user search by default.

## Related Issue(s)

- #4110 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added 