### PR TITLE
chore(bicep): bump Microsoft.Network resources to 2025-07-01 API version

### DIFF
--- a/.azure/modules/privateDnsZoneGroup/main.bicep
+++ b/.azure/modules/privateDnsZoneGroup/main.bicep
@@ -3,11 +3,11 @@ param privateEndpointName string
 param name string
 param dnsZoneGroupName string
 
-resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' existing = {
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2025-07-01' existing = {
   name: privateEndpointName
 }
 
-resource pe_dns_zone_group 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01' = {
+resource pe_dns_zone_group 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2025-07-01' = {
   name: name
   parent: privateEndpoint
   properties: {

--- a/.azure/modules/redis/main.bicep
+++ b/.azure/modules/redis/main.bicep
@@ -64,7 +64,7 @@ var redisAccessKeys = redis.listKeys()
 // private endpoint name max characters is 80
 var redisPrivateEndpointName = uniqueResourceName('${namePrefix}-redis-pe', 80)
 
-resource redisPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
+resource redisPrivateEndpoint 'Microsoft.Network/privateEndpoints@2025-07-01' = {
   name: redisPrivateEndpointName
   location: location
   properties: {

--- a/.azure/modules/serviceBus/main.bicep
+++ b/.azure/modules/serviceBus/main.bicep
@@ -57,7 +57,7 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
 // private endpoint name max characters is 80
 var serviceBusPrivateEndpointName = uniqueResourceName('${namePrefix}-service-bus-pe', 80)
 
-resource serviceBusPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = if (vnetEnabled) {
+resource serviceBusPrivateEndpoint 'Microsoft.Network/privateEndpoints@2025-07-01' = if (vnetEnabled) {
   name: serviceBusPrivateEndpointName
   location: location
   properties: {

--- a/.azure/modules/ssh-jumper/main.bicep
+++ b/.azure/modules/ssh-jumper/main.bicep
@@ -21,7 +21,7 @@ param vmSize string
 
 var name = '${namePrefix}-ssh-jumper'
 
-resource publicIp 'Microsoft.Network/publicIPAddresses@2024-05-01' = {
+resource publicIp 'Microsoft.Network/publicIPAddresses@2025-07-01' = {
   name: '${name}-ip'
   location: location
   sku: {
@@ -40,7 +40,7 @@ resource publicIp 'Microsoft.Network/publicIPAddresses@2024-05-01' = {
   tags: tags
 }
 
-resource networkInterface 'Microsoft.Network/networkInterfaces@2024-05-01' = {
+resource networkInterface 'Microsoft.Network/networkInterfaces@2025-07-01' = {
   name: name
   location: location
   properties: {

--- a/.azure/modules/vnet/main.bicep
+++ b/.azure/modules/vnet/main.bicep
@@ -18,7 +18,7 @@ var serviceBusSubnetPrefix = '10.0.4.0/24'
 var redisSubnetPrefix = '10.0.5.0/24'
 var sshJumperSubnetPrefix = '10.0.6.0/24'
 
-resource defaultNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+resource defaultNSG 'Microsoft.Network/networkSecurityGroups@2025-07-01' = {
   name: '${namePrefix}-default-nsg'
   location: location
   properties: {
@@ -58,7 +58,7 @@ resource defaultNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
 }
 
 // https://learn.microsoft.com/en-us/azure/container-apps/firewall-integration?tabs=consumption-only
-resource containerAppEnvironmentNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+resource containerAppEnvironmentNSG 'Microsoft.Network/networkSecurityGroups@2025-07-01' = {
   name: '${namePrefix}-container-app-environment-nsg'
   location: location
   properties: {
@@ -157,7 +157,7 @@ resource containerAppEnvironmentNSG 'Microsoft.Network/networkSecurityGroups@202
   tags: tags
 }
 
-resource postgresqlNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+resource postgresqlNSG 'Microsoft.Network/networkSecurityGroups@2025-07-01' = {
   name: '${namePrefix}-postgresql-nsg'
   location: location
   properties: {
@@ -196,7 +196,7 @@ resource postgresqlNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
   tags: tags
 }
 
-resource redisNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+resource redisNSG 'Microsoft.Network/networkSecurityGroups@2025-07-01' = {
   name: '${namePrefix}-redis-nsg'
   location: location
   properties: {
@@ -235,7 +235,7 @@ resource redisNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
   tags: tags
 }
 
-resource serviceBusNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+resource serviceBusNSG 'Microsoft.Network/networkSecurityGroups@2025-07-01' = {
   name: '${namePrefix}-service-bus-nsg'
   location: location
   properties: {
@@ -274,7 +274,7 @@ resource serviceBusNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
   tags: tags
 }
 
-resource sshJumperNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+resource sshJumperNSG 'Microsoft.Network/networkSecurityGroups@2025-07-01' = {
   name: '${namePrefix}-ssh-jumper-nsg'
   location: location
   properties: {
@@ -298,7 +298,7 @@ resource sshJumperNSG 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
   tags: tags
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-07-01' = {
   name: '${namePrefix}-vnet'
   location: location
   properties: {


### PR DESCRIPTION
## Description

Bumps the API version of all `Microsoft.Network/*` resources from `2024-05-01` to `2025-07-01` (the current latest stable version, verified against the Azure Resource Manager change-logs). Affected resource types: `networkSecurityGroups` and `virtualNetworks` (vnet module), `privateEndpoints` + `privateEndpoints/privateDnsZoneGroups` (privateDnsZoneGroup module), `privateEndpoints` (redis and serviceBus modules), and `publicIPAddresses` + `networkInterfaces` (ssh-jumper module). Only the API version strings changed — no resource declarations or properties were modified. `Microsoft.Network/privateDnsZones` is intentionally left on `2024-06-01`, since it follows a separate, slower API-version track whose newest release is `2024-06-01`.

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
