### PR TITLE
feat: Add dialog token validation sample for enduser and serviceowner sdk

### DIFF
--- a/Digdir.Domain.Dialogporten.slnx
+++ b/Digdir.Domain.Dialogporten.slnx
@@ -27,6 +27,8 @@
     <Project Path="src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Digdir.Library.Dialogporten.WebApiClient.EndUser.csproj" />
     <Project Path="src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.csproj" />
     <Project Path="src/Digdir.Library.Dialogporten.WebApiClient.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.WebApiSample.csproj" />
+    <Project Path="src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample.csproj" />
+    <Project Path="src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample.csproj" />
     <Project Path="src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient/Digdir.Library.Dialogporten.WebApiClient.csproj" />
   </Folder>
   <Folder Name="/src/Tools/">

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample.csproj
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample.csproj
@@ -5,7 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+        <!-- Pin transitive Microsoft.OpenApi to a non-vulnerable version (GHSA-v5pm-xwqc-g5wc) -->
+        <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample.csproj
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <UserSecretsId>4b7609a0-55bb-4d9e-96bc-390692d2f6a7</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\WebApiClient\Digdir.Library.Dialogporten.WebApiClient.Common\Digdir.Library.Dialogporten.WebApiClient.Common.csproj" />
+        <ProjectReference Include="..\WebApiClient\Digdir.Library.Dialogporten.WebApiClient.EndUser\Digdir.Library.Dialogporten.WebApiClient.EndUser.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/EndUserWebApiSample.http
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/EndUserWebApiSample.http
@@ -5,11 +5,9 @@
 ### Verify DialogToken
 
 POST {{HostAddress}}/dialogTokenVerify/
-Accept: application/json
+Content-Type: application/json
 
-{
-   "token": {{dialogToken}}
-}
+{{dialogToken}}
 
 ### Get dialog by id
 GET {{HostAddress}}/dialog/{{dialogId}}

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/EndUserWebApiSample.http
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/EndUserWebApiSample.http
@@ -1,0 +1,16 @@
+@HostAddress = http://localhost:5008
+@dialogId = DIALOG_ID_HERE
+@dialogToken = "DIALOG_TOKEN_HERE"
+
+### Verify DialogToken
+
+POST {{HostAddress}}/dialogTokenVerify/
+Accept: application/json
+
+{
+   "token": {{dialogToken}}
+}
+
+### Get dialog by id
+GET {{HostAddress}}/dialog/{{dialogId}}
+Accept: application/json

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Program.cs
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Program.cs
@@ -6,8 +6,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 var dialogportenSettings = builder.Configuration
     .GetSection("DialogportenSettings")
-    .Get<DialogportenSettings>()!;
-builder.Services.AddDialogportenClient(dialogportenSettings);
+    .Get<DialogportenSettings>();
+builder.Services.AddDialogportenClient(dialogportenSettings ?? throw new InvalidOperationException("No Dialogporten settings found"));
 
 builder.Services.AddOpenApi();
 

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Program.cs
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Program.cs
@@ -1,0 +1,36 @@
+using Altinn.ApiClients.Dialogporten;
+using Altinn.ApiClients.Dialogporten.EndUser;
+using Microsoft.AspNetCore.Mvc;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var dialogportenSettings = builder.Configuration
+    .GetSection("DialogportenSettings")
+    .Get<DialogportenSettings>()!;
+builder.Services.AddDialogportenClient(dialogportenSettings);
+
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+app.MapOpenApi();
+app.UseHttpsRedirection();
+
+app.MapPost("/dialogTokenVerify", (
+        [FromServices] IDialogTokenValidator dialogTokenVerifier,
+        [FromBody] string token)
+    => dialogTokenVerifier.Validate(token).IsValid
+        ? Results.Ok()
+        : Results.Unauthorized());
+
+app.MapGet("/dialog/{dialogId:Guid}", async (
+        [FromServices] IEndUserApi endUserApi,
+        [FromRoute] Guid dialogId,
+        CancellationToken cancellationToken) =>
+{
+    var response = await endUserApi.V1.GetDialog(dialogId, cancellationToken: cancellationToken);
+    return response.IsSuccessful
+        ? Results.Ok(response.Content)
+        : Results.StatusCode((int)response.StatusCode);
+});
+
+app.Run();

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Properties/launchSettings.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5008",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7173;http://localhost:5008",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/appsettings.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "DialogportenSettings": {
+    "BaseUri": "https://localhost:7214",
+    "ThrowOnPublicKeyFetchInit": false,
+    "Maskinporten": {
+      "Environment": "test",
+      "Scope": "digdir:dialogporten",
+      "ClientId": "Configure in local secrets",
+      "EncodedJwk": "Configure in local secrets"
+    }
+  }
+}

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/packages.lock.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/packages.lock.json
@@ -4,12 +4,18 @@
     "net10.0": {
       "Microsoft.AspNetCore.OpenApi": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "1ihb8FO9cGgEK1/m3CTtT/SfnynwmiZib0W2pcDVj3KSWk/Sca4VOXEtaptKQc582zpFrzTFiwkGRCglt6H+WQ==",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "d4Atx9IHq7JgX0F/h7Db+m9zAUzC+cKdI9k+OWnnyQIOUQtfvjIEuhvbjPigVMkAmPUgCbJ8Yp6M9ghUqHtJSQ==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "Direct",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Altinn.ApiClients.Maskinporten": {
         "type": "Transitive",
@@ -53,11 +59,6 @@
         "dependencies": {
           "Microsoft.IdentityModel.Logging": "8.15.0"
         }
-      },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
       },
       "NSec.Cryptography": {
         "type": "Transitive",

--- a/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/packages.lock.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample/packages.lock.json
@@ -1,0 +1,112 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "Direct",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "1ihb8FO9cGgEK1/m3CTtT/SfnynwmiZib0W2pcDVj3KSWk/Sca4VOXEtaptKQc582zpFrzTFiwkGRCglt6H+WQ==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Altinn.ApiClients.Maskinporten": {
+        "type": "Transitive",
+        "resolved": "10.1.0",
+        "contentHash": "abW7+F17oxpEMdub40S2RvySV7Fwk0aez4CmedwHbm9RwFd2rRPv9Ng7jjM5Tn2pSBddfbIfsochxJrmykAVRA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.15.0",
+          "System.IdentityModel.Tokens.Jwt": "8.15.0"
+        }
+      },
+      "libsodium": {
+        "type": "Transitive",
+        "resolved": "1.0.20.1",
+        "contentHash": "pkiceEqJDQFHjbga3k/oPfTVX9g+GKJZ1VrkuiLhaymt9YNw1Dr7cX9hNuZuNaWcr9WD0moW55k4pMwzQ7JaZQ=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.15.0",
+        "contentHash": "e/DApa1GfxUqHSBHcpiQg8yaghKAvFVBQFcWh25jNoRobDZbduTUACY8bZ54eeGWXvimGmEDdF0zkS5Dq16XPQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.15.0",
+        "contentHash": "3513f5VzvOZy3ELd42wGnh1Q3e83tlGAuXFSNbENpgWYoAhLLzgFtd5PiaOPGAU0gqKhYGVzKavghLUGfX3HQg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.15.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.15.0",
+        "contentHash": "1gJLjhy0LV2RQMJ9NGzi5Tnb2l+c37o8D8Lrk2mrvmb6OQHZ7XJstd/XxvncXgBpad4x9CGXdipbZzJJCXKyAg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.15.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.15.0",
+        "contentHash": "zUE9ysJXBtXlHHRtcRK3Sp8NzdCI1z/BRDTXJQ2TvBoI0ENRtnufYIep0O5TSCJRJGDwwuLTUx+l/bEYZUxpCA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "8.15.0"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "NSec.Cryptography": {
+        "type": "Transitive",
+        "resolved": "25.4.0",
+        "contentHash": "Z3wPpG0xefMLmhn9T+Ka/EzAmMQPT0THL/5E4lf9cXI/N9rbGH0G23ZFpRcPnD0ast2k7ieG6QSVNIjmfPCXBQ==",
+        "dependencies": {
+          "libsodium": "[1.0.20.1, 1.0.21)"
+        }
+      },
+      "Refit": {
+        "type": "Transitive",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
+      },
+      "Refit.HttpClientFactory": {
+        "type": "Transitive",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
+        "dependencies": {
+          "Refit": "10.2.0"
+        }
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.15.0",
+        "contentHash": "dpodi7ixz6hxK8YCBYAWzm0IA8JYXoKcz0hbCbNifo519//rjUI0fBD8rfNr+IGqq+2gm4oQoXwHk09LX5SqqQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.15.0",
+          "Microsoft.IdentityModel.Tokens": "8.15.0"
+        }
+      },
+      "Altinn.ApiClients.Dialogporten.Common": {
+        "type": "Project",
+        "dependencies": {
+          "Altinn.ApiClients.Maskinporten": "[10.1.0, )",
+          "NSec.Cryptography": "[25.4.0, )",
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
+        }
+      },
+      "Altinn.ApiClients.Dialogporten.EndUser": {
+        "type": "Project",
+        "dependencies": {
+          "Altinn.ApiClients.Maskinporten": "[10.1.0, )",
+          "NSec.Cryptography": "[25.4.0, )",
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
+        }
+      }
+    }
+  }
+}

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample.csproj
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample.csproj
@@ -5,7 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+        <!-- Pin transitive Microsoft.OpenApi to a non-vulnerable version (GHSA-v5pm-xwqc-g5wc) -->
+        <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample.csproj
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <UserSecretsId>6002da88-f29d-4f42-8bf3-3c4ce8d40e28</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\WebApiClient\Digdir.Library.Dialogporten.WebApiClient.Common\Digdir.Library.Dialogporten.WebApiClient.Common.csproj" />
+        <ProjectReference Include="..\WebApiClient\Digdir.Library.Dialogporten.WebApiClient.ServiceOwner\Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Program.cs
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Program.cs
@@ -6,8 +6,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 var dialogportenSettings = builder.Configuration
     .GetSection("DialogportenSettings")
-    .Get<DialogportenSettings>()!;
-builder.Services.AddDialogportenClient(dialogportenSettings);
+    .Get<DialogportenSettings>();
+builder.Services.AddDialogportenClient(dialogportenSettings ?? throw new InvalidOperationException("No Dialogporten settings found"));
 
 builder.Services.AddOpenApi();
 

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Program.cs
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Program.cs
@@ -1,0 +1,36 @@
+using Altinn.ApiClients.Dialogporten;
+using Altinn.ApiClients.Dialogporten.ServiceOwner;
+using Microsoft.AspNetCore.Mvc;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var dialogportenSettings = builder.Configuration
+    .GetSection("DialogportenSettings")
+    .Get<DialogportenSettings>()!;
+builder.Services.AddDialogportenClient(dialogportenSettings);
+
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+app.MapOpenApi();
+app.UseHttpsRedirection();
+
+app.MapPost("/dialogTokenVerify", (
+        [FromServices] IDialogTokenValidator dialogTokenVerifier,
+        [FromBody] string token)
+    => dialogTokenVerifier.Validate(token).IsValid
+        ? Results.Ok()
+        : Results.Unauthorized());
+
+app.MapGet("/dialog/{dialogId:Guid}", async (
+        [FromServices] IServiceOwnerApi serviceOwnerApi,
+        [FromRoute] Guid dialogId,
+        CancellationToken cancellationToken) =>
+{
+    var response = await serviceOwnerApi.V1.GetDialog(dialogId, cancellationToken: cancellationToken);
+    return response.IsSuccessful
+        ? Results.Ok(response.Content)
+        : Results.StatusCode((int)response.StatusCode);
+});
+
+app.Run();

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Properties/launchSettings.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5007",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7172;http://localhost:5007",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/ServiceOwnerWebApiSample.http
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/ServiceOwnerWebApiSample.http
@@ -1,0 +1,16 @@
+@HostAddress = http://localhost:5007
+@dialogId = DIALOG_ID_HERE
+@dialogToken = "DIALOG_TOKEN_HERE"
+
+### Verify DialogToken
+
+POST {{HostAddress}}/dialogTokenVerify/
+Accept: application/json
+
+{
+   "token": {{dialogToken}}
+}
+
+### Get dialog by id
+GET {{HostAddress}}/dialog/{{dialogId}}
+Accept: application/json

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/ServiceOwnerWebApiSample.http
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/ServiceOwnerWebApiSample.http
@@ -5,11 +5,9 @@
 ### Verify DialogToken
 
 POST {{HostAddress}}/dialogTokenVerify/
-Accept: application/json
+Content-Type: application/json
 
-{
-   "token": {{dialogToken}}
-}
+{{dialogToken}}
 
 ### Get dialog by id
 GET {{HostAddress}}/dialog/{{dialogId}}

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/appsettings.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "DialogportenSettings": {
+    "BaseUri": "https://localhost:7214",
+    "ThrowOnPublicKeyFetchInit": false,
+    "Maskinporten": {
+      "Environment": "test",
+      "Scope": "digdir:dialogporten.serviceprovider digdir:dialogporten.serviceprovider.search",
+      "ClientId": "Configure in local secrets",
+      "EncodedJwk": "Configure in local secrets"
+    }
+  }
+}

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/packages.lock.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/packages.lock.json
@@ -4,12 +4,18 @@
     "net10.0": {
       "Microsoft.AspNetCore.OpenApi": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "1ihb8FO9cGgEK1/m3CTtT/SfnynwmiZib0W2pcDVj3KSWk/Sca4VOXEtaptKQc582zpFrzTFiwkGRCglt6H+WQ==",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "d4Atx9IHq7JgX0F/h7Db+m9zAUzC+cKdI9k+OWnnyQIOUQtfvjIEuhvbjPigVMkAmPUgCbJ8Yp6M9ghUqHtJSQ==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "Direct",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Altinn.ApiClients.Maskinporten": {
         "type": "Transitive",
@@ -53,11 +59,6 @@
         "dependencies": {
           "Microsoft.IdentityModel.Logging": "8.15.0"
         }
-      },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
       },
       "NSec.Cryptography": {
         "type": "Transitive",

--- a/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/packages.lock.json
+++ b/src/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample/packages.lock.json
@@ -1,0 +1,112 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "Direct",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "1ihb8FO9cGgEK1/m3CTtT/SfnynwmiZib0W2pcDVj3KSWk/Sca4VOXEtaptKQc582zpFrzTFiwkGRCglt6H+WQ==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Altinn.ApiClients.Maskinporten": {
+        "type": "Transitive",
+        "resolved": "10.1.0",
+        "contentHash": "abW7+F17oxpEMdub40S2RvySV7Fwk0aez4CmedwHbm9RwFd2rRPv9Ng7jjM5Tn2pSBddfbIfsochxJrmykAVRA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.15.0",
+          "System.IdentityModel.Tokens.Jwt": "8.15.0"
+        }
+      },
+      "libsodium": {
+        "type": "Transitive",
+        "resolved": "1.0.20.1",
+        "contentHash": "pkiceEqJDQFHjbga3k/oPfTVX9g+GKJZ1VrkuiLhaymt9YNw1Dr7cX9hNuZuNaWcr9WD0moW55k4pMwzQ7JaZQ=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.15.0",
+        "contentHash": "e/DApa1GfxUqHSBHcpiQg8yaghKAvFVBQFcWh25jNoRobDZbduTUACY8bZ54eeGWXvimGmEDdF0zkS5Dq16XPQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.15.0",
+        "contentHash": "3513f5VzvOZy3ELd42wGnh1Q3e83tlGAuXFSNbENpgWYoAhLLzgFtd5PiaOPGAU0gqKhYGVzKavghLUGfX3HQg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.15.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.15.0",
+        "contentHash": "1gJLjhy0LV2RQMJ9NGzi5Tnb2l+c37o8D8Lrk2mrvmb6OQHZ7XJstd/XxvncXgBpad4x9CGXdipbZzJJCXKyAg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.15.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.15.0",
+        "contentHash": "zUE9ysJXBtXlHHRtcRK3Sp8NzdCI1z/BRDTXJQ2TvBoI0ENRtnufYIep0O5TSCJRJGDwwuLTUx+l/bEYZUxpCA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "8.15.0"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "NSec.Cryptography": {
+        "type": "Transitive",
+        "resolved": "25.4.0",
+        "contentHash": "Z3wPpG0xefMLmhn9T+Ka/EzAmMQPT0THL/5E4lf9cXI/N9rbGH0G23ZFpRcPnD0ast2k7ieG6QSVNIjmfPCXBQ==",
+        "dependencies": {
+          "libsodium": "[1.0.20.1, 1.0.21)"
+        }
+      },
+      "Refit": {
+        "type": "Transitive",
+        "resolved": "10.2.0",
+        "contentHash": "zwPmA4p0ZDCeg0/z0hRUXj4aS0y0mlJ8TSri4pz4e0MWmRXAtjSVeQdnkyRah2f6+I0JlP14UqMQW4N8u/hVeg=="
+      },
+      "Refit.HttpClientFactory": {
+        "type": "Transitive",
+        "resolved": "10.2.0",
+        "contentHash": "pDd73YQWLFxqwP01H4vpXqu6BJAPKJrci7+Nmlhx+Xg5asklGhmoAUVAeGeEKAqyOMQeN7wl5tCKcihus+Gzmw==",
+        "dependencies": {
+          "Refit": "10.2.0"
+        }
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.15.0",
+        "contentHash": "dpodi7ixz6hxK8YCBYAWzm0IA8JYXoKcz0hbCbNifo519//rjUI0fBD8rfNr+IGqq+2gm4oQoXwHk09LX5SqqQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.15.0",
+          "Microsoft.IdentityModel.Tokens": "8.15.0"
+        }
+      },
+      "Altinn.ApiClients.Dialogporten.Common": {
+        "type": "Project",
+        "dependencies": {
+          "Altinn.ApiClients.Maskinporten": "[10.1.0, )",
+          "NSec.Cryptography": "[25.4.0, )",
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
+        }
+      },
+      "Altinn.ApiClients.Dialogporten.ServiceOwner": {
+        "type": "Project",
+        "dependencies": {
+          "Altinn.ApiClients.Maskinporten": "[10.1.0, )",
+          "NSec.Cryptography": "[25.4.0, )",
+          "Refit": "[10.2.0, )",
+          "Refit.HttpClientFactory": "[10.2.0, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds two new sample web API projects demonstrating the new Dialogporten
WebApiClient SDK packages, mirroring the existing
`Digdir.Library.Dialogporten.WebApiClient.WebApiSample` (which targets the
legacy SDK):

- **`Digdir.Library.Dialogporten.WebApiClient.ServiceOwner.WebApiSample`** —
  references the `Common` + `ServiceOwner` packages, injects `IServiceOwnerApi`
  and calls `serviceOwnerApi.V1.GetDialog(...)`. Scope
  `digdir:dialogporten.serviceprovider digdir:dialogporten.serviceprovider.search`.
- **`Digdir.Library.Dialogporten.WebApiClient.EndUser.WebApiSample`** —
  references the `Common` + `EndUser` packages, injects `IEndUserApi` and calls
  `endUserApi.V1.GetDialog(...)`. Scope `digdir:dialogporten`.

Each sample exposes the same two endpoints as the original:
- `POST /dialogTokenVerify` — validates a dialog token via the shared
  `IDialogTokenValidator`.
- `GET /dialog/{dialogId}` — fetches a dialog by id.

Unlike the legacy sample, the new SDKs expose a versioned root interface
(`IServiceOwnerApi.V1` / `IEndUserApi.V1`) returning `Task<IApiResponse<T>>`, so
the `GetDialog` endpoint is now `async` and checks `response.IsSuccessful`.

Both projects are registered under `/src/Libraries/WebApiClient/` in
`Digdir.Domain.Dialogporten.slnx`.

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/3750

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [x] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
