### PR TITLE
fix(infra): align test postgres2 storage with live server to unblock deploy

### DIFF
--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -34,10 +34,10 @@ param postgresConfiguration = {
     tier: 'Burstable'
   }
   storage: {
-    storageSizeGB: 32
-    autoGrow: 'Enabled'
+    storageSizeGB: 64
+    autoGrow: 'Disabled'
     type: 'Premium_LRS'
-    tier: 'P4'
+    tier: 'P6'
   }
   // Enabling index tuning will practically also enable query performance insight
   enableIndexTuning: false


### PR DESCRIPTION
## Problem

Deploy to test on `CI/CD Main` was failing on the `postgresql` deployment:

```
UpsertServerManagementOperationDowngradeDiskSizeUnsupported:
Requested data Disk size '32768' cannot be less than current size '65536'.
```

The test `postgres2` server (`dp-be-test-postgres2-i7se3jtjey3lo`) had auto-grown from 32 GB / P4 to **64 GB / P6**, but `test.bicepparam` still declared 32 GB / P4. Azure PostgreSQL Flexible Server cannot shrink disk size, so every deploy hit this error and failed.

## Fix

Bring the declared storage in line with the live server:

| Field | Before | After |
|---|---|---|
| `storageSizeGB` | 32 | 64 |
| `autoGrow` | `Enabled` | `Disabled` |
| `tier` | P4 | P6 |

`autoGrow` is disabled so the same IaC-vs-reality drift cannot silently recur the next time the disk crosses a threshold. Current usage is ~46% of 64 GB, so there is comfortable headroom.

Cost delta of staying at 64 GB (P6) vs 32 GB (P4) is ~$6/month in Norway East; delete-and-recreate to reclaim the smaller disk is also still an option. Auto grow should be disabled either way.

## Validation

- `az bicep build-params` compiles cleanly; the resolved storage block is `64 GB / Premium_LRS / P6 / autoGrow Disabled`.

## Notes

This unblocks the **deploy** failure only. Two unrelated failures remain on `CI/CD Main` and are out of scope here:
- E2E test failures (`SearchDialogSystemUserTests`, `SearchDialogTests`)
- Queued runs waiting on offline `self-hosted` runners
