### PR TITLE
trivial: default Scalar UI to ServiceOwner document

### DIFF
--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -177,7 +177,7 @@ static void BuildAndRun(string[] args)
         // Behind APIM that base path is already "/dialogporten", so the route pattern must NOT
         // include the prefix here, or it would be applied twice (e.g. /dialogporten/dialogporten/...).
         .WithOpenApiRoutePattern("/swagger/{documentName}/swagger.json")
-        .AddDocument("v1", "Dialogporten")
+        .AddDocument("v1", "Dialogporten - EndUser/ServiceOwner combined (legacy)")
         .AddDocument("v1.enduser", "Dialogporten EndUser")
         .AddDocument("v1.serviceowner", "Dialogporten ServiceOwner", isDefault: true)
         .DisableAgent());

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -179,7 +179,7 @@ static void BuildAndRun(string[] args)
         .WithOpenApiRoutePattern("/swagger/{documentName}/swagger.json")
         .AddDocument("v1", "Dialogporten")
         .AddDocument("v1.enduser", "Dialogporten EndUser")
-        .AddDocument("v1.serviceowner", "Dialogporten ServiceOwner")
+        .AddDocument("v1.serviceowner", "Dialogporten ServiceOwner", isDefault: true)
         .DisableAgent());
 
     app.UseHttpsRedirection();


### PR DESCRIPTION
## Description

Marks the **Dialogporten ServiceOwner** OpenAPI document as the default selection in the Scalar API reference UI (`/scalar`) via the `isDefault: true` parameter on `AddDocument`. Previously Scalar defaulted to the first-added document ("Dialogporten"); the document dropdown order is unchanged, only the initial selection differs.

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
