### PR TITLE
docs: add readme to enduser and serviceowner sdk

### DIFF
--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/README.md
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/README.md
@@ -160,8 +160,6 @@ The validator caches public keys fetched from the Dialogporten `.well-known` end
 // Per-call override with extra clock skew
 var result = validator.Validate(token, options: new DialogTokenValidationParameters
 {
-    // Disable lifetime validation (useful in tests)
-    ValidateLifetime = false,
     ClockSkew = TimeSpan.FromSeconds(30)
 });
 ```

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/README.md
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/README.md
@@ -1,4 +1,195 @@
-# .NET SDK for Dialogporten EndUser API
+# Altinn.ApiClients.Dialogporten.EndUser
 
-Simple overview
-TODO
+.NET SDK for the [Dialogporten](https://github.com/altinn/dialogporten) EndUser API. Provides a typed HTTP client for reading dialogs and related resources on behalf of end users, backed by Maskinporten authentication and automatic EdDSA key caching for dialog token validation.
+
+Sample projects are available at https://github.com/Altinn/dialogporten-samples.
+
+## Installation
+
+```
+dotnet add package Altinn.ApiClients.Dialogporten.EndUser
+```
+
+Targets net8.0, net9.0, and net10.0.
+
+## Setup
+
+Register the client in your DI container using `AddDialogportenClient`. The `BaseUri` must point to the Dialogporten root, excluding `/api/v...`.
+
+| Environment | BaseUri |
+|---|---|
+| Production | `https://platform.altinn.no/dialogporten` |
+| TT02 (staging) | `https://platform.tt02.altinn.no/dialogporten` |
+| AT23 (test) | `https://platform.at23.altinn.cloud/dialogporten` |
+
+### Built-in Maskinporten authentication
+
+Provide Maskinporten settings and the SDK handles token acquisition automatically. The required scope is `digdir:dialogporten`.
+
+```csharp
+builder.Services.AddDialogportenClient(options =>
+{
+    options.BaseUri = "https://platform.altinn.no/dialogporten";
+    options.Maskinporten = new MaskinportenSettings
+    {
+        Authority = "https://maskinporten.no/",
+        ClientId = "your-client-id",
+        Scope = "digdir:dialogporten",
+        // Supply either EncodedJwk or a certificate
+        EncodedJwk = "..."
+    };
+});
+```
+
+### Custom authentication
+
+If you manage Maskinporten tokens yourself (e.g. via a shared client definition), use the overload that accepts an `IHttpClientBuilder` delegate:
+
+```csharp
+builder.Services.AddDialogportenClient(
+    options => options.BaseUri = "https://platform.altinn.no/dialogporten",
+    httpClientBuilder => httpClientBuilder.AddMaskinportenHttpMessageHandler<MyClientDefinition>("my-key")
+);
+```
+
+## Using the client
+
+Inject `IEndUserApi` and call methods on the `V1` property:
+
+```csharp
+public class MyService(IEndUserApi dialogporten)
+{
+    public async Task<ICollection<DialogListItem>> GetMyDialogsAsync(CancellationToken ct)
+    {
+        var response = await dialogporten.V1.SearchDialogs(
+            new SearchDialogsQueryParams { Status = [DialogStatus.InProgress] },
+            cancellationToken: ct);
+
+        if (!response.IsSuccessStatusCode)
+            throw new Exception($"Failed: {response.StatusCode}");
+
+        return response.Content!.Items;
+    }
+}
+```
+
+All methods return `IApiResponse<T>` (or `IApiResponse` for void responses) from [Refit](https://github.com/reactiveui/refit), giving you access to the status code, headers, and deserialized content.
+
+## Available operations
+
+### Dialogs
+
+| Method | Description |
+|---|---|
+| `SearchDialogs(queryParams, acceptLanguage, ct)` | Paginated list of dialogs. Use `continuationToken` from the response to page through results. |
+| `GetDialog(dialogId, acceptLanguage, ct)` | Single dialog aggregate. Accessing this endpoint marks the dialog content as seen. |
+| `GetDialogLookup(instanceRef, acceptLanguage, ct)` | Resolve dialog metadata by an external instance reference. |
+
+**Search filter highlights** (`SearchDialogsQueryParams`):
+- `Org`, `ServiceResource`, `Party` — filter by org, resource, or owning party
+- `Status` — `New`, `InProgress`, `Waiting`, `Signing`, `Cancelled`, `Completed`
+- `SystemLabel` — `Default`, `Bin`, `Archive`
+- `CreatedAfter/Before`, `UpdatedAfter/Before`, `DueAfter/Before`
+- `IsContentSeen` — filter by seen/unseen content
+- `Search` / `SearchLanguageCode` — free-text fuzzy search
+- `ContinuationToken`, `Limit` (1–1000, default 100)
+
+Dates must include an explicit time zone, e.g. `2024-01-15T10:00:00Z`.
+
+### Transmissions
+
+| Method | Description |
+|---|---|
+| `SearchDialogTransmissions(dialogId, acceptLanguage, ct)` | All transmissions for a dialog. |
+| `GetDialogTransmission(dialogId, transmissionId, acceptLanguage, ct)` | Single transmission. |
+
+### Activities
+
+| Method | Description |
+|---|---|
+| `SearchDialogActivities(dialogId, acceptLanguage, ct)` | All activities for a dialog. |
+| `GetDialogActivity(dialogId, activityId, acceptLanguage, ct)` | Single activity. |
+
+### Seen log
+
+| Method | Description |
+|---|---|
+| `SearchDialogSeenLogs(dialogId, ct)` | All seen-log records for a dialog. |
+| `GetDialogSeenLog(dialogId, seenLogId, ct)` | Single seen-log record. |
+
+### System labels
+
+| Method | Description |
+|---|---|
+| `SetDialogSystemLabels(dialogId, request, ifMatch, ct)` | Set system label(s) on a single dialog. Supply `EnduserContextRevision` as `ifMatch` for optimistic concurrency. |
+| `BulkSetDialogSystemLabels(dto, ct)` | Set system labels on multiple dialogs in one call. |
+| `SearchDialogLabelAssignmentLogs(dialogId, ct)` | History of label assignment changes for a dialog. |
+
+### Parties and resources
+
+| Method | Description |
+|---|---|
+| `GetParties(ct)` | Authorized parties available to the authenticated end user. |
+| `SearchAuthorizedServiceResources(party, acceptLanguage, ct)` | Service resources the end user is authorized to access, optionally filtered by party. |
+
+## Dialog token validation
+
+Dialogporten issues short-lived EdDSA-signed dialog tokens when an end user accesses a dialog. Your backend can validate these tokens using the injected `IDialogTokenValidator`:
+
+```csharp
+public class MyController(IDialogTokenValidator validator)
+{
+    [HttpGet("resource/{dialogId}")]
+    public IActionResult Get(Guid dialogId, [FromHeader] string dialogToken)
+    {
+        var result = validator.Validate(dialogToken, dialogId: dialogId, requiredActions: ["read"]);
+
+        if (!result.IsValid)
+            return Forbid();
+
+        // result.ClaimsPrincipal is non-null here
+        return Ok();
+    }
+}
+```
+
+The validator caches public keys fetched from the Dialogporten `.well-known` endpoint (via a background hosted service). By default it throws on startup if keys cannot be fetched; set `ThrowOnPublicKeyFetchInit = false` in `DialogportenSettings` to make startup tolerant of transient failures.
+
+**`DialogTokenValidationParameters`** lets you override defaults globally or per-call:
+
+```csharp
+// Per-call override with extra clock skew
+var result = validator.Validate(token, options: new DialogTokenValidationParameters
+{
+    // Disable lifetime validation (useful in tests)
+    ValidateLifetime = false,
+    ClockSkew = TimeSpan.FromSeconds(30)
+});
+```
+
+## Settings reference
+
+```json
+{
+  "Dialogporten": {
+    "BaseUri": "https://platform.altinn.no/dialogporten",
+    "ThrowOnPublicKeyFetchInit": true,
+    "Maskinporten": {
+      "Authority": "https://maskinporten.no/",
+      "ClientId": "your-client-id",
+      "Scope": "digdir:dialogporten",
+      "EncodedJwk": "..."
+    }
+  }
+}
+```
+
+Bind and register:
+
+```csharp
+var settings = builder.Configuration
+    .GetSection("Dialogporten")
+    .Get<DialogportenSettings>()!;
+
+builder.Services.AddDialogportenClient(settings);
+```

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/README.md
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/README.md
@@ -85,7 +85,7 @@ All methods return `IApiResponse<T>` (or `IApiResponse` for void responses) from
 | `GetDialogLookup(instanceRef, acceptLanguage, ct)` | Resolve dialog metadata by an external instance reference. |
 
 **Search filter highlights** (`SearchDialogsQueryParams`):
-- `Org`, `ServiceResource`, `Party` — filter by org, resource, or owning party
+- `Org`, `ServiceResource`, `Party` — filter by org, resource, or receiving party
 - `Status` — `New`, `InProgress`, `Waiting`, `Signing`, `Cancelled`, `Completed`
 - `SystemLabel` — `Default`, `Bin`, `Archive`
 - `CreatedAfter/Before`, `UpdatedAfter/Before`, `DueAfter/Before`

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/README.md
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/README.md
@@ -19,8 +19,7 @@ Register the client in your DI container using `AddDialogportenClient`. The `Bas
 | Environment | BaseUri |
 |---|---|
 | Production | `https://platform.altinn.no/dialogporten` |
-| TT02 (staging) | `https://platform.tt02.altinn.no/dialogporten` |
-| AT23 (test) | `https://platform.at23.altinn.cloud/dialogporten` |
+| TT02 | `https://platform.tt02.altinn.no/dialogporten` |
 
 ### Built-in Maskinporten authentication
 

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/README.md
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/README.md
@@ -91,7 +91,7 @@ All methods return `IApiResponse<T>` (or `IApiResponse` for void responses) from
 | `GetDialogLookup(instanceRef, acceptLanguage, ct)` | Resolve dialog metadata by an external instance reference. |
 
 **Search filter highlights** (`SearchDialogsQueryParams`):
-- `ServiceResource`, `Party`, `EndUserId` — filter by resource, owning party, or a specific end user
+- `ServiceResource`, `Party`, `EndUserId` — filter by resource, receiving party, or a specific end user
 - `Status` — `New`, `InProgress`, `Waiting`, `Signing`, `Cancelled`, `Completed`
 - `Deleted` — `Include`, `Exclude` (default), or `Only`
 - `SystemLabel`, `ServiceOwnerLabels` — filter by system or custom service-owner labels (prefix matching with `*` supported)

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/README.md
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/README.md
@@ -1,4 +1,217 @@
-# .NET SDK for Dialogporten ServiceOwner API
+# Altinn.ApiClients.Dialogporten.ServiceOwner
 
-Simple overview
-TODO
+.NET SDK for the [Dialogporten](https://github.com/altinn/dialogporten) ServiceOwner API. Provides a typed HTTP client for creating and managing dialogs on behalf of a service owner, backed by Maskinporten authentication and automatic EdDSA key caching for dialog token validation.
+
+Sample projects are available at https://github.com/Altinn/dialogporten-samples.
+
+## Installation
+
+```
+dotnet add package Altinn.ApiClients.Dialogporten.ServiceOwner
+```
+
+Targets net8.0, net9.0, and net10.0.
+
+## Setup
+
+Register the client in your DI container using `AddDialogportenClient`. The `BaseUri` must point to the Dialogporten root, excluding `/api/v...`.
+
+| Environment | BaseUri |
+|---|---|
+| Production | `https://platform.altinn.no/dialogporten` |
+| TT02 (staging) | `https://platform.tt02.altinn.no/dialogporten` |
+| AT23 (test) | `https://platform.at23.altinn.cloud/dialogporten` |
+
+### Built-in Maskinporten authentication
+
+Provide Maskinporten settings and the SDK handles token acquisition automatically. The primary scope is `digdir:dialogporten.serviceprovider`; list/search operations also require `digdir:dialogporten.serviceprovider.search`.
+
+```csharp
+builder.Services.AddDialogportenClient(options =>
+{
+    options.BaseUri = "https://platform.altinn.no/dialogporten";
+    options.Maskinporten = new MaskinportenSettings
+    {
+        Authority = "https://maskinporten.no/",
+        ClientId = "your-client-id",
+        Scope = "digdir:dialogporten.serviceprovider digdir:dialogporten.serviceprovider.search",
+        // Supply either EncodedJwk or a certificate
+        EncodedJwk = "..."
+    };
+});
+```
+
+### Custom authentication
+
+If you manage Maskinporten tokens yourself (e.g. via a shared client definition), use the overload that accepts an `IHttpClientBuilder` delegate:
+
+```csharp
+builder.Services.AddDialogportenClient(
+    options => options.BaseUri = "https://platform.altinn.no/dialogporten",
+    httpClientBuilder => httpClientBuilder.AddMaskinportenHttpMessageHandler<MyClientDefinition>("my-key")
+);
+```
+
+## Using the client
+
+Inject `IServiceOwnerApi` and call methods on the `V1` property:
+
+```csharp
+public class MyService(IServiceOwnerApi dialogporten)
+{
+    public async Task<string> CreateDialogAsync(CreateDialog dto, CancellationToken ct)
+    {
+        var response = await dialogporten.V1.CreateDialog(dto, ct);
+
+        if (!response.IsSuccessStatusCode)
+            throw new Exception($"Failed: {response.StatusCode}");
+
+        // response.Content contains the new dialog ID
+        return response.Content!;
+    }
+}
+```
+
+All methods return `IApiResponse<T>` (or `IApiResponse` for void responses) from [Refit](https://github.com/reactiveui/refit), giving you access to the status code, headers, and deserialized content.
+
+## Available operations
+
+### Dialogs (CRUD)
+
+| Method | Description |
+|---|---|
+| `SearchDialogs(queryParams, ct)` | Paginated list of dialogs owned by the authenticated service owner. Use `continuationToken` from the response to page through results. |
+| `CreateDialog(dto, ct)` | Create a new dialog. Returns the new dialog ID. |
+| `GetDialog(dialogId, endUserId?, ct)` | Single dialog aggregate. Can return deleted dialogs (check `DeletedAt`). |
+| `UpdateDialog(dialogId, dto, ifMatch, ct)` | Full replace of a dialog. Supply `Revision` as `ifMatch` for optimistic concurrency. |
+| `PatchDialog(dialogId, patchDocument, etag, ct)` | Partial update via [RFC 6902 JSON Patch](https://tools.ietf.org/html/rfc6902). |
+| `DeleteDialog(dialogId, ifMatch, ct)` | Soft-delete a dialog. End users get 410 Gone; service owner can still read via `GetDialog`. |
+| `RestoreDialog(dialogId, ifMatch, ct)` | Restore a soft-deleted dialog. |
+| `PurgeDialog(dialogId, ifMatch, ct)` | Permanently delete a dialog (hard delete). |
+| `FreezeDialog(dialogId, ifMatch, ct)` | Freeze a dialog to prevent further modification (admin scope required to unfreeze). |
+| `GetDialogLookup(instanceRef, acceptLanguage, ct)` | Resolve dialog metadata by an external instance reference. |
+
+**Search filter highlights** (`SearchDialogsQueryParams`):
+- `ServiceResource`, `Party`, `EndUserId` — filter by resource, owning party, or a specific end user
+- `Status` — `New`, `InProgress`, `Waiting`, `Signing`, `Cancelled`, `Completed`
+- `Deleted` — `Include`, `Exclude` (default), or `Only`
+- `SystemLabel`, `ServiceOwnerLabels` — filter by system or custom service-owner labels (prefix matching with `*` supported)
+- `CreatedAfter/Before`, `UpdatedAfter/Before`, `ContentUpdatedAfter/Before`, `DueAfter/Before`, `VisibleAfter/Before`
+- `IsContentSeen` — filter by seen/unseen content
+- `Search` / `SearchLanguageCode` — free-text fuzzy search
+- `ContinuationToken`, `Limit` (1–1000, default 100)
+
+Dates must include an explicit time zone, e.g. `2024-01-15T10:00:00Z`.
+
+### Transmissions
+
+| Method | Description |
+|---|---|
+| `SearchDialogTransmissions(dialogId, ct)` | All transmissions for a dialog. |
+| `CreateDialogTransmission(dialogId, dto, ifMatch, ct)` | Add a transmission. Returns the new transmission ID. |
+| `GetDialogTransmission(dialogId, transmissionId, ct)` | Single transmission. |
+| `UpdateDialogTransmission(dialogId, transmissionId, dto, ifMatch, ct)` | Full replace of a transmission. |
+
+### Activities
+
+| Method | Description |
+|---|---|
+| `SearchDialogActivities(dialogId, ct)` | All activities for a dialog. |
+| `CreateDialogActivity(dialogId, dto, ifMatch, ct)` | Add an activity to a dialog's history. Returns the new activity ID. |
+| `GetDialogActivity(dialogId, activityId, ct)` | Single activity. |
+
+### Seen log
+
+| Method | Description |
+|---|---|
+| `SearchDialogSeenLogs(dialogId, ct)` | All seen-log records for a dialog. |
+| `GetDialogSeenLog(dialogId, seenLogId, ct)` | Single seen-log record. |
+
+### Service owner labels
+
+| Method | Description |
+|---|---|
+| `GetServiceOwnerLabels(dialogId, ct)` | All service-owner labels for a dialog. |
+| `CreateServiceOwnerLabel(dialogId, dto, ifMatch, ct)` | Add a label. Supply `Revision` as `ifMatch`. |
+| `DeleteServiceOwnerLabel(dialogId, label, ifMatch, ct)` | Remove a label. |
+
+### System labels (end user context)
+
+| Method | Description |
+|---|---|
+| `SetDialogSystemLabels(dialogId, request, enduserId?, ifMatch, ct)` | Set system label(s) on a single dialog for a given end user. |
+| `BulkSetDialogSystemLabels(dto, enduserId?, ct)` | Set system labels on multiple dialogs in one call. |
+| `SearchDialogEndUserContexts(queryParams, ct)` | Paginated list of dialog end-user context labels for given parties. |
+
+### Other
+
+| Method | Description |
+|---|---|
+| `CheckNotificationCondition(dialogId, queryParams, ct)` | Check whether a notification condition is met (used by Altinn Notification). |
+
+## Optimistic concurrency
+
+Write operations accept an optional `ifMatch` parameter (maps to `If-Match` header). Pass the `Revision` GUID from a prior `GetDialog` response to prevent overwriting concurrent changes. A mismatched revision returns `412 Precondition Failed`.
+
+## Dialog token validation
+
+Dialogporten issues short-lived EdDSA-signed dialog tokens when an end user accesses a dialog. Your backend can validate these tokens using the injected `IDialogTokenValidator`:
+
+```csharp
+public class MyController(IDialogTokenValidator validator)
+{
+    [HttpGet("resource/{dialogId}")]
+    public IActionResult Get(Guid dialogId, [FromHeader] string dialogToken)
+    {
+        var result = validator.Validate(dialogToken, dialogId: dialogId, requiredActions: ["read"]);
+
+        if (!result.IsValid)
+            return Forbid();
+
+        // result.ClaimsPrincipal is non-null here
+        return Ok();
+    }
+}
+```
+
+The validator caches public keys fetched from the Dialogporten `.well-known` endpoint (via a background hosted service). By default it throws on startup if keys cannot be fetched; set `ThrowOnPublicKeyFetchInit = false` in `DialogportenSettings` to make startup tolerant of transient failures.
+
+**`DialogTokenValidationParameters`** lets you override defaults globally or per-call:
+
+```csharp
+// Disable lifetime validation (useful in tests)
+DialogTokenValidationParameters.Default.ValidateLifetime = false;
+
+// Per-call override with extra clock skew
+var result = validator.Validate(token, options: new DialogTokenValidationParameters
+{
+    ClockSkew = TimeSpan.FromSeconds(30)
+});
+```
+
+## Settings reference
+
+```json
+{
+  "Dialogporten": {
+    "BaseUri": "https://platform.altinn.no/dialogporten",
+    "ThrowOnPublicKeyFetchInit": true,
+    "Maskinporten": {
+      "Authority": "https://maskinporten.no/",
+      "ClientId": "your-client-id",
+      "Scope": "digdir:dialogporten.serviceprovider digdir:dialogporten.serviceprovider.search",
+      "EncodedJwk": "..."
+    }
+  }
+}
+```
+
+Bind and register:
+
+```csharp
+var settings = builder.Configuration
+    .GetSection("Dialogporten")
+    .Get<DialogportenSettings>()!;
+
+builder.Services.AddDialogportenClient(settings);
+```

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/README.md
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/README.md
@@ -178,9 +178,6 @@ The validator caches public keys fetched from the Dialogporten `.well-known` end
 **`DialogTokenValidationParameters`** lets you override defaults globally or per-call:
 
 ```csharp
-// Disable lifetime validation (useful in tests)
-DialogTokenValidationParameters.Default.ValidateLifetime = false;
-
 // Per-call override with extra clock skew
 var result = validator.Validate(token, options: new DialogTokenValidationParameters
 {

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/README.md
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/README.md
@@ -19,8 +19,7 @@ Register the client in your DI container using `AddDialogportenClient`. The `Bas
 | Environment | BaseUri |
 |---|---|
 | Production | `https://platform.altinn.no/dialogporten` |
-| TT02 (staging) | `https://platform.tt02.altinn.no/dialogporten` |
-| AT23 (test) | `https://platform.at23.altinn.cloud/dialogporten` |
+| TT02 | `https://platform.tt02.altinn.no/dialogporten` |
 
 ### Built-in Maskinporten authentication
 


### PR DESCRIPTION
## Description

README added with help from Claud. I am not sure if we should include everything that is mentioned here.
Open for opinions

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/3816

## Verification

Only update of documentation

## Documentation

- [x] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
