### PR TITLE
chore(infra): make PostgreSQL diagnostic setting unconditional and resource-specific

### DIFF
--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -444,11 +444,12 @@ var diagnosticLogCategories = [
   'PostgreSQLFlexDatabaseXacts'
 ]
 
-resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (enableQueryStore) {
+resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
   name: 'PostgreSQLDiagnosticSetting'
   scope: postgres
   properties: {
     workspaceId: appInsightsWorkspace.id
+    logAnalyticsDestinationType: 'Dedicated'
     logs: [for category in diagnosticLogCategories: {
       category: category
       enabled: true
@@ -463,7 +464,6 @@ resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-pre
       }
     ]
   }
-  dependsOn: [pg_qs_query_capture_mode]
 }
 
 module adoConnectionString '../keyvault/upsertSecret.bicep' = if (shouldPublishCanonicalConnectionSecrets) {


### PR DESCRIPTION
## What

Brings the `PostgreSQLDiagnosticSetting` diagnostic setting (the one that ships PostgreSQL logs to Log Analytics) under consistent IaC management across all envs:

- Remove the `if (enableQueryStore)` guard so the setting is deployed in **every** env, regardless of the query-store tuning flags.
- Set `logAnalyticsDestinationType: 'Dedicated'` so logs land in the typed resource-specific tables (`PGSQLServerLogs` etc.) instead of the legacy shared `AzureDiagnostics` table.
- Drop the `dependsOn` on the query-store capture-mode resource (a false dependency; the setting only needs the server + workspace, which Bicep infers).

## Why

The setting was guarded by `if (enableQueryStore)`. Prod has both query-store tuning flags off, so prod got **no IaC-managed diagnostic setting at all**, and it ended up being created and deleted manually in the portal. That caused a multi-day window where prod PostgreSQL logging stopped entirely, with no traceable cause.

We are standing up database audit logging (Entra group-based access + pgaudit), which depends on this diagnostic setting existing. It therefore needs to be present and IaC-managed in every env, not gated on an unrelated tuning flag.

Resource-specific (`Dedicated`) is Microsoft's recommended destination, and the typed `ProcessId` column it provides is what per-individual audit attribution joins on.

## Deploy notes (please review the rollout with eyes on it)

- **Prod** already has a manually-created `PostgreSQLDiagnosticSetting` with the same name and shape; this deploy adopts it in place (effectively a no-op there).
- **Test and staging** flip from `AzureDiagnostics` to `Dedicated`. The log categories are unchanged, but new data will land in the resource-specific tables (`PGSQLServerLogs`, `PGSQLPgStatActivitySessions`, etc.) instead of `AzureDiagnostics`. Expect the usual ~15-20 min crossover after deploy.
- **Anything querying the legacy `AzureDiagnostics` table for PostgreSQL logs in test/staging will need updating** to the resource-specific tables. Worth a quick check of Grafana panels / saved queries before merging.
- The query-store log categories are harmless when query store is off: they emit no data until `pg_qs.query_capture_mode` is enabled.

Related to altinn-platform#3407 and #3883.