### PR TITLE
fix: skip memory cache in partyserviceresource

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -237,6 +237,12 @@ public static class InfrastructureExtensions
         })
         .ConfigureFusionCache(nameof(IPartyResourceReferenceRepository), new()
         {
+            // High cardinality: one entry per caller party (ps:<hash> keys written by
+            // PartyResourceRepository.GetReferencedResourcesByParty). Keeping these in the in-memory (L1)
+            // tier is unbounded (the shared MemoryCache has no SizeLimit), so working set grows with the
+            // number of distinct parties seen within the cache window. Rely solely on the distributed
+            // (Redis) tier, mirroring the high-cardinality Altinn.Authorization PDP cache above.
+            SkipMemoryCache = true,
             Duration = TimeSpan.FromMinutes(30),
             FailSafeMaxDuration = TimeSpan.FromMinutes(60)
         })


### PR DESCRIPTION
## Description

The authorized service resources cache introduces in 1.118.0 caused a substantial increase in partyresource cache entries.

1.117.3 — shared, party-independent catalogue:
GetServiceResources → GetServiceResourceMetadataQuery → full referenced-resource catalogue
This is the same response for everyone, party-independent, and never touches the per-party pruning cache.

1.118.0 — per-caller, per-party authorized lookup (new default):
GetServiceResources (includeUnauthorized=false, the default)
  → SearchAuthorizedServiceResourcesQuery
  → AuthorizedServiceResourcesProvider.GetAuthorizedServiceResourcesByParty
  → AuthorizationHelper.PruneUnreferencedResources(minResourcesPruningThreshold: 0)  // forced
  → PartyResourceRepository.GetReferencedResourcesByParty

Since AF is calling GetServiceResoures unconditionally on dialog lists, this substantially increased the calls to GetReferencedResourcesByParty which triggered a new cache entry.

Pending a better implementation, we skip memory cache on these keys, deferring to Redis alone.

## Related Issue(s)

- #4153 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

