### PR TITLE
feat(webapiclient): support custom authentication for DP client

### DIFF
--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/DialogportenServiceCollectionExtensions.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/DialogportenServiceCollectionExtensions.cs
@@ -20,7 +20,8 @@ internal static class DialogportenServiceCollectionExtensions
         this IServiceCollection services,
         DialogportenSettings settings,
         string clientDefinitionKey,
-        Assembly clientAssembly)
+        Assembly clientAssembly,
+        Action<IHttpClientBuilder>? configureAuthentication = null)
     {
         if (!DialogportenSettings.Validate())
         {
@@ -29,7 +30,14 @@ internal static class DialogportenServiceCollectionExtensions
 
         services.TryAddSingleton<IOptions<DialogportenSettings>>(new OptionsWrapper<DialogportenSettings>(settings));
 
-        services.RegisterMaskinportenClientDefinition<SettingsJwkClientDefinition>(clientDefinitionKey, settings.Maskinporten);
+        // When the caller supplies their own authentication setup we do not wire up Maskinporten at all;
+        // the caller is responsible for attaching the desired auth (e.g. Maskinporten) to each Refit client.
+        if (configureAuthentication is null)
+        {
+            services.RegisterMaskinportenClientDefinition<SettingsJwkClientDefinition>(clientDefinitionKey, settings.Maskinporten
+                ?? throw new InvalidOperationException(
+                    $"{nameof(DialogportenSettings)}.{nameof(DialogportenSettings.Maskinporten)} must be set when no authentication is configured."));
+        }
 
         var refitClients = clientAssembly.GetTypes()
             .Where(x =>
@@ -45,13 +53,21 @@ internal static class DialogportenServiceCollectionExtensions
 
         foreach (var refitClient in refitClients)
         {
-            services
+            var clientBuilder = services
                 .AddRefitClient(refitClient, new RefitSettings
                 {
                     ContentSerializer = new SystemTextJsonContentSerializer(jsonSerializerOptions)
                 })
-                .ConfigureHttpClient(c => c.BaseAddress = new Uri(settings.BaseUri))
-                .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition>(clientDefinitionKey);
+                .ConfigureHttpClient(c => c.BaseAddress = new Uri(settings.BaseUri));
+
+            if (configureAuthentication is null)
+            {
+                clientBuilder.AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition>(clientDefinitionKey);
+            }
+            else
+            {
+                configureAuthentication(clientBuilder);
+            }
         }
 
         services
@@ -71,11 +87,12 @@ internal static class DialogportenServiceCollectionExtensions
         this IServiceCollection services,
         DialogportenSettings settings,
         string clientDefinitionKey,
-        Assembly clientAssembly)
+        Assembly clientAssembly,
+        Action<IHttpClientBuilder>? configureAuthentication = null)
         where TRootApi : class
         where TRootApiImplementation : class, TRootApi
     {
-        services.AddDialogportenClientCore(settings, clientDefinitionKey, clientAssembly);
+        services.AddDialogportenClientCore(settings, clientDefinitionKey, clientAssembly, configureAuthentication);
         services.TryAddTransient<TRootApi, TRootApiImplementation>();
         return services;
     }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/DialogportenSettings.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/DialogportenSettings.cs
@@ -19,7 +19,16 @@ public sealed class DialogportenSettings
     /// </remarks>
     public bool ThrowOnPublicKeyFetchInit { get; set; } = true;
 
-    public MaskinportenSettings Maskinporten { get; set; } = null!;
+    /// <summary>
+    /// Maskinporten settings used to authenticate requests to Dialogporten.
+    /// </summary>
+    /// <remarks>
+    /// Only required when using the built-in Maskinporten authentication. When registering the client with a
+    /// custom authentication setup (see the <c>AddDialogportenClient</c> overload that accepts an
+    /// <see cref="Microsoft.Extensions.DependencyInjection.IHttpClientBuilder"/> configuration delegate),
+    /// this can be left unset and the caller is responsible for attaching authentication.
+    /// </remarks>
+    public MaskinportenSettings? Maskinporten { get; set; }
 
     internal static bool Validate() => true;
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/ServiceCollectionExtensions.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/ServiceCollectionExtensions.cs
@@ -15,4 +15,21 @@ public static class ServiceCollectionExtensions
         configureOptions.Invoke(dialogportenSettings);
         return services.AddDialogportenClient(dialogportenSettings);
     }
+
+    /// <summary>
+    /// Registers the Dialogporten end user client without configuring any authentication.
+    /// The Dialogporten <see cref="DialogportenSettings.Maskinporten"/> settings are not used; the caller is
+    /// responsible for attaching authentication (e.g. Maskinporten) to each underlying Refit client via
+    /// <paramref name="configureAuthentication"/>.
+    /// </summary>
+    public static IServiceCollection AddDialogportenClient(this IServiceCollection services, DialogportenSettings settings, Action<IHttpClientBuilder> configureAuthentication)
+        => services.AddDialogportenClientCore<IEndUserApi, EndUserApi>(settings, ClientDefinitionKey, AssemblyMarker.Assembly, configureAuthentication);
+
+    /// <inheritdoc cref="AddDialogportenClient(IServiceCollection, DialogportenSettings, Action{IHttpClientBuilder})"/>
+    public static IServiceCollection AddDialogportenClient(this IServiceCollection services, Action<DialogportenSettings> configureOptions, Action<IHttpClientBuilder> configureAuthentication)
+    {
+        var dialogportenSettings = new DialogportenSettings();
+        configureOptions.Invoke(dialogportenSettings);
+        return services.AddDialogportenClient(dialogportenSettings, configureAuthentication);
+    }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/ServiceCollectionExtensions.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/ServiceCollectionExtensions.cs
@@ -15,4 +15,21 @@ public static class ServiceCollectionExtensions
         configureOptions.Invoke(dialogportenSettings);
         return services.AddDialogportenClient(dialogportenSettings);
     }
+
+    /// <summary>
+    /// Registers the Dialogporten service owner client without configuring any authentication.
+    /// The Dialogporten <see cref="DialogportenSettings.Maskinporten"/> settings are not used; the caller is
+    /// responsible for attaching authentication (e.g. Maskinporten) to each underlying Refit client via
+    /// <paramref name="configureAuthentication"/>.
+    /// </summary>
+    public static IServiceCollection AddDialogportenClient(this IServiceCollection services, DialogportenSettings settings, Action<IHttpClientBuilder> configureAuthentication)
+        => services.AddDialogportenClientCore<IServiceOwnerApi, ServiceOwnerApi>(settings, ClientDefinitionKey, AssemblyMarker.Assembly, configureAuthentication);
+
+    /// <inheritdoc cref="AddDialogportenClient(IServiceCollection, DialogportenSettings, Action{IHttpClientBuilder})"/>
+    public static IServiceCollection AddDialogportenClient(this IServiceCollection services, Action<DialogportenSettings> configureOptions, Action<IHttpClientBuilder> configureAuthentication)
+    {
+        var dialogportenSettings = new DialogportenSettings();
+        configureOptions.Invoke(dialogportenSettings);
+        return services.AddDialogportenClient(dialogportenSettings, configureAuthentication);
+    }
 }

--- a/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/AddDialogportenClientTests.cs
+++ b/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/AddDialogportenClientTests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using Altinn.ApiClients.Dialogporten;
+using Altinn.ApiClients.Dialogporten.ServiceOwner;
+using Altinn.ApiClients.Maskinporten.Config;
+using Altinn.ApiClients.Maskinporten.Extensions;
+using Altinn.ApiClients.Maskinporten.Interfaces;
+using Altinn.ApiClients.Maskinporten.Models;
+using Altinn.ApiClients.Maskinporten.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Digdir.Library.Dialogporten.WebApiClient.Unit.Tests;
+
+public class AddDialogportenClientTests
+{
+    private const string MaskinportenClientKey = "test-maskinporten-client";
+    private const string ExpectedAccessToken = "test-access-token";
+
+    [Fact]
+    public void CustomAuthentication_InvokesDelegatePerRefitClient_WithoutWiringMaskinporten()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var settings = new DialogportenSettings { BaseUri = "https://example.com" };
+        var configuredClientNames = new List<string>();
+
+        // Act
+        services.AddDialogportenClient(settings, builder => configuredClientNames.Add(builder.Name));
+
+        // Assert
+        // The ServiceOwner package exposes two Refit clients (IServiceownerApi + IMetadataApi),
+        // so the authentication delegate must be invoked once for each of them.
+        Assert.Equal(2, configuredClientNames.Count);
+
+        // No Maskinporten settings were required, and the SDK did not register a Maskinporten client definition itself.
+        Assert.Null(settings.Maskinporten);
+        var provider = services.BuildServiceProvider();
+        Assert.Empty(provider.GetServices<IClientDefinition>());
+    }
+
+    [Fact]
+    public async Task CustomAuthentication_AllowsConsumerToAttachMaskinportenFromNuget()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Fake the Maskinporten token service so the test never calls Maskinporten over the network.
+        // AddMaskinportenHttpMessageHandler registers the real service via TryAdd, so our fake wins.
+        var maskinportenService = Substitute.For<IMaskinportenService>();
+        maskinportenService
+            .GetToken(Arg.Any<IClientDefinition>(), Arg.Any<MaskinportenRequestContext>(), Arg.Any<bool>())
+            .Returns(new TokenResponse { AccessToken = ExpectedAccessToken });
+        services.AddSingleton(maskinportenService);
+
+        // Consumer registers their own Maskinporten client definition, exactly as a real consumer would.
+        var maskinportenSettings = new MaskinportenSettings
+        {
+            ClientId = "client-id",
+            Scope = "digdir:dialogporten.serviceprovider",
+            Environment = "test"
+        };
+        services.RegisterMaskinportenClientDefinition<SettingsJwkClientDefinition>(MaskinportenClientKey, maskinportenSettings);
+
+        var capturingHandler = new CapturingHandler();
+        var settings = new DialogportenSettings { BaseUri = "https://example.com" };
+        string? clientName = null;
+
+        // Act
+        services.AddDialogportenClient(settings, builder =>
+        {
+            clientName ??= builder.Name;
+            builder.AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition>(MaskinportenClientKey);
+            builder.ConfigurePrimaryHttpMessageHandler(() => capturingHandler);
+        });
+
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient(clientName!);
+        await client.GetAsync("https://example.com/api/v1/serviceowner/dialogs", TestContext.Current.CancellationToken);
+
+        // Assert
+        // The consumer-attached Maskinporten handler ran and set the Authorization header.
+        Assert.NotNull(capturingHandler.LastRequest);
+        Assert.Equal("Bearer", capturingHandler.LastRequest!.Headers.Authorization?.Scheme);
+        Assert.Equal(ExpectedAccessToken, capturingHandler.LastRequest.Headers.Authorization?.Parameter);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}

--- a/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests.csproj
+++ b/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests.csproj
@@ -20,6 +20,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\WebApiClient\Digdir.Library.Dialogporten.WebApiClient.Common\Digdir.Library.Dialogporten.WebApiClient.Common.csproj" />
         <ProjectReference Include="..\..\src\WebApiClient\Digdir.Library.Dialogporten.WebApiClient\Digdir.Library.Dialogporten.WebApiClient.csproj"/>
+        <ProjectReference Include="..\..\src\WebApiClient\Digdir.Library.Dialogporten.WebApiClient.ServiceOwner\Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/packages.lock.json
+++ b/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/packages.lock.json
@@ -447,6 +447,16 @@
           "Refit": "[10.2.0, )",
           "Refit.HttpClientFactory": "[10.2.0, )"
         }
+      },
+      "Altinn.ApiClients.Dialogporten.ServiceOwner": {
+        "type": "Project",
+        "dependencies": {
+          "Altinn.ApiClients.Maskinporten": "[10.1.0, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.9, )",
+          "NSec.Cryptography": "[25.4.0, )",
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

Adds an `AddDialogportenClient` overload that lets consumers bring their own
authentication instead of being forced to hand full Maskinporten credentials
to the SDK.

Today `AddDialogportenClient` requires `DialogportenSettings.Maskinporten` and
internally registers a `SettingsJwkClientDefinition` plus a Maskinporten
message handler on every Refit client. From Altinn.App v8.3, apps configure
Maskinporten centrally (via Altinn.App.Core's own `UseMaskinportenAuthorization`
/ `UseMaskinportenAltinnAuthorization`) and shouldn't have to repeat client
credentials — see #4166.

This is intentionally scoped: the new overload makes the SDK do **nothing**
with Maskinporten. It wires up the Refit clients (base address, serializer)
and hands each one's `IHttpClientBuilder` to the caller, who attaches whatever
authentication they want. The SDK does not take a dependency on Altinn.App.Core.

## Changes

- New overload `AddDialogportenClient(settings, Action<IHttpClientBuilder> configureAuthentication)`
  on both the **ServiceOwner** and **EndUser** packages (plus the
  `Action<DialogportenSettings>` flavor).
- `AddDialogportenClientCore` skips all Maskinporten registration when a
  `configureAuthentication` delegate is supplied, and invokes it once per Refit
  client; otherwise behaves exactly as before.
- `DialogportenSettings.Maskinporten` is now optional (nullable). The legacy
  path throws a clear error if it's left unset; the new path ignores it.
- Tests using the `Altinn.ApiClients.Maskinporten` NuGet directly to mimic a
  real consumer.

## Usage

```csharp
// Altinn app (v8.3+) reusing its central Maskinporten setup:
services.AddDialogportenClient(settings, auth =>
    auth.UseMaskinportenAltinnAuthorization("digdir:dialogporten.serviceprovider"));
```

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/4166

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [x] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
