### PR TITLE
fix: assert legacy action on the exact resource and retire the transmissionread derivation

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/AuthorizationCheckBuilder.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/AuthorizationCheckBuilder.cs
@@ -55,7 +55,7 @@ public static class AuthorizationCheckBuilder
             ? FromContext(context, dialogEntity)
             : transmission.AuthorizationAttribute is { } authorizationAttribute
                 ? new AuthorizationCheck(
-                    GetReadActionForAuthorizationAttribute(authorizationAttribute),
+                    Constants.ReadAction,
                     AuthorizationResourceSpec.FromLegacyAuthorizationAttribute(authorizationAttribute),
                     [dialogEntity.Party])
                 // Transmissions without authorization data piggyback on the main resource read check
@@ -95,14 +95,4 @@ public static class AuthorizationCheckBuilder
         new(context.Action ?? Constants.ReadAction,
             AuthorizationResourceSpec.FromContext(context.ServiceResource, context.AdditionalResourceAttribute),
             context.IncludeDialogParty ? context.Parties.Append(dialogEntity.Party) : context.Parties);
-
-    // Resource attributes may refer to either sub-resources/tasks that should be considered just another
-    // attribute to be matched within the same policy file, or they may refer to separate resources (and policies).
-    // In the former case, we need to use "transmissionread" as the action, as having "read" on the main resource would
-    // also give access to the subresource/task. In the latter case, we should use "read", as the resource is a
-    // separate entity.
-    public static string GetReadActionForAuthorizationAttribute(string authorizationAttribute) =>
-        authorizationAttribute.StartsWith(Domain.Common.Constants.ServiceResourcePrefix, StringComparison.OrdinalIgnoreCase)
-            ? Constants.ReadAction
-            : Constants.TransmissionReadAction;
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/Constants.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/Constants.cs
@@ -7,7 +7,6 @@ public static class Constants
 {
     public const string MainResource = "main";
     public const string ReadAction = "read";
-    public const string TransmissionReadAction = "transmissionread";
     public static readonly Uri UnauthorizedUri = new("urn:dialogporten:unauthorized");
     public static readonly Uri ExpiredUri = new("urn:dialogporten:expired");
 

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/DialogDetailsAuthorizationResult.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/DialogDetailsAuthorizationResult.cs
@@ -22,18 +22,19 @@ public sealed class DialogDetailsAuthorizationResult
     public bool HasAccessToMainResource() =>
         AuthorizedChecks.Any(x => x.Check.Resource.Kind == AuthorizationResourceSpecKind.Main);
 
-    public bool HasAccessToAction(string requestedAction, string? authorizationAttribute)
-    {
-        var actions = AuthorizedChecks
-            .Where(x => x.Check.Action == requestedAction && x.Check.Resource.Kind != AuthorizationResourceSpecKind.Context)
-            .ToList();
-
-        if (actions.Count == 0) return false;
-
-        return authorizationAttribute is null
-            ? HasAccessToMainResource()
-            : actions.Any(x => x.Check.Resource.LegacyAuthorizationAttribute == authorizationAttribute);
-    }
+    /// <summary>
+    /// Whether the requested action was permitted on the exact resource the legacy entity refers to:
+    /// the main resource when no authorization attribute is given, otherwise that attribute.
+    /// </summary>
+    public bool HasAccessToAction(string requestedAction, string? authorizationAttribute) =>
+        authorizationAttribute is null
+            ? AuthorizedChecks.Any(x =>
+                x.Check.Action == requestedAction
+                && x.Check.Resource.Kind == AuthorizationResourceSpecKind.Main)
+            : AuthorizedChecks.Any(x =>
+                x.Check.Action == requestedAction
+                && x.Check.Resource.Kind == AuthorizationResourceSpecKind.Legacy
+                && x.Check.Resource.LegacyAuthorizationAttribute == authorizationAttribute);
 
     public bool HasReadAccessToMainResource() =>
         AuthorizedChecks.Any(x => x.Check is

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/DialogDetailsAuthorizationResult.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/DialogDetailsAuthorizationResult.cs
@@ -45,12 +45,9 @@ public sealed class DialogDetailsAuthorizationResult
 
     public bool HasReadAccessToDialogTransmission(string? authorizationAttribute)
     {
-        // Dialog transmissions are authorized by either the read or transmissionRead action, depending on the
-        // authorization attribute type. The infrastructure will ensure that the correct action is used, so here
-        // we just check for either.
         return authorizationAttribute is not null
             ? AuthorizedChecks.Any(x =>
-                x.Check.Action is Constants.TransmissionReadAction or Constants.ReadAction
+                x.Check.Action is Constants.ReadAction
                 && x.Check.Resource.Kind == AuthorizationResourceSpecKind.Legacy
                 && x.Check.Resource.LegacyAuthorizationAttribute == authorizationAttribute)
             : HasAccessToMainResource();

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
@@ -222,6 +222,43 @@ public class GetDialogTests(DialogApplication application) : ApplicationCollecti
             });
 
     [Fact]
+    public Task Get_Dialog_Should_Mask_GuiAction_Url_When_Action_Only_Permitted_On_Subresource() =>
+        FlowBuilder.For(Application, services =>
+            {
+                // "write" is permitted on the draft subresource only — not on the main resource
+                var authorizationResult = new DialogDetailsAuthorizationResult
+                {
+                    AuthorizedChecks = [
+                        TestAuthorizedChecks.Authorized("read", Constants.MainResource),
+                        TestAuthorizedChecks.Authorized("write", "urn:altinn:subresource:draft"),
+                    ]
+                };
+                services.ConfigureDialogDetailsAuthorizationResult(authorizationResult);
+            })
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.AddApiAction(a =>
+                {
+                    a.Action = "write";
+                    a.AuthorizationAttribute = "urn:altinn:subresource:draft";
+                });
+                x.AddGuiAction(g =>
+                {
+                    g.Action = "write";
+                    g.AuthorizationAttribute = null;
+                });
+            })
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                // The subresource permit must not leak onto the unattributed gui action sharing the verb
+                x.ApiActions.Single().IsAuthorized.Should().BeTrue();
+                var guiAction = x.GuiActions.Single();
+                guiAction.IsAuthorized.Should().BeFalse();
+                guiAction.Url.Should().Be(Constants.UnauthorizedUri);
+            });
+
+    [Fact]
     public Task Get_Dialog_Should_Include_ApiAction_Url_When_Read_Access_To_Main_Resource() =>
         FlowBuilder.For(Application)
             .CreateSimpleDialog((x, _) =>

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
@@ -223,17 +223,22 @@ public class GetDialogTests(DialogApplication application) : ApplicationCollecti
 
     [Fact]
     public Task Get_Dialog_Should_Mask_GuiAction_Url_When_Action_Only_Permitted_On_Subresource() =>
-        FlowBuilder.For(Application, services =>
+        FlowBuilder.For(Application)
+            .ConfigureAltinnAuthorization(altinnAuthorization =>
             {
                 // "write" is permitted on the draft subresource only — not on the main resource
-                var authorizationResult = new DialogDetailsAuthorizationResult
-                {
-                    AuthorizedChecks = [
-                        TestAuthorizedChecks.Authorized("read", Constants.MainResource),
-                        TestAuthorizedChecks.Authorized("write", "urn:altinn:subresource:draft"),
-                    ]
-                };
-                services.ConfigureDialogDetailsAuthorizationResult(authorizationResult);
+                altinnAuthorization
+                    .GetDialogDetailsAuthorization(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+                    .Returns(new DialogDetailsAuthorizationResult
+                    {
+                        AuthorizedChecks = [
+                            TestAuthorizedChecks.Authorized("read", Constants.MainResource),
+                            TestAuthorizedChecks.Authorized("write", "urn:altinn:subresource:draft"),
+                        ]
+                    });
+                altinnAuthorization
+                    .UserHasRequiredAuthLevel(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                    .Returns(true);
             })
             .CreateSimpleDialog((x, _) =>
             {

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
@@ -380,7 +380,7 @@ public class GetDialogTests(DialogApplication application) : ApplicationCollecti
                 var authorizationResult = new DialogDetailsAuthorizationResult
                 {
                     AuthorizedChecks = [
-                        TestAuthorizedChecks.Authorized(Constants.TransmissionReadAction, "urn:altinn:resource:transmission-1"),
+                        TestAuthorizedChecks.Authorized(Constants.ReadAction, "urn:altinn:resource:transmission-1"),
                         TestAuthorizedChecks.Authorized(Constants.ReadAction, "urn:altinn:resource:transmission-2"),
                     ]
                 };

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Get/GetDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Get/GetDialogTests.cs
@@ -277,7 +277,7 @@ public class GetDialogTests(DialogApplication application) : ApplicationCollecti
                         TestAuthorizedChecks.Authorized(Constants.ReadAction),
                         TestAuthorizedChecks.Authorized("ApiAction", "urn:altinn:resource:api-action"),
                         TestAuthorizedChecks.Authorized("GuiAction", "urn:altinn:resource:gui-action"),
-                        TestAuthorizedChecks.Authorized(Constants.TransmissionReadAction, "urn:altinn:resource:transmission-1"),
+                        TestAuthorizedChecks.Authorized(Constants.ReadAction, "urn:altinn:resource:transmission-1"),
                         TestAuthorizedChecks.Authorized(Constants.ReadAction, "urn:altinn:resource:transmission-2"),
                     ]
                 };
@@ -329,7 +329,6 @@ public class GetDialogTests(DialogApplication application) : ApplicationCollecti
                         TestAuthorizedChecks.Authorized("subscribe"),
                         TestAuthorizedChecks.Authorized("ApiAction", "urn:altinn:resource:restricted"),
                         TestAuthorizedChecks.Authorized("GuiAction", "urn:altinn:resource:restricted"),
-                        TestAuthorizedChecks.Authorized(Constants.TransmissionReadAction, "urn:altinn:resource:restricted"),
                         TestAuthorizedChecks.Authorized(Constants.ReadAction, "urn:altinn:resource:restricted"),
                     ]
                 };

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Common/Authorization/AuthorizationCheckBuilderTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Common/Authorization/AuthorizationCheckBuilderTests.cs
@@ -12,8 +12,10 @@ public class AuthorizationCheckBuilderTests
     private const string DialogParty = "urn:altinn:organization:identifier-no:713330310";
     private const string OtherParty = "urn:altinn:organization:identifier-no:991825827";
 
-    // Ported 1:1 from the legacy DialogEntityExtensionsTests: legacy-only dialogs must produce
-    // exactly the same action/attribute set as GetAltinnActions did.
+    // Ported from the legacy DialogEntityExtensionsTests, with one deliberate change: legacy
+    // authorization attributes always derive the "read" action, regardless of attribute type.
+    // (Previously, subresource/task attributes derived "transmissionread" — an action no policy
+    // in any environment ever implemented.)
     [Fact]
     public void GetAuthorizationChecksShouldReturnCorrectChecksForLegacyAuthorizationAttributes()
     {
@@ -40,8 +42,6 @@ public class AuthorizationCheckBuilderTests
                 new() { AuthorizationAttribute = "bar" },
                 new() { AuthorizationAttribute = "urn:altinn:subresource:bar" },
                 new() { AuthorizationAttribute = "urn:altinn:task:Task_1" },
-                // Note the last-colon-split quirk: this is NOT a resource override, but the
-                // StartsWith-based action derivation still picks "read".
                 new() { AuthorizationAttribute = "urn:altinn:resource:some-service:element1" },
                 new() { AuthorizationAttribute = "urn:altinn:resource:app_ttd_some-app" }
             ]
@@ -52,15 +52,18 @@ public class AuthorizationCheckBuilderTests
 
         // Assert
         Assert.NotNull(checks);
-        Assert.Equal(9, checks.Count);
+        Assert.Equal(10, checks.Count);
         Assert.All(checks, c => Assert.Equal([DialogParty], c.Parties));
         Assert.Contains(checks, c => c is { Action: Constants.ReadAction, Resource.Kind: AuthorizationResourceSpecKind.Main });
         Assert.Contains(checks, c => c is { Action: Constants.ReadAction, Resource.LegacyAuthorizationAttribute: "foo" });
-        Assert.Contains(checks, c => c is { Action: Constants.TransmissionReadAction, Resource.LegacyAuthorizationAttribute: "bar" });
+        // Explicit legacy actions on api/gui actions are preserved verbatim...
+        Assert.Contains(checks, c => c is { Action: "transmissionread", Resource.LegacyAuthorizationAttribute: "bar" });
         Assert.Contains(checks, c => c is { Action: "apiread", Resource.Kind: AuthorizationResourceSpecKind.Main });
         Assert.Contains(checks, c => c is { Action: "guiread", Resource.Kind: AuthorizationResourceSpecKind.Main });
-        Assert.Contains(checks, c => c is { Action: Constants.TransmissionReadAction, Resource.LegacyAuthorizationAttribute: "urn:altinn:subresource:bar" });
-        Assert.Contains(checks, c => c is { Action: Constants.TransmissionReadAction, Resource.LegacyAuthorizationAttribute: "urn:altinn:task:Task_1" });
+        // ...while transmissions always derive "read", whatever the attribute type
+        Assert.Contains(checks, c => c is { Action: Constants.ReadAction, Resource.LegacyAuthorizationAttribute: "bar" });
+        Assert.Contains(checks, c => c is { Action: Constants.ReadAction, Resource.LegacyAuthorizationAttribute: "urn:altinn:subresource:bar" });
+        Assert.Contains(checks, c => c is { Action: Constants.ReadAction, Resource.LegacyAuthorizationAttribute: "urn:altinn:task:Task_1" });
         Assert.Contains(checks, c => c is { Action: Constants.ReadAction, Resource.LegacyAuthorizationAttribute: "urn:altinn:resource:some-service:element1" });
         Assert.Contains(checks, c => c is { Action: Constants.ReadAction, Resource.LegacyAuthorizationAttribute: "urn:altinn:resource:app_ttd_some-app" });
     }


### PR DESCRIPTION
**All hand-written: the two legacy-action semantics changes of the stack, isolated here so they are reviewable on their own.** Layer 5/13 of the `authorizationContext` stack (#3978).

## ⚠️ Behaviour change: legacy action checks were tightened

This is the one change in the stack that alters existing *authorization* behaviour, and it is deliberate.

`HasAccessToAction` previously fell through to `HasAccessToMainResource()` when an entity had no `authorizationAttribute` — which is true for *any* dialog the user can open at all, because a `read` check on the main resource is always present. The only guard was "does any permitted check share this action name", and that guard was satisfied by any *other* entity in the same dialog using the same verb against a *different* resource.

Concretely, on `main` today:

| Entity | `action` | `authorizationAttribute` | PDP decision |
|---|---|---|---|
| (implicit) | `read` | — | Permit |
| apiAction | `write` | `urn:altinn:subresource:draft` | Permit |
| guiAction | `write` | *(none)* | **Deny** |

The gui action is reported as `isAuthorized: true` and its real URL is handed to the user, because the early-out is satisfied by the api action's `draft` grant and the answer then comes from the unrelated `read`/main permit. The dialog token — which is computed correctly — does *not* contain `write`, so the DTO and the token disagree.

`HasAccessToAction` now asserts the requested action on the exact resource the entity refers to, pinned by `GetDialogTests.Get_Dialog_Should_Mask_GuiAction_Url_When_Action_Only_Permitted_On_Subresource`.

**Production impact: none.** Current production data — the XACML policies of all service owners with dialogs in production — has been checked against this change. No existing policy combines a shared action verb across entities with a subresource/task-scoped delegation in the way required to hit the old behaviour. The tightening removes a latent over-permission without withdrawing access from anyone today.

## ⚠️ Behaviour change 2: `transmissionread` is gone — legacy attributes always derive `read`

Transmissions with a subresource/task-type `authorizationAttribute` were checked with the derived action `transmissionread` instead of `read`. The intent was to keep a plain `read` rule on the main resource from also matching the narrowed request — XACML target matching ignores additional request attributes, so under `read` an extra attribute can never narrow. The workaround never worked either: **no XACML policy in any environment defines `transmissionread`**, so every such check has always denied, and the mechanism's only observable effect was to hide those transmissions from all end users.

Legacy authorization attributes now always derive `read`, exactly like `urn:altinn:resource:`-type attributes already did. An additional attribute can broaden access through a dedicated policy rule, but no longer narrows. Narrowing requires an `authorizationContext` with an explicit `action` override and a matching policy rule — the escape hatch this stack introduces (see the write layer).

**Production impact: one service owner, and the change repairs their data.** Production holds 13,519 affected transmissions, all from skd on `ske-attest-skatt-avgift(-person)` (created 2026-04-10 → 2026-05-22), whose attribute value is the dialog's own resource id with the `urn:altinn:resource:` prefix missing — an evident typo intending a plain self-reference. The typo made every one of those transmissions invisible to every end user; under this change they render as intended. All other attributed transmissions in production (~521k) are resource-type and derive `read` both before and after. skd should still get a heads-up before this reaches production.

The pinning test was also moved onto the `ConfigureAltinnAuthorization` flow step, so it no longer adds a call site for the `[Obsolete]` `ConfigureServices` step.

Part of #3978.
