### PR TITLE
chore(infra): add OOB deploy workflows

### DIFF
--- a/.github/workflows/dispatch-build-hotfix-prod.yml
+++ b/.github/workflows/dispatch-build-hotfix-prod.yml
@@ -30,14 +30,12 @@ concurrency:
   group: hotfix-prod-${{ inputs.ref }}
   cancel-in-progress: false
 
-# Minimal default; jobs that need more (packages/contents write) opt in below.
-permissions:
-  contents: read
-
 jobs:
   resolve:
     name: Resolve hotfix version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       hotfixVersion: ${{ steps.resolve.outputs.hotfixVersion }}
       sha: ${{ steps.resolve.outputs.sha }}
@@ -138,6 +136,8 @@ jobs:
     name: Print next steps
     needs: [resolve, tag-and-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Write summary
         env:

--- a/.github/workflows/dispatch-build-hotfix-prod.yml
+++ b/.github/workflows/dispatch-build-hotfix-prod.yml
@@ -1,0 +1,143 @@
+# Builds and releases an emergency production hotfix from a branch cut off the currently deployed prod
+# release, skipping the normal main -> test -> staging promotion chain.
+#
+# This workflow only does the *build + tag + release* half. The actual production deploy is performed
+# afterwards by the existing "CI/CD Production" workflow (ci-cd-prod.yml), which keeps the prod approval
+# gate, change detection, manifests update, issue tagging and Swarmia/Slack reporting intact.
+#
+# OPERATOR PROCESS (see docs/CI-CD.md -> "Out-of-band deploys"):
+#   1. Branch from the currently deployed prod tag:
+#        git switch -c hotfix/<desc> v<currentProdVersion> && <commit fix> && git push
+#   2. Run THIS workflow from `main` with ref = hotfix/<desc>.
+#   3. Run "CI/CD Production" with the hotfix version printed in this workflow's summary (approval gate fires).
+#   4. Open a PR to back-merge hotfix/<desc> into main (MANDATORY, so the fix survives the next release).
+#
+# NOTE: Run this workflow from `main` (the file only needs to exist on the dispatched ref). The `ref`
+# input below is what gets built, tagged and eventually deployed.
+name: Build Production Hotfix Release
+
+run-name: Build prod hotfix from ${{ inputs.ref }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Hotfix branch or sha (branched from the current prod release tag)"
+        required: true
+        type: string
+
+concurrency:
+  group: hotfix-prod-${{ inputs.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+
+jobs:
+  resolve:
+    name: Resolve hotfix version
+    runs-on: ubuntu-latest
+    outputs:
+      hotfixVersion: ${{ steps.resolve.outputs.hotfixVersion }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: "Checkout ref"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Resolve hotfix version
+        id: resolve
+        run: |
+          set -euo pipefail
+          BASE=$(cat version.txt)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          FULL_SHA=$(git rev-parse HEAD)
+          # Alphanumeric suffix -> satisfies both the prod tag check and the manifests image_tag regex
+          # (^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$).
+          HOTFIX_VERSION="${BASE}-hotfix${SHORT_SHA}"
+          echo "Base (prod) version: ${BASE}"
+          echo "Hotfix version: ${HOTFIX_VERSION}"
+          if ! git rev-parse "v${BASE}" >/dev/null 2>&1; then
+            echo "::warning::No git tag 'v${BASE}' found. A hotfix is normally branched from the currently deployed prod release tag; double-check '${{ inputs.ref }}' was cut from the right place."
+          fi
+          echo "hotfixVersion=${HOTFIX_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sha=${FULL_SHA}" >> "$GITHUB_OUTPUT"
+
+  build-and-push:
+    name: Build and push hotfix images
+    needs: [resolve]
+    uses: ./.github/workflows/workflow-publish-docker-images.yml
+    secrets:
+      GCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      dockerImageBaseName: ghcr.io/altinn/dialogporten-
+      version: ${{ needs.resolve.outputs.hotfixVersion }}
+      push: true
+      ref: ${{ inputs.ref }}
+
+  tag-and-release:
+    name: Tag and create hotfix release
+    needs: [resolve, build-and-push]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: "Checkout ref"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Create and push tag
+        env:
+          HOTFIX_VERSION: ${{ needs.resolve.outputs.hotfixVersion }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+        run: |
+          set -euo pipefail
+          TAG="v${HOTFIX_VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists. Commit a new change to the hotfix branch and re-run."
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" "$SHA" -m "Emergency production hotfix ${HOTFIX_VERSION}"
+          git push origin "$TAG"
+
+      - name: Create GitHub prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOTFIX_VERSION: ${{ needs.resolve.outputs.hotfixVersion }}
+          SOURCE_REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          TAG="v${HOTFIX_VERSION}"
+          gh release create "$TAG" \
+            --prerelease \
+            --title "Hotfix ${HOTFIX_VERSION}" \
+            --notes "Emergency production hotfix built from \`${SOURCE_REF}\`. Deploy via the **CI/CD Production** workflow with version \`${HOTFIX_VERSION}\`. Remember to back-merge \`${SOURCE_REF}\` into \`main\`."
+
+  summary:
+    name: Print next steps
+    needs: [resolve, tag-and-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write summary
+        env:
+          HOTFIX_VERSION: ${{ needs.resolve.outputs.hotfixVersion }}
+          SOURCE_REF: ${{ inputs.ref }}
+        run: |
+          {
+            echo "## Hotfix \`${HOTFIX_VERSION}\` built and released :rocket:"
+            echo ""
+            echo "Images pushed: \`ghcr.io/altinn/dialogporten-*:${HOTFIX_VERSION}\`"
+            echo "Tag + prerelease: \`v${HOTFIX_VERSION}\`"
+            echo ""
+            echo "### Next steps"
+            echo "1. Run the **CI/CD Production** workflow with \`version = ${HOTFIX_VERSION}\` (the prod approval gate will fire)."
+            echo "2. Open a PR to back-merge \`${SOURCE_REF}\` into \`main\` so the fix is not lost on the next release. **This is mandatory.**"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dispatch-build-hotfix-prod.yml
+++ b/.github/workflows/dispatch-build-hotfix-prod.yml
@@ -41,12 +41,14 @@ jobs:
       sha: ${{ steps.resolve.outputs.sha }}
     steps:
       - name: Validate dispatched ref
+        env:
+          # Via env (not interpolated into the script) so a crafted ref can't inject shell commands.
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
-          REF='${{ inputs.ref }}'
           # Allow only operator hotfix branches or an explicit full commit SHA.
-          if [[ ! "$REF" =~ ^hotfix\/[A-Za-z0-9._/-]+$ && ! "$REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            echo "::error::Invalid ref '$REF'. Allowed formats: hotfix/<name> or 40-char commit SHA."
+          if [[ ! "$INPUT_REF" =~ ^hotfix/[A-Za-z0-9._/-]+$ && ! "$INPUT_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::Invalid ref. Allowed formats: hotfix/<name> or 40-char commit SHA."
             exit 1
           fi
 

--- a/.github/workflows/dispatch-build-hotfix-prod.yml
+++ b/.github/workflows/dispatch-build-hotfix-prod.yml
@@ -42,6 +42,16 @@ jobs:
       hotfixVersion: ${{ steps.resolve.outputs.hotfixVersion }}
       sha: ${{ steps.resolve.outputs.sha }}
     steps:
+      - name: Validate dispatched ref
+        run: |
+          set -euo pipefail
+          REF='${{ inputs.ref }}'
+          # Allow only operator hotfix branches or an explicit full commit SHA.
+          if [[ ! "$REF" =~ ^hotfix\/[A-Za-z0-9._/-]+$ && ! "$REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::Invalid ref '$REF'. Allowed formats: hotfix/<name> or 40-char commit SHA."
+            exit 1
+          fi
+
       - name: "Checkout ref"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/dispatch-build-hotfix-prod.yml
+++ b/.github/workflows/dispatch-build-hotfix-prod.yml
@@ -30,10 +30,9 @@ concurrency:
   group: hotfix-prod-${{ inputs.ref }}
   cancel-in-progress: false
 
+# Minimal default; jobs that need more (packages/contents write) opt in below.
 permissions:
-  contents: write
-  id-token: write
-  packages: write
+  contents: read
 
 jobs:
   resolve:
@@ -48,6 +47,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve hotfix version
         id: resolve
@@ -62,7 +62,7 @@ jobs:
           echo "Base (prod) version: ${BASE}"
           echo "Hotfix version: ${HOTFIX_VERSION}"
           if ! git rev-parse "v${BASE}" >/dev/null 2>&1; then
-            echo "::warning::No git tag 'v${BASE}' found. A hotfix is normally branched from the currently deployed prod release tag; double-check '${{ inputs.ref }}' was cut from the right place."
+            echo "::warning::No git tag 'v${BASE}' found. A hotfix is normally branched from the currently deployed prod release tag; double-check that the dispatched ref was cut from the right place."
           fi
           echo "hotfixVersion=${HOTFIX_VERSION}" >> "$GITHUB_OUTPUT"
           echo "sha=${FULL_SHA}" >> "$GITHUB_OUTPUT"
@@ -70,6 +70,9 @@ jobs:
   build-and-push:
     name: Build and push hotfix images
     needs: [resolve]
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/workflow-publish-docker-images.yml
     secrets:
       GCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dispatch-deploy-branch-yt01.yml
+++ b/.github/workflows/dispatch-deploy-branch-yt01.yml
@@ -29,14 +29,12 @@ concurrency:
   group: deploy-branch-yt01-${{ inputs.ref }}
   cancel-in-progress: true
 
-# Minimal default; jobs that need more (packages write, Azure OIDC) opt in below.
-permissions:
-  contents: read
-
 jobs:
   resolve:
     name: Resolve image tag from ref
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       imageTag: ${{ steps.resolve.outputs.imageTag }}
     steps:

--- a/.github/workflows/dispatch-deploy-branch-yt01.yml
+++ b/.github/workflows/dispatch-deploy-branch-yt01.yml
@@ -29,10 +29,9 @@ concurrency:
   group: deploy-branch-yt01-${{ inputs.ref }}
   cancel-in-progress: true
 
+# Minimal default; jobs that need more (packages write, Azure OIDC) opt in below.
 permissions:
   contents: read
-  id-token: write
-  packages: write
 
 jobs:
   resolve:
@@ -45,6 +44,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
 
       - name: Resolve image tag
         id: resolve
@@ -59,6 +59,9 @@ jobs:
   build-and-push:
     name: Build and push images
     needs: [resolve]
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/workflow-publish-docker-images.yml
     secrets:
       GCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -71,6 +74,9 @@ jobs:
   deploy-apps:
     name: Deploy apps to YT01
     needs: [resolve, build-and-push]
+    permissions:
+      id-token: write # Azure OIDC login in workflow-deploy-apps.yml
+      contents: read
     uses: ./.github/workflows/workflow-deploy-apps.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/dispatch-deploy-branch-yt01.yml
+++ b/.github/workflows/dispatch-deploy-branch-yt01.yml
@@ -1,0 +1,89 @@
+# Deploys an arbitrary (typically unmerged) branch/tag/sha to YT01 for early performance testing.
+#
+# This is an *ephemeral* deploy: it builds and pushes images from the given ref and updates the YT01
+# container apps, but it deliberately does NOT update the dialogporten-manifests GitOps repo. The next
+# normal YT01 deploy will overwrite it.
+#
+# Scope is intentionally just "build + deploy apps". Migrations, infrastructure and performance tests
+# are handled by their own dispatch workflows (dispatch-apps.yml runs migrations, dispatch-infrastructure.yml
+# deploys infra, dispatch-k6-performance.yml runs perf tests) and can be run separately against YT01.
+#
+# NOTE: Run this workflow from `main` (the workflow file only needs to exist on the dispatched ref).
+# The `ref` input below is what actually gets built and deployed.
+#
+# OPERATIONAL NOTE: YT01 is scale-to-zero. Bring the environment up first via the `Scale yt01 (manual)`
+# workflow (dispatch-scale-yt01-manual.yml, action: on).
+name: Dispatch Deploy Branch to YT01
+
+run-name: Deploy ${{ inputs.ref }} to YT01
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag or sha to build and deploy (e.g. my-feature-branch)"
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-branch-yt01-${{ inputs.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+jobs:
+  resolve:
+    name: Resolve image tag from ref
+    runs-on: ubuntu-latest
+    outputs:
+      imageTag: ${{ steps.resolve.outputs.imageTag }}
+    steps:
+      - name: "Checkout ref"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Resolve image tag
+        id: resolve
+        run: |
+          set -euo pipefail
+          VERSION=$(cat version.txt)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          IMAGE_TAG="${VERSION}-${SHORT_SHA}"
+          echo "Resolved image tag: ${IMAGE_TAG}"
+          echo "imageTag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+  build-and-push:
+    name: Build and push images
+    needs: [resolve]
+    uses: ./.github/workflows/workflow-publish-docker-images.yml
+    secrets:
+      GCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      dockerImageBaseName: ghcr.io/altinn/dialogporten-
+      version: ${{ needs.resolve.outputs.imageTag }}
+      push: true
+      ref: ${{ inputs.ref }}
+
+  deploy-apps:
+    name: Deploy apps to YT01
+    needs: [resolve, build-and-push]
+    uses: ./.github/workflows/workflow-deploy-apps.yml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_RESOURCE_GROUP_NAME: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+      AZURE_ENVIRONMENT_KEY_VAULT_NAME: ${{ secrets.AZURE_ENVIRONMENT_KEY_VAULT_NAME }}
+      AZURE_CONTAINER_APP_ENVIRONMENT_NAME: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
+      AZURE_APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.AZURE_APP_INSIGHTS_CONNECTION_STRING }}
+      AZURE_APP_CONFIGURATION_NAME: ${{ secrets.AZURE_APP_CONFIGURATION_NAME }}
+      AZURE_SERVICE_BUS_NAMESPACE_NAME: ${{ secrets.AZURE_SERVICE_BUS_NAMESPACE_NAME }}
+    with:
+      environment: yt01
+      version: ${{ needs.resolve.outputs.imageTag }}
+      runMigration: false # DB may be off due to scale-to-zero; run migrations separately if needed
+      ref: ${{ inputs.ref }}

--- a/.github/workflows/workflow-publish-docker-images.yml
+++ b/.github/workflows/workflow-publish-docker-images.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: true
         type: boolean
+      ref:
+        description: "The branch, tag or sha to build the image from. Uses the default checkout ref if not provided."
+        required: false
+        default: ""
+        type: string
 
 jobs:
   publish-docker-images:
@@ -51,6 +56,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/workflow-publish-docker-images.yml
+++ b/.github/workflows/workflow-publish-docker-images.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -95,6 +95,8 @@ Available manual workflows for all environments:
 - `dispatch-k6-performance.yml`: Performance testing
 - `dispatch-k6-breakpoint.yml`: Breakpoint testing
 - `dispatch-deployment-lag-check.yml`: Deployment lag monitoring
+- `dispatch-deploy-branch-yt01.yml`: Deploy an arbitrary branch to YT01 (see [Out-of-band deploys](#out-of-band-deploys))
+- `dispatch-build-hotfix-prod.yml`: Build + release an emergency production hotfix image (see [Out-of-band deploys](#out-of-band-deploys))
 
 ### 6. Automated Monitoring
 
@@ -143,6 +145,59 @@ This workflow facilitates the deployment of infrastructure to the specified envi
 ### 8. Visual Workflow
 
 ![Deployment process](deploy-process.png)
+
+## Out-of-band deploys
+
+The normal flow promotes a release tag through `main → test → [yt01 + staging] → prod`. Two dispatch
+workflows support deploying *outside* that chain. Both are run **from `main`** and take an explicit
+`ref` input (branch/tag/sha) that is what actually gets built and deployed — GitHub only lists a
+workflow in the "Run workflow" picker if the file exists on the chosen branch, so a hotfix branch cut
+from an older tag would not show a newly added workflow. Running from `main` and passing the target as
+`ref` avoids that.
+
+### Experimental branch in YT01 (`dispatch-deploy-branch-yt01.yml`)
+
+Deploy an unmerged branch to YT01 for early performance testing. This is **ephemeral**: it builds and
+pushes images from the ref and updates the YT01 container apps, but does **not** update the
+`dialogporten-manifests` GitOps repo, so the next normal YT01 deploy overwrites it.
+
+Scope is intentionally just *build + deploy apps*. Migrations, infrastructure and performance tests are
+handled by their own dispatch workflows (`dispatch-apps.yml`, `dispatch-infrastructure.yml`,
+`dispatch-k6-performance.yml`) and can be run separately against YT01.
+
+1. YT01 is scale-to-zero. Bring the environment up first via the `Scale yt01 (manual)` workflow
+   (`dispatch-scale-yt01-manual.yml`, action `on`).
+2. Run **Dispatch Deploy Branch to YT01** from `main` with **ref** = the branch/tag/sha to deploy.
+
+Images are tagged `<version>-<shortsha>` (from `version.txt` + the ref's short sha), same as the main
+build convention.
+
+### Emergency production hotfix (`dispatch-build-hotfix-prod.yml`)
+
+A governed fast path to prod that skips test/staging but keeps the prod approval gate, produces a real
+tag/release (rollback point + audit trail), and updates the prod manifests — by reusing the existing
+**CI/CD Production** workflow for the actual deploy. The hotfix workflow itself only builds, tags and
+releases.
+
+1. **Branch from the currently deployed prod release tag** and commit the fix:
+   ```bash
+   git switch -c hotfix/<desc> v<currentProdVersion>
+   # ...make the fix...
+   git commit -am "fix: <desc>"
+   git push -u origin hotfix/<desc>
+   ```
+   Branching from the prod tag (not `main`) keeps unreleased work off the hotfix.
+2. Run **Build Production Hotfix Release** from `main` with **ref** = `hotfix/<desc>`. It builds and
+   pushes images, creates tag `v<base>-hotfix<shortsha>` and a GitHub **prerelease**, and prints the
+   resulting hotfix version in the run summary.
+3. Run the **CI/CD Production** workflow with `version = <base>-hotfix<shortsha>` (the value from the
+   summary). The prod approval gate fires; on approval it deploys infra/apps from the hotfix tag,
+   updates the prod manifests, tags issues and reports to Swarmia/Slack.
+4. **Back-merge (mandatory):** open a PR to merge `hotfix/<desc>` into `main` so the fix is not lost on
+   the next release.
+
+**Rollback:** redeploy the previous prod version by running **CI/CD Production** with the prior
+`v<x.y.z>`.
 
 ## Version Tracking and Change Detection
 

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -197,7 +197,7 @@ releases.
    the next release.
 
 **Rollback:** redeploy the previous prod version by running **CI/CD Production** with the prior
-`v<x.y.z>`.
+`version = <x.y.z>` (same input format as step 3, without a leading `v`).
 
 ## Version Tracking and Change Detection
 


### PR DESCRIPTION
## Description

Adds a supported way to deploy outside the normal `main → test → staging → prod` chain, composed almost entirely from the existing reusable workflows.

### Changes

- **`workflow-publish-docker-images.yml`** — add an optional `ref` input (default empty → unchanged behavior) wired into checkout, so images can be built from an arbitrary branch/tag/sha. Only edit to an existing workflow.
- **`dispatch-deploy-branch-yt01.yml`** (new) — build + deploy an unmerged branch to YT01 for early perf testing. Ephemeral: updates the YT01 container apps but does **not** touch the `dialogporten-manifests` GitOps repo. Migrations/infra/perf-tests stay in their own existing dispatch workflows.
- **`dispatch-build-hotfix-prod.yml`** (new) — governed emergency hotfix: builds images from a hotfix branch, creates a `v<base>-hotfix<sha>` tag + GitHub prerelease, and prints next steps. The actual prod deploy still goes through the unchanged **CI/CD Production** workflow, so the approval gate, manifests update, rollback point and reporting stay intact.
- **`docs/CI-CD.md`** — new "Out-of-band deploys" section documenting both flows, including the mandatory back-merge to `main` and rollback.

### Notes

- Both new workflows run **from `main`** and take an explicit `ref` input (GitHub only lists a workflow if it exists on the chosen branch — a hotfix branch cut from an old tag wouldn't).
- Prod deploy hand-off is **manual** (no auto-trigger / PAT), and the back-merge PR is documented rather than automated — by design.
- Validated with `actionlint` (clean on all new/edited files).

## Related Issue(s)

- #4151 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [x] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
