### PR TITLE
test: remove seen log retry polling

### DIFF
--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
@@ -175,12 +175,13 @@ public class GetDialogTests(WebApiE2EFixture fixture) : E2ETestBase<WebApiE2EFix
         setLabelsResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
 
         // Act
-        var getDialogResult = await E2ERetryPolicies.RetryUntilAsync(
-            operation: ct => Fixture.EndUserApi.GetDialog(dialogId, cancellationToken: ct),
-            isSuccessful: result => result is { IsSuccessful: true, Content.SeenSinceLastUpdate.Count: 1 },
-            degradationMessage: "Seen log creation delayed");
+        var getDialogResult = await Fixture.EndUserApi.GetDialog(
+            dialogId,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
+        getDialogResult.ShouldHaveStatusCode(HttpStatusCode.OK);
+        getDialogResult.Content.Should().NotBeNull();
         await JsonSnapshotVerifier.VerifyJsonSnapshot(
             JsonSerializer.Serialize(getDialogResult.Content));
     }

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EndUser/SeenLogs/Queries/GetSeenLogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EndUser/SeenLogs/Queries/GetSeenLogTests.cs
@@ -17,11 +17,11 @@ public class GetSeenLogTests(WebApiE2EFixture fixture) : E2ETestBase<WebApiE2EFi
         // Arrange
         var dialogId = await Fixture.ServiceownerApi.CreateSimpleDialogAsync();
 
-        var getDialogResponse = await E2ERetryPolicies.RetryUntilAsync(
-            operation: ct => Fixture.EndUserApi.GetDialog(dialogId, cancellationToken: ct),
-            isSuccessful: result => result is { IsSuccessful: true, Content.SeenSinceLastUpdate.Count: 1 },
-            degradationMessage: "Seen log creation delayed");
+        var getDialogResponse = await Fixture.EndUserApi.GetDialog(
+            dialogId,
+            cancellationToken: TestContext.Current.CancellationToken);
 
+        getDialogResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
         getDialogResponse.Content.Should().NotBeNull();
         var seenLog = getDialogResponse.Content
             .SeenSinceLastUpdate.FirstOrDefault();

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EndUser/SeenLogs/Queries/SearchSeenLogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/EndUser/SeenLogs/Queries/SearchSeenLogTests.cs
@@ -17,11 +17,11 @@ public class SearchSeenLogTests(WebApiE2EFixture fixture) : E2ETestBase<WebApiE2
         // Arrange
         var dialogId = await Fixture.ServiceownerApi.CreateSimpleDialogAsync();
 
-        var getDialogResponse = await E2ERetryPolicies.RetryUntilAsync(
-            operation: ct => Fixture.EndUserApi.GetDialog(dialogId, cancellationToken: ct),
-            isSuccessful: result => result is { IsSuccessful: true, Content.SeenSinceLastUpdate.Count: 1 },
-            degradationMessage: "Seen log creation delayed");
+        var getDialogResponse = await Fixture.EndUserApi.GetDialog(
+            dialogId,
+            cancellationToken: TestContext.Current.CancellationToken);
 
+        getDialogResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
         getDialogResponse.Content.Should().NotBeNull();
         var seenLogId = getDialogResponse.Content.SeenSinceLastUpdate.Single().Id;
 
@@ -32,8 +32,8 @@ public class SearchSeenLogTests(WebApiE2EFixture fixture) : E2ETestBase<WebApiE2
 
         // Assert
         response.ShouldHaveStatusCode(HttpStatusCode.OK);
-        var content = response.Content ?? throw new InvalidOperationException("Seen log content was null.");
-        content.Should().ContainSingle().Which.Id.Should().Be(seenLogId);
+        response.Content.Should().NotBeNull();
+        response.Content.Should().ContainSingle().Which.Id.Should().Be(seenLogId);
     }
 
     [E2EFact]
@@ -63,11 +63,9 @@ public class SearchSeenLogTests(WebApiE2EFixture fixture) : E2ETestBase<WebApiE2
         getDialogResponse2.ShouldHaveStatusCode(HttpStatusCode.OK);
 
         // Act
-        var response = await E2ERetryPolicies.RetryUntilAsync(
-            operation: ct => Fixture.EndUserApi.V1.SearchDialogSeenLogs(
-                dialogId, cancellationToken: ct),
-            isSuccessful: result => result is { IsSuccessful: true, Content.Count: 2 },
-            degradationMessage: "Seen log creation delayed");
+        var response = await Fixture.EndUserApi.V1.SearchDialogSeenLogs(
+            dialogId,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         response.ShouldHaveStatusCode(HttpStatusCode.OK);

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/SeenLogs/Queries/GetSeenLogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/SeenLogs/Queries/GetSeenLogTests.cs
@@ -16,13 +16,12 @@ public class GetSeenLogTests(WebApiE2EFixture fixture) : E2ETestBase<WebApiE2EFi
         // Arrange
         var dialogId = await Fixture.ServiceownerApi.CreateSimpleDialogAsync();
 
-        // Trigger seen log by fetching the dialog as the end user, retrying
-        // until the seen log entry has propagated.
-        var getDialogResponse = await E2ERetryPolicies.RetryUntilAsync(
-            operation: ct => Fixture.EndUserApi.GetDialog(dialogId, cancellationToken: ct),
-            isSuccessful: result => result is { IsSuccessful: true, Content.SeenSinceLastUpdate.Count: 1 },
-            degradationMessage: "Seen log creation delayed");
+        // Trigger seen log by fetching the dialog as the end user.
+        var getDialogResponse = await Fixture.EndUserApi.GetDialog(
+            dialogId,
+            cancellationToken: TestContext.Current.CancellationToken);
 
+        getDialogResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
         getDialogResponse.Content.Should().NotBeNull();
         var seenLog = getDialogResponse.Content.SeenSinceLastUpdate.FirstOrDefault();
         seenLog.Should().NotBeNull();


### PR DESCRIPTION
## Description

Removes seen-log creation polling from WebAPI E2E tests now that seen logs are expected to be available immediately. The touched tests use direct dialog and seen-log API calls with explicit status/content assertions.

## Related Issue(s)

- None

## Verification

- [x] `dotnet build Digdir.Domain.Dialogporten.slnx --configuration Release` passed; existing obsolete transmission-client warnings remain
- [x] `dotnet test Digdir.Domain.Dialogporten.slnx --configuration Release --no-build --filter 'FullyQualifiedName!~E2E'` passed
- [ ] Manual testing done (required)
- [ ] Relevant automated test added
- [x] Database changes manually applied to prod/YT01 (not relevant; no database changes)

## Documentation

- [x] Documentation is updated (not applicable)
