### PR TITLE
fix: throw unreachableexception on unknown party identifier

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/IUserParties.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IUserParties.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
+using Microsoft.Extensions.Logging;
 
 namespace Digdir.Domain.Dialogporten.Application.Common;
 
@@ -13,21 +15,34 @@ public sealed class UserParties : IUserParties
 {
     private readonly IUser _user;
     private readonly IAltinnAuthorization _altinnAuthorization;
+    private readonly ILogger<UserParties> _logger;
 
-    public UserParties(IUser user, IAltinnAuthorization altinnAuthorization)
+    public UserParties(IUser user, IAltinnAuthorization altinnAuthorization, ILogger<UserParties> logger)
     {
         ArgumentNullException.ThrowIfNull(user);
         ArgumentNullException.ThrowIfNull(altinnAuthorization);
+        ArgumentNullException.ThrowIfNull(logger);
 
         _user = user;
         _altinnAuthorization = altinnAuthorization;
+        _logger = logger;
     }
 
     public Task<AuthorizedPartiesResult> GetUserParties(CancellationToken cancellationToken = default)
     {
-        var partyIdentifier = _user.GetPrincipal().GetEndUserPartyIdentifier();
-        return partyIdentifier != null
-            ? _altinnAuthorization.GetAuthorizedParties(partyIdentifier, cancellationToken: cancellationToken)
-            : Task.FromResult(new AuthorizedPartiesResult());
+        var userPrincipal = _user.GetPrincipal();
+        var partyIdentifier = userPrincipal.GetEndUserPartyIdentifier();
+
+        if (partyIdentifier is null)
+        {
+            var (userType, _) = userPrincipal.GetUserType();
+            _logger.LogError(
+                "The request was authenticated, but could not find party identifier. UserType={UserType}, {DiagnosticSummary}",
+                userType,
+                userPrincipal.GetDiagnosticSummary());
+            throw new UnreachableException("Party identifier could not be found");
+        }
+
+        return _altinnAuthorization.GetAuthorizedParties(partyIdentifier, cancellationToken: cancellationToken);
     }
 }


### PR DESCRIPTION
## Description
If party identifier is unknown, GetUserParties will throw UnreachableException

Get a better log and error for case:
https://digdir.crm4.dynamics.com/main.aspx?appid=8bb89bb1-9c24-4d6e-951b-4653560a3656&pagetype=entityrecord&etn=incident&id=db07ad57-bc76-f111-ab0d-000d3a293bba

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)
