### PR TITLE
fix: Dont cache null names

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/NameRegistry/PartyNameRegistryClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/NameRegistry/PartyNameRegistryClient.cs
@@ -8,6 +8,7 @@ using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion;
+using static System.StringComparison;
 
 namespace Digdir.Domain.Dialogporten.Infrastructure.Altinn.NameRegistry;
 
@@ -58,13 +59,24 @@ internal sealed class PartyNameRegistryClient : IPartyNameRegistry
         return async (ctx, ct) =>
         {
             var name = await GetNameFromRegister(externalIdWithPrefix, ct);
-            if (name is null)
+            if (name is not null) return name;
+
+            if (externalIdWithPrefix.StartsWith(SystemUserIdentifier.Prefix, InvariantCultureIgnoreCase))
             {
-                // Short negative cache
-                ctx.Options.Duration = TimeSpan.FromSeconds(10);
+                _logger.LogWarning(
+                    "Got null when getting system username. Retrying once after 100ms. ExternalId: {ExternalId}",
+                    externalIdWithPrefix
+                );
+                await Task.Delay(TimeSpan.FromMilliseconds(100), ct);
+                name = await GetNameFromRegister(externalIdWithPrefix, ct);
             }
 
-            return name;
+            if (name is not null) return name;
+
+            ctx.Options.SkipMemoryCacheWrite = true;
+            ctx.Options.SkipDistributedCacheWrite = true;
+
+            return null;
         };
     }
 
@@ -117,8 +129,12 @@ internal sealed class PartyNameRegistryClient : IPartyNameRegistry
         var name = nameLookupResult.Data.FirstOrDefault()?.DisplayName;
         if (name is null)
         {
-            // This is PII, but this is an error condition (probably due to missing Altinn profile)
-            _logger.LogError("Failed to get name from party name registry for external id {ExternalId}", externalIdWithPrefix);
+            _logger.LogError(
+                "Failed to get name from party name registry for external id {ExternalId}. Response: {@Response}",
+                externalIdWithPrefix,
+                nameLookupResult
+            );
+
             return null;
         }
 

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/NameRegistry/PartyNameRegistryClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/NameRegistry/PartyNameRegistryClient.cs
@@ -67,7 +67,9 @@ internal sealed class PartyNameRegistryClient : IPartyNameRegistry
                     "Got null when getting system username. Retrying once after 100ms. ExternalId: {ExternalId}",
                     externalIdWithPrefix
                 );
-                await Task.Delay(TimeSpan.FromMilliseconds(100), ct);
+                // We inline a simple retry here to account for propagation delays in register
+                // This will block gets performed by system users, but might save them a 500
+                await Task.Delay(TimeSpan.FromMilliseconds(500), ct);
                 name = await GetNameFromRegister(externalIdWithPrefix, ct);
             }
 


### PR DESCRIPTION
- Also log whole response from party name lookup if its null. This is regarded as an error, and is justified for debugging purposes.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/4137

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
