### PR TITLE
chore: bump OperationalInsights workspace API version

### DIFF
--- a/.azure/modules/appConfiguration/create.bicep
+++ b/.azure/modules/appConfiguration/create.bicep
@@ -40,7 +40,7 @@ resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-06-01' =
   tags: tags
 }
 
-resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' existing = {
   name: logAnalyticsWorkspaceName
 }
 

--- a/.azure/modules/applicationInsights/create.bicep
+++ b/.azure/modules/applicationInsights/create.bicep
@@ -27,7 +27,7 @@ type Sku = {
 @description('The SKU of the Application Insights')
 param sku Sku
 
-resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' = {
   name: '${namePrefix}-insightsWorkspace'
   location: location
   properties: {

--- a/.azure/modules/containerAppEnv/main.bicep
+++ b/.azure/modules/containerAppEnv/main.bicep
@@ -30,7 +30,7 @@ param workloadProfiles array = [
   }
 ]
 
-resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' existing = {
   name: appInsightWorkspaceName
 }
 

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -425,7 +425,7 @@ resource staticPostgresServerConfigurations 'Microsoft.DBforPostgreSQL/flexibleS
   dependsOn: [additionalPostgresServerConfigurations]
 }]
 
-resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' existing = {
   name: appInsightWorkspaceName
 }
 


### PR DESCRIPTION
## Description

Bumps all `Microsoft.OperationalInsights/workspaces` Bicep resource declarations from API version `2023-09-01` to `2025-07-01`.

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

Manual verification: confirmed via Microsoft Learn that `2025-07-01` is the latest listed deployment API version for `Microsoft.OperationalInsights/workspaces`; scanned the repository for `Microsoft.OperationalInsights/`; reviewed `git diff origin/main...`.

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)

No documentation changes required for this infrastructure API version bump.