### PR TITLE
ci: move lightweight notification/bookkeeping jobs to self-hosted runners

### DIFF
--- a/.github/workflows/workflow-delete-deployments.yml
+++ b/.github/workflows/workflow-delete-deployments.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   delete_github_deployments:
     name: Delete GitHub deployments
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:

--- a/.github/workflows/workflow-get-latest-deployed-version-info-from-github.yml
+++ b/.github/workflows/workflow-get-latest-deployed-version-info-from-github.yml
@@ -23,7 +23,7 @@ jobs:
     name: Get Latest Deployed Versions from GitHub Variables
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ inputs.environment }}
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/workflow-send-ci-cd-status-slack-message.yml
+++ b/.github/workflows/workflow-send-ci-cd-status-slack-message.yml
@@ -61,7 +61,7 @@ jobs:
     name: Send Slack message
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/workflow-send-deployment-lag-slack-message.yml
+++ b/.github/workflows/workflow-send-deployment-lag-slack-message.yml
@@ -42,7 +42,7 @@ jobs:
     name: Send Deployment Lag Slack Message
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/workflow-store-github-env-variable.yml
+++ b/.github/workflows/workflow-store-github-env-variable.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   store-variable:
     name: Store GitHub Environment Variable
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout

--- a/.github/workflows/workflow-swarmia-deployment.yml
+++ b/.github/workflows/workflow-swarmia-deployment.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   send-deployment-to-swarmia:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - name: Send deployment to Swarmia
       run: |

--- a/.github/workflows/workflow-tag-issues-with-environment.yml
+++ b/.github/workflows/workflow-tag-issues-with-environment.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   tag-issues-with-environment:
     name: Tag PRs and issues with ${{ inputs.environment-label }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       GH_TOKEN: ${{ github.token }}
       LABEL: ${{ inputs.environment-label }}


### PR DESCRIPTION
## What

Moves 7 **non-gating** reusable workflows from `ubuntu-latest` → `self-hosted`, continuing the migration started in #4116:

| Workflow | What it does |
|---|---|
| `workflow-send-ci-cd-status-slack-message.yml` | Slack CI/CD status notification |
| `workflow-send-deployment-lag-slack-message.yml` | Slack deployment-lag notification |
| `workflow-swarmia-deployment.yml` | Swarmia deployment ping (HTTP) |
| `workflow-store-github-env-variable.yml` | Stores a GitHub environment variable (`gh`) |
| `workflow-tag-issues-with-environment.yml` | Tags PRs/issues with the environment (`gh`) |
| `workflow-get-latest-deployed-version-info-from-github.yml` | Reads GitHub variables (`gh`) |
| `workflow-delete-deployments.yml` | Deletes GitHub deployments on PR cleanup (`gh`) |

Each change is a single-line `runs-on` flip.

## Why these (lowest risk)

- **Non-gating** — none block a PR merge or a deployment. A runner hiccup degrades a notification or bookkeeping step at worst; nothing rolls back or fails a gate.
- **No Docker / minimal tooling** — pure `gh` / `az` / `curl` / Node steps. The self-hosted runners are ephemeral **Azure Container App Jobs** with **no Docker daemon** and a minimal image (Azure CLI, Node 24, `gh`, `jq`, `make`), so these jobs run unchanged.
- The PR pipeline already depends on self-hosted runners for `check-for-changes`, so this adds **no new critical-path dependency**.

## ⚠️ Caveats

- **Shared across all environments** — these are reusable workflows called by the test/staging/yt01/prod pipelines, so the change applies everywhere at once.
- **Concurrency ceiling unverified** — max parallel runners (`maxExecutions`) is set in the external `Altinn/altinn-modules` Terraform module (v1.2.3), not in the runner-config repo. If the pool is small, higher-volume use could queue. Worth confirming with the platform team before moving busier jobs.
- **Ephemeral = cold caches** — each job gets a fresh runner (no local NuGet/npm/Docker-layer reuse). Negligible for these lightweight jobs.
- **Smaller runners** — 4 vCPU / 8 GiB vs 16 GB on `ubuntu-latest`. Fine here; relevant for heavier jobs later.
- **Public-repo + self-hosted security** — flagged in altinn-platform RFC 0002. Mitigated by ephemeral, repo-scoped runners and secrets not flowing to fork PRs; confirm "require approval for outside collaborators" is enabled.

## 🚫 Blocked — cannot move (need a Docker daemon / missing tooling)

Out of scope here; staying on `ubuntu-latest`:

- `workflow-build-and-test.yml` — integration tests use **Testcontainers.PostgreSql** (needs Docker).
- `workflow-publish-docker-images.yml` — `docker/setup-buildx` + `build-push` (needs Docker).
- `workflow-run-k6-tests.yml` — `grafana/k6-action` runs k6 via Docker.
- `workflow-deploy-infra.yml` — uses `shell: pwsh`, which isn't in the runner image.

## Next candidates (future PRs, once this is proven stable)

Docker-free but gating/heavier, so deferred until the pool's reliability and concurrency are confirmed: PR checks `validate-schema` and `vulnerabilities-introduced`, and the E2E test workflows (`run-webapi-e2e-tests`, `run-graphql-e2e-tests`, `run-k6-performance`, which runs k6 in AKS rather than on the runner).

## Rollback

Revert the single commit — every change is a one-line `runs-on` flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
