### PR TITLE
chore(infra): use traceidratio sampler instead of parentbased_traceidratio

### DIFF
--- a/.azure/applications/graphql/main.bicep
+++ b/.azure/applications/graphql/main.bicep
@@ -94,7 +94,7 @@ var containerAppEnvVars = [
   }
   {
     name: 'OTEL_TRACES_SAMPLER'
-    value: 'parentbased_traceidratio'
+    value: 'traceidratio'
   }
   {
     name: 'OTEL_TRACES_SAMPLER_ARG'

--- a/.azure/applications/graphql/test.bicepparam
+++ b/.azure/applications/graphql/test.bicepparam
@@ -14,7 +14,7 @@ param resources = {
     memory: '2Gi'
 }
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/service/main.bicep
+++ b/.azure/applications/service/main.bicep
@@ -131,7 +131,7 @@ var containerAppEnvVars = [
   }
   {
     name: 'OTEL_TRACES_SAMPLER'
-    value: 'parentbased_traceidratio'
+    value: 'traceidratio'
   }
   {
     name: 'OTEL_TRACES_SAMPLER_ARG'

--- a/.azure/applications/service/test.bicepparam
+++ b/.azure/applications/service/test.bicepparam
@@ -9,7 +9,7 @@ param appConfigurationName = readEnvironmentVariable('AZURE_APP_CONFIGURATION_NA
 param containerAppEnvironmentName = readEnvironmentVariable('AZURE_CONTAINER_APP_ENVIRONMENT_NAME')
 param serviceBusNamespaceName = readEnvironmentVariable('AZURE_SERVICE_BUS_NAMESPACE_NAME')
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // secrets
 param appInsightConnectionString = readEnvironmentVariable('AZURE_APP_INSIGHTS_CONNECTION_STRING')

--- a/.azure/applications/web-api-eu/main.bicep
+++ b/.azure/applications/web-api-eu/main.bicep
@@ -98,7 +98,7 @@ var containerAppEnvVars = [
   }
   {
     name: 'OTEL_TRACES_SAMPLER'
-    value: 'parentbased_traceidratio'
+    value: 'traceidratio'
   }
   {
     name: 'OTEL_TRACES_SAMPLER_ARG'

--- a/.azure/applications/web-api-eu/test.bicepparam
+++ b/.azure/applications/web-api-eu/test.bicepparam
@@ -14,7 +14,7 @@ param resources = {
     memory: '2Gi'
 }
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/web-api-so/main.bicep
+++ b/.azure/applications/web-api-so/main.bicep
@@ -150,7 +150,7 @@ var containerAppEnvVars = [
   }
   {
     name: 'OTEL_TRACES_SAMPLER'
-    value: 'parentbased_traceidratio'
+    value: 'traceidratio'
   }
   {
     name: 'OTEL_TRACES_SAMPLER_ARG'

--- a/.azure/applications/web-api-so/test.bicepparam
+++ b/.azure/applications/web-api-so/test.bicepparam
@@ -9,7 +9,7 @@ param whitelistedIPs = [
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param revisionSuffix = readEnvironmentVariable('REVISION_SUFFIX')
 
-param otelTraceSamplerRatio = '1'
+param otelTraceSamplerRatio = '0.05'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('AZURE_ENVIRONMENT_KEY_VAULT_NAME')


### PR DESCRIPTION
## Description

Switches the OpenTelemetry trace sampler for all four prod-facing apps (`web-api-eu`, `web-api-so`, `graphql`, `service`) from `parentbased_traceidratio` to `traceidratio`.

With `parentbased_*`, the sampling decision honors the `traceparent` sampled flag set by the upstream API gateway (APIM). Because every inbound request carries that flag, the gateway's sampling configuration dictates how much request/dependency telemetry these apps retain. The local ratio only ever applies to root spans, of which these apps have effectively none.

The practical consequence: a change to the gateway's diagnostic/sampling configuration can silently zero out our `requests` telemetry while the apps are healthy and serving traffic. This was observed in production, with the `requests` table dropping to zero for hours while `dependencies`, `traces`, `customMetrics`, and Redis activity all continued normally, correlated with a bulk gateway diagnostics rewrite.

`traceidratio` makes each app decide sampling locally from a deterministic hash of the trace-id, independent of the gateway's flag. End-to-end trace correlation across the gateway is preserved; we still read the incoming `traceparent`, we just no longer inherit its sample/drop decision.

## What this does and does not change

- The prod/staging/yt01 sampling **ratio is unchanged** at `0.05`.
- **Test (AT23) ratio is lowered from `1` to `0.05`** to match the other environments. This is required by the sampler switch: under `parentbased_*`, the inbound flag gated sampling regardless of the ratio, so test's `1` did not actually sample everything. Under `traceidratio`, a ratio of `1` would sample 100%, increasing ingestion in test for no benefit. `0.05` keeps test at the effective rate it has had in practice.
- This decouples sampling from the gateway. It does **not** raise fidelity during low-traffic periods. At 5%, very low request rates can still round the sampled `requests` count toward zero. Raising the prod ratio is a separate decision.
- Takes effect on the next deployment of each app (the env-var change forces a new revision).

## Changes

- `OTEL_TRACES_SAMPLER`: `parentbased_traceidratio` -> `traceidratio` in the four app `main.bicep` files.
- `otelTraceSamplerRatio`: `1` -> `0.05` in the four app `test.bicepparam` files.

## Verification

- No `parentbased` sampler value remains in `.azure/`.
- All four `main.bicep` files build cleanly (`az bicep build`).
- Effective ratio after change is `0.05` for every app across test/staging/yt01/prod.