### PR TITLE
feat: accept authorizationContext on dialog create and update

### DIFF
--- a/docs/schema/V1/openapi.v1.serviceowner.verified.json
+++ b/docs/schema/V1/openapi.v1.serviceowner.verified.json
@@ -167,6 +167,51 @@
         },
         "type": "object"
       },
+      "AuthorizationContextInput": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "The XACML action to evaluate. Optional; defaults to \u0022read\u0022 if not supplied.",
+            "example": "read",
+            "nullable": true,
+            "type": "string"
+          },
+          "additionalResourceAttribute": {
+            "description": "An additional resource attribute to be matched within the effective service policy, e.g. a task or\nsubresource. Cannot contain a service resource reference; use \u0022serviceResource\u0022 for that.",
+            "example": "urn:altinn:task:Task_1\nurn:altinn:subresource:mycustomresource",
+            "nullable": true,
+            "type": "string"
+          },
+          "includeDialogParty": {
+            "description": "Whether the dialog\u0027s own party is included in the evaluation in addition to \u0022parties\u0022.",
+            "type": "boolean"
+          },
+          "parties": {
+            "description": "The parties to evaluate access on behalf of. Access is granted if the end user has access to the\neffective resource for at least one of the parties. Must contain at least one party unless\n\u0022includeDialogParty\u0022 is true.",
+            "example": "urn:altinn:organization:identifier-no:912345678",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "serviceResource": {
+            "description": "A service resource that overrides the dialog\u0027s own service resource in the authorization evaluation,\nreferring to another service policy. The service owner must have access to the referenced resource.\nWhen set, the dialog\u0027s instance reference no longer applies to the evaluation of this entity.",
+            "example": "urn:altinn:resource:some-other-service-identifier",
+            "nullable": true,
+            "type": "string"
+          },
+          "unauthorizedPresentation": {
+            "description": "Required. Controls how the entity is presented to end users that fail the authorization check:\n\u0022disabled\u0022 keeps the entity visible but masks its URLs and embedded content references, while\n\u0022excluded\u0022 removes it from the collection it belongs to entirely, leaving only its id and\ncreation time in the sibling \u0022excluded\u0022 list (e.g. \u0022excludedTransmissions\u0022 beside\n\u0022transmissions\u0022).",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextUnauthorizedPresentation"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
       "AuthorizationContextUnauthorizedPresentation": {
         "description": "",
         "enum": [
@@ -619,15 +664,29 @@
         "additionalProperties": false,
         "properties": {
           "action": {
+            "deprecated": true,
             "description": "String identifier for the action, corresponding to the \u0022action\u0022 attributeId used in the XACML service policy,\nwhich by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.",
             "example": "write",
-            "type": "string"
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext.Action\u0027 instead."
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -715,6 +774,15 @@
       "CreateDialogAttachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -865,14 +933,28 @@
         "additionalProperties": false,
         "properties": {
           "action": {
+            "deprecated": true,
             "description": "The action identifier for the action, corresponding to the \u0022action\u0022 attributeId used in the XACML service policy.",
-            "type": "string"
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext.Action\u0027 instead."
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -973,10 +1055,21 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -1051,6 +1144,15 @@
       "CreateDialogTransmissionAttachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -1149,6 +1251,15 @@
       "CreateDialogTransmissionNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
@@ -1183,6 +1294,15 @@
       "CreateTransmissionAttachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -1281,6 +1401,15 @@
       "CreateTransmissionNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
@@ -1315,10 +1444,21 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -4275,15 +4415,29 @@
         "additionalProperties": false,
         "properties": {
           "action": {
+            "deprecated": true,
             "description": "String identifier for the action, corresponding to the \u0022action\u0022 attributeId used in the XACML service policy,\nwhich by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.",
             "example": "write",
-            "type": "string"
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext.Action\u0027 instead."
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -4371,6 +4525,15 @@
       "UpdateDialogAttachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -4522,14 +4685,28 @@
         "additionalProperties": false,
         "properties": {
           "action": {
+            "deprecated": true,
             "description": "The action identifier for the action, corresponding to the \u0022action\u0022 attributeId used in the XACML service policy.",
-            "type": "string"
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext.Action\u0027 instead."
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -4606,10 +4783,21 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -4684,6 +4872,15 @@
       "UpdateDialogTransmissionAttachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -4782,6 +4979,15 @@
       "UpdateDialogTransmissionNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
@@ -4807,6 +5013,15 @@
       "UpdateTransmissionAttachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -4912,6 +5127,15 @@
       "UpdateTransmissionNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
@@ -4946,10 +5170,21 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuthorizationContextInput"
+              }
+            ]
           },
           "content": {
             "description": "The transmission unstructured text content.",

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -479,6 +479,51 @@
           "Only"
         ]
       },
+      "V1CommonAuthorizationContexts_AuthorizationContext": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "The XACML action to evaluate. Optional; defaults to \u0022read\u0022 if not supplied.",
+            "example": "read",
+            "nullable": true,
+            "type": "string"
+          },
+          "additionalResourceAttribute": {
+            "description": "An additional resource attribute to be matched within the effective service policy, e.g. a task or\nsubresource. Cannot contain a service resource reference; use \u0022serviceResource\u0022 for that.",
+            "example": "urn:altinn:task:Task_1\nurn:altinn:subresource:mycustomresource",
+            "nullable": true,
+            "type": "string"
+          },
+          "includeDialogParty": {
+            "description": "Whether the dialog\u0027s own party is included in the evaluation in addition to \u0022parties\u0022.",
+            "type": "boolean"
+          },
+          "parties": {
+            "description": "The parties to evaluate access on behalf of. Access is granted if the end user has access to the\neffective resource for at least one of the parties. Must contain at least one party unless\n\u0022includeDialogParty\u0022 is true.",
+            "example": "urn:altinn:organization:identifier-no:912345678",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "serviceResource": {
+            "description": "A service resource that overrides the dialog\u0027s own service resource in the authorization evaluation,\nreferring to another service policy. The service owner must have access to the referenced resource.\nWhen set, the dialog\u0027s instance reference no longer applies to the evaluation of this entity.",
+            "example": "urn:altinn:resource:some-other-service-identifier",
+            "nullable": true,
+            "type": "string"
+          },
+          "unauthorizedPresentation": {
+            "description": "Required. Controls how the entity is presented to end users that fail the authorization check:\n\u0022disabled\u0022 keeps the entity visible but masks its URLs and embedded content references, while\n\u0022excluded\u0022 removes it from the collection it belongs to entirely, leaving only its id and\ncreation time in the sibling \u0022excluded\u0022 list (e.g. \u0022excludedTransmissions\u0022 beside\n\u0022transmissions\u0022).",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DialogsEntitiesAuthorizationContexts_AuthorizationContextUnauthorizedPresentation"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
       "V1CommonContent_ContentValue": {
         "additionalProperties": false,
         "properties": {
@@ -3009,15 +3054,29 @@
         "additionalProperties": false,
         "properties": {
           "action": {
+            "deprecated": true,
             "description": "String identifier for the action, corresponding to the \u0022action\u0022 attributeId used in the XACML service policy,\nwhich by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.",
             "example": "write",
-            "type": "string"
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext.Action\u0027 instead."
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -3105,6 +3164,15 @@
       "V1ServiceOwnerDialogsCommandsCreate_Attachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -3455,14 +3523,28 @@
         "additionalProperties": false,
         "properties": {
           "action": {
+            "deprecated": true,
             "description": "The action identifier for the action, corresponding to the \u0022action\u0022 attributeId used in the XACML service policy.",
-            "type": "string"
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext.Action\u0027 instead."
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -3549,10 +3631,21 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -3627,6 +3720,15 @@
       "V1ServiceOwnerDialogsCommandsCreate_TransmissionAttachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -3725,6 +3827,15 @@
       "V1ServiceOwnerDialogsCommandsCreate_TransmissionNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
@@ -3805,6 +3916,15 @@
       "V1ServiceOwnerDialogsCommandsCreateTransmission_TransmissionAttachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -3903,6 +4023,15 @@
       "V1ServiceOwnerDialogsCommandsCreateTransmission_TransmissionNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
@@ -3937,10 +4066,21 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -4071,15 +4211,29 @@
         "additionalProperties": false,
         "properties": {
           "action": {
+            "deprecated": true,
             "description": "String identifier for the action, corresponding to the \u0022action\u0022 attributeId used in the XACML service policy,\nwhich by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.",
             "example": "write",
-            "type": "string"
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext.Action\u0027 instead."
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -4167,6 +4321,15 @@
       "V1ServiceOwnerDialogsCommandsUpdate_Attachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -4442,14 +4605,28 @@
         "additionalProperties": false,
         "properties": {
           "action": {
+            "deprecated": true,
             "description": "The action identifier for the action, corresponding to the \u0022action\u0022 attributeId used in the XACML service policy.",
-            "type": "string"
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext.Action\u0027 instead."
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -4526,10 +4703,21 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -4604,6 +4792,15 @@
       "V1ServiceOwnerDialogsCommandsUpdate_TransmissionAttachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -4702,6 +4899,15 @@
       "V1ServiceOwnerDialogsCommandsUpdate_TransmissionNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
@@ -4727,6 +4933,15 @@
       "V1ServiceOwnerDialogsCommandsUpdateTransmission_TransmissionAttachment": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -4832,6 +5047,15 @@
       "V1ServiceOwnerDialogsCommandsUpdateTransmission_TransmissionNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "authorizationContext": {
+            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
@@ -4866,10 +5090,21 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
+          },
+          "authorizationContext": {
+            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
+              }
+            ]
           },
           "content": {
             "description": "The transmission unstructured text content.",

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDto.cs
@@ -1,0 +1,52 @@
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
+
+public sealed class AuthorizationContextDto
+{
+    /// <summary>
+    /// A service resource that overrides the dialog's own service resource in the authorization evaluation,
+    /// referring to another service policy. The service owner must have access to the referenced resource.
+    /// When set, the dialog's instance reference no longer applies to the evaluation of this entity.
+    /// </summary>
+    /// <example>urn:altinn:resource:some-other-service-identifier</example>
+    public string? ServiceResource { get; set; }
+
+    /// <summary>
+    /// An additional resource attribute to be matched within the effective service policy, e.g. a task or
+    /// subresource. Cannot contain a service resource reference; use "serviceResource" for that.
+    /// </summary>
+    /// <example>
+    /// urn:altinn:task:Task_1
+    /// urn:altinn:subresource:mycustomresource
+    /// </example>
+    public string? AdditionalResourceAttribute { get; set; }
+
+    /// <summary>
+    /// The parties to evaluate access on behalf of. Access is granted if the end user has access to the
+    /// effective resource for at least one of the parties. Must contain at least one party unless
+    /// "includeDialogParty" is true.
+    /// </summary>
+    /// <example>urn:altinn:organization:identifier-no:912345678</example>
+    public List<string> Parties { get; set; } = [];
+
+    /// <summary>
+    /// Whether the dialog's own party is included in the evaluation in addition to "parties".
+    /// </summary>
+    public bool IncludeDialogParty { get; set; }
+
+    /// <summary>
+    /// The XACML action to evaluate. Optional; defaults to "read" if not supplied.
+    /// </summary>
+    /// <example>read</example>
+    public string? Action { get; set; }
+
+    /// <summary>
+    /// Required. Controls how the entity is presented to end users that fail the authorization check:
+    /// "disabled" keeps the entity visible but masks its URLs and embedded content references, while
+    /// "excluded" removes it from the collection it belongs to entirely, leaving only its id and
+    /// creation time in the sibling "excluded" list (e.g. "excludedTransmissions" beside
+    /// "transmissions").
+    /// </summary>
+    public AuthorizationContextUnauthorizedPresentation.Values UnauthorizedPresentation { get; set; }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDto.cs
@@ -28,7 +28,14 @@ public sealed class AuthorizationContextDto
     /// "includeDialogParty" is true.
     /// </summary>
     /// <example>urn:altinn:organization:identifier-no:912345678</example>
-    public List<string> Parties { get; set; } = [];
+    public List<string> Parties
+    {
+        get;
+        // Nullable in the OpenAPI schema (and reachable as an explicit JSON null via the JsonPatch-based
+        // update endpoint, which binds through Newtonsoft rather than the STJ pipeline's null-annotation
+        // enforcement); normalize here so every consumer - validator, mapper - can assume a non-null list.
+        set => field = value ?? [];
+    } = [];
 
     /// <summary>
     /// Whether the dialog's own party is included in the evaluation in addition to "parties".

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDtoValidator.cs
@@ -1,0 +1,50 @@
+using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Domain.Common;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
+using FluentValidation;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
+
+internal sealed class AuthorizationContextDtoValidator : AbstractValidator<AuthorizationContextDto>
+{
+    public AuthorizationContextDtoValidator()
+    {
+        RuleFor(x => x.ServiceResource)
+            .IsValidAuthorizationAttribute()
+            .Must(x => x is null || x.StartsWith(Constants.ServiceResourcePrefix, StringComparison.OrdinalIgnoreCase))
+            .WithMessage($"'{{PropertyName}}' must start with '{Constants.ServiceResourcePrefix}'.");
+
+        RuleFor(x => x.AdditionalResourceAttribute)
+            .IsValidAuthorizationAttribute()
+            .Must(x => x is null || !x.StartsWith(Constants.ServiceResourcePrefix, StringComparison.OrdinalIgnoreCase))
+            .WithMessage($"'{{PropertyName}}' cannot contain a service resource reference ('{Constants.ServiceResourcePrefix}...'); use 'ServiceResource' instead.");
+
+        RuleFor(x => x.Parties)
+            .Must(x => x.Count <= AuthorizationContext.MaxNumberOfParties)
+            .WithMessage($"'{{PropertyName}}' cannot contain more than {AuthorizationContext.MaxNumberOfParties} parties.");
+
+        RuleFor(x => x.Parties)
+            .UniqueBy(x => x);
+
+        RuleFor(x => x.Parties)
+            .NotEmpty()
+            .WithMessage("'{PropertyName}' must contain at least one party when 'IncludeDialogParty' is false.")
+            .When(x => !x.IncludeDialogParty);
+
+        RuleForEach(x => x.Parties)
+            .NotEmpty()
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .IsValidPartyIdentifier();
+
+        RuleFor(x => x.Action)
+            .NotEmpty()
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .When(x => x.Action is not null);
+
+        RuleFor(x => x.UnauthorizedPresentation)
+            .IsInEnum()
+            .WithMessage($"'{{PropertyName}}' is required and must be either " +
+                         $"'{AuthorizationContextUnauthorizedPresentation.Values.Disabled}' or " +
+                         $"'{AuthorizationContextUnauthorizedPresentation.Values.Excluded}'.");
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/Mapper.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/Mapper.cs
@@ -35,8 +35,14 @@ internal static class LegacyAuthorizationFieldMapExtensions
         /// The legacy action in the form it is persisted in: the empty-string sentinel when the caller
         /// supplied none, because the entity carries an authorization context instead. See
         /// <see cref="DialogGuiAction.Action"/> for why the column stays NOT NULL.
+        ///
+        /// Whitespace normalizes to the sentinel too. The rule that the legacy action must be empty when a
+        /// context is supplied is expressed with FluentValidation's Empty(), which counts a whitespace-only
+        /// string as empty — so storing it verbatim would leave a value that
+        /// <see cref="DialogGuiAction.EffectiveLegacyAction"/> reports as a real legacy action.
         /// </summary>
-        internal string ToStoredLegacyAction() => action ?? string.Empty;
+        internal string ToStoredLegacyAction() =>
+            string.IsNullOrWhiteSpace(action) ? string.Empty : action;
     }
 
     extension(string? authorizationAttribute)

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/Mapper.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/Mapper.cs
@@ -1,0 +1,56 @@
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
+
+internal static class AuthorizationContextMapExtensions
+{
+    internal static TContext? ToAuthorizationContext<TContext>(
+        this AuthorizationContextDto? source, TContext? destination = null)
+        where TContext : AuthorizationContext, new()
+    {
+        if (source is null)
+        {
+            return null;
+        }
+
+        // Copy into the existing context when present to avoid delete+insert churn on every update.
+        var context = destination ?? new TContext();
+        context.ServiceResource = source.ServiceResource;
+        context.AdditionalResourceAttribute = source.AdditionalResourceAttribute;
+        context.Parties = [.. source.Parties];
+        context.IncludeDialogParty = source.IncludeDialogParty;
+        context.Action = source.Action;
+        context.UnauthorizedPresentation = source.UnauthorizedPresentation;
+        return context;
+    }
+}
+
+internal static class LegacyAuthorizationFieldMapExtensions
+{
+    extension(string? action)
+    {
+        /// <summary>
+        /// The legacy action in the form it is persisted in: the empty-string sentinel when the caller
+        /// supplied none, because the entity carries an authorization context instead. See
+        /// <see cref="DialogGuiAction.Action"/> for why the column stays NOT NULL.
+        /// </summary>
+        internal string ToStoredLegacyAction() => action ?? string.Empty;
+    }
+
+    extension(string? authorizationAttribute)
+    {
+        /// <summary>
+        /// The legacy authorization attribute in the form it is persisted in on a transmission. A
+        /// transmission governed by an authorization context stores
+        /// <see cref="Constants.ExcludedTransmissionAttribute"/>, which is inert here — access is decided
+        /// from the context — but keeps the transmission hidden from code predating this feature.
+        /// The two are mutually exclusive on the write surface, so nothing is overwritten.
+        /// </summary>
+        internal string? ToStoredTransmissionAttribute(AuthorizationContextDto? authorizationContext) =>
+            authorizationContext is null
+                ? authorizationAttribute
+                : Constants.ExcludedTransmissionAttribute;
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogDto.cs
@@ -1,4 +1,5 @@
-﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
+﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.DialogStatuses;
@@ -7,6 +8,7 @@ using Digdir.Domain.Dialogporten.Domain.Attachments;
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 using Digdir.Domain.Dialogporten.Domain.Http;
 
@@ -203,7 +205,14 @@ public sealed class TransmissionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete($"Use '{nameof(AuthorizationContext)}' instead.")]
     public string? AuthorizationAttribute { get; set; }
+
+    /// <summary>
+    /// Describes the authorization inputs used when evaluating end user access to this transmission.
+    /// Cannot be combined with "authorizationAttribute".
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 
     /// <summary>
     /// Arbitrary URI/URN describing a service-specific transmission type.
@@ -386,7 +395,8 @@ public sealed class ApiActionDto
     /// which by default is the policy belonging to the service referred to by "serviceResource" in the dialog.
     /// </summary>
     /// <example>write</example>
-    public string Action { get; set; } = null!;
+    [Obsolete($"Use '{nameof(AuthorizationContext)}.{nameof(AuthorizationContextDto.Action)}' instead.")]
+    public string? Action { get; set; }
 
     /// <summary>
     /// Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service
@@ -402,7 +412,15 @@ public sealed class ApiActionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete($"Use '{nameof(AuthorizationContext)}' instead.")]
     public string? AuthorizationAttribute { get; set; }
+
+    /// <summary>
+    /// Describes the authorization inputs used when evaluating end user access to this action.
+    /// Cannot be combined with "authorizationAttribute" or "action"; the XACML action is given by
+    /// "authorizationContext.action".
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 
     /// <summary>
     /// The logical name of the operation the API action refers to.
@@ -480,7 +498,8 @@ public sealed class GuiActionDto
     /// <summary>
     /// The action identifier for the action, corresponding to the "action" attributeId used in the XACML service policy.
     /// </summary>
-    public string Action { get; set; } = null!;
+    [Obsolete($"Use '{nameof(AuthorizationContext)}.{nameof(AuthorizationContextDto.Action)}' instead.")]
+    public string? Action { get; set; }
 
     /// <summary>
     /// The fully qualified URL of the action, to which the user will be redirected when the action is triggered. Will be set to
@@ -506,7 +525,15 @@ public sealed class GuiActionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete($"Use '{nameof(AuthorizationContext)}' instead.")]
     public string? AuthorizationAttribute { get; set; }
+
+    /// <summary>
+    /// Describes the authorization inputs used when evaluating end user access to this action.
+    /// Cannot be combined with "authorizationAttribute" or "action"; the XACML action is given by
+    /// "authorizationContext.action".
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 
     /// <summary>
     /// Indicates whether the action results in the dialog being deleted. Used by frontends to implement custom UX
@@ -564,6 +591,13 @@ public sealed class AttachmentDto
     /// The UTC timestamp when the attachment expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Describes additional authorization inputs used when evaluating end user access to this attachment.
+    /// The XACML action defaults to "read". Access to the parent is always required in addition; this context
+    /// can only further restrict access, never widen it.
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 }
 
 public sealed class AttachmentUrlDto
@@ -622,6 +656,13 @@ public sealed class TransmissionAttachmentDto
     /// The UTC timestamp when the attachment expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Describes additional authorization inputs used when evaluating end user access to this attachment.
+    /// The XACML action defaults to "read". Access to the parent is always required in addition; this context
+    /// can only further restrict access, never widen it.
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 }
 
 public sealed class TransmissionAttachmentUrlDto
@@ -662,4 +703,11 @@ public sealed class TransmissionNavigationalActionDto
     /// The UTC timestamp when the navigational action expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Describes additional authorization inputs used when evaluating end user access to this navigational action.
+    /// The XACML action defaults to "read". Access to the parent transmission is always required in addition; this
+    /// context can only further restrict access, never widen it.
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Mappers.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Mappers.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are mapped for backwards compatibility
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
@@ -5,6 +7,7 @@ using Digdir.Domain.Dialogporten.Domain.Attachments;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 using Digdir.Domain.Dialogporten.Domain.DialogServiceOwnerContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.Http;
@@ -66,12 +69,13 @@ internal static class Mappers
             Id = source.Id ?? Guid.Empty,
             IdempotentKey = source.IdempotentKey,
             CreatedAt = source.CreatedAt,
-            AuthorizationAttribute = source.AuthorizationAttribute,
+            AuthorizationAttribute = source.AuthorizationAttribute.ToStoredTransmissionAttribute(source.AuthorizationContext),
             ExtendedType = source.ExtendedType,
             ExternalReference = source.ExternalReference,
             RelatedTransmissionId = source.RelatedTransmissionId,
             TypeId = source.Type,
             Sender = source.Sender.ToActor<DialogTransmissionSenderActor>(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogTransmissionAuthorizationContext>(),
             Content = source.Content.ToDialogTransmissionContentList() ?? [],
             Attachments = source.Attachments.Select(x => x.ToDialogTransmissionAttachment()).ToList(),
             NavigationalActions = source.NavigationalActions.Select(x => x.ToDialogTransmissionNavigationalAction()).ToList()
@@ -84,7 +88,8 @@ internal static class Mappers
             Name = source.Name,
             ExpiresAt = source.ExpiresAt,
             DisplayName = source.DisplayName.ToLocalizationSet<AttachmentDisplayName>(),
-            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList()
+            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<AttachmentAuthorizationContext>()
         };
 
     private static AttachmentUrl ToAttachmentUrl(this AttachmentUrlDto source) =>
@@ -100,24 +105,26 @@ internal static class Mappers
         new()
         {
             Id = source.Id ?? Guid.Empty,
-            Action = source.Action,
+            Action = source.Action.ToStoredLegacyAction(),
             Url = source.Url,
             AuthorizationAttribute = source.AuthorizationAttribute,
             IsDeleteDialogAction = source.IsDeleteDialogAction,
             PriorityId = source.Priority,
             HttpMethodId = source.HttpMethod ?? HttpVerb.Values.GET,
             Title = source.Title.ToLocalizationSet<DialogGuiActionTitle>(),
-            Prompt = source.Prompt.ToLocalizationSet<DialogGuiActionPrompt>()
+            Prompt = source.Prompt.ToLocalizationSet<DialogGuiActionPrompt>(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogGuiActionAuthorizationContext>()
         };
 
     private static DialogApiAction ToDialogApiAction(this ApiActionDto source) =>
         new()
         {
             Id = source.Id ?? Guid.Empty,
-            Action = source.Action,
+            Action = source.Action.ToStoredLegacyAction(),
             AuthorizationAttribute = source.AuthorizationAttribute,
             Name = source.Name,
-            Endpoints = source.Endpoints.Select(x => x.ToDialogApiActionEndpoint()).ToList()
+            Endpoints = source.Endpoints.Select(x => x.ToDialogApiActionEndpoint()).ToList(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogApiActionAuthorizationContext>()
         };
 
     private static DialogApiActionEndpoint ToDialogApiActionEndpoint(this ApiActionEndpointDto source) =>
@@ -141,7 +148,8 @@ internal static class Mappers
             Name = source.Name,
             ExpiresAt = source.ExpiresAt,
             DisplayName = source.DisplayName.ToLocalizationSet<AttachmentDisplayName>(),
-            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList()
+            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<AttachmentAuthorizationContext>()
         };
 
     private static AttachmentUrl ToAttachmentUrl(this TransmissionAttachmentUrlDto source) =>
@@ -158,6 +166,7 @@ internal static class Mappers
         {
             Url = source.Url,
             ExpiresAt = source.ExpiresAt,
-            Title = source.Title.ToLocalizationSet<DialogTransmissionNavigationalActionTitle>()!
+            Title = source.Title.ToLocalizationSet<DialogTransmissionNavigationalActionTitle>()!,
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogTransmissionNavigationalActionAuthorizationContext>()
         };
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogApiActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogApiActionDtoValidator.cs
@@ -1,5 +1,7 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are validated for backwards compatibility
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
 
@@ -9,6 +11,7 @@ internal sealed class CreateDialogDialogApiActionDtoValidator : AbstractValidato
 {
     public CreateDialogDialogApiActionDtoValidator(
         IValidator<ApiActionEndpointDto> apiActionEndpointValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -17,10 +20,26 @@ internal sealed class CreateDialogDialogApiActionDtoValidator : AbstractValidato
 
         RuleFor(x => x.Action)
             .NotEmpty()
-            .MaximumLength(Constants.DefaultMaxStringLength);
+            .WithMessage($"'{{PropertyName}}' must not be empty when '{nameof(ApiActionDto.AuthorizationContext)}' is not supplied.")
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .When(x => x.AuthorizationContext is null);
+
+        RuleFor(x => x.Action)
+            .Empty()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(ApiActionDto.AuthorizationContext)}'; use '{nameof(ApiActionDto.AuthorizationContext)}.{nameof(AuthorizationContextDto.Action)}' instead.")
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.AuthorizationAttribute)
             .IsValidAuthorizationAttribute();
+
+        RuleFor(x => x.AuthorizationAttribute)
+            .Null()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(ApiActionDto.AuthorizationContext)}'.")
+            .When(x => x.AuthorizationContext is not null);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.Name)
             .MaximumLength(Constants.DefaultMaxStringLength);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogAttachmentDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogAttachmentDtoValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -11,6 +12,7 @@ internal sealed class CreateDialogDialogAttachmentDtoValidator : AbstractValidat
     public CreateDialogDialogAttachmentDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
         IValidator<AttachmentUrlDto> urlValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -33,5 +35,9 @@ internal sealed class CreateDialogDialogAttachmentDtoValidator : AbstractValidat
 
         RuleFor(x => x.ExpiresAt)
             .IsInFuture(clock);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogGuiActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogGuiActionDtoValidator.cs
@@ -1,5 +1,7 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are validated for backwards compatibility
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using Digdir.Domain.Dialogporten.Domain.Http;
@@ -11,6 +13,7 @@ internal sealed class CreateDialogDialogGuiActionDtoValidator : AbstractValidato
 {
     public CreateDialogDialogGuiActionDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -19,7 +22,14 @@ internal sealed class CreateDialogDialogGuiActionDtoValidator : AbstractValidato
 
         RuleFor(x => x.Action)
             .NotEmpty()
-            .MaximumLength(Constants.DefaultMaxStringLength);
+            .WithMessage($"'{{PropertyName}}' must not be empty when '{nameof(GuiActionDto.AuthorizationContext)}' is not supplied.")
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .When(x => x.AuthorizationContext is null);
+
+        RuleFor(x => x.Action)
+            .Empty()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(GuiActionDto.AuthorizationContext)}'; use '{nameof(GuiActionDto.AuthorizationContext)}.{nameof(AuthorizationContextDto.Action)}' instead.")
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.Url)
             .NotNull()
@@ -28,6 +38,15 @@ internal sealed class CreateDialogDialogGuiActionDtoValidator : AbstractValidato
 
         RuleFor(x => x.AuthorizationAttribute)
             .IsValidAuthorizationAttribute();
+
+        RuleFor(x => x.AuthorizationAttribute)
+            .Null()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(GuiActionDto.AuthorizationContext)}'.")
+            .When(x => x.AuthorizationContext is not null);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.Priority)
             .IsInEnum();

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogTransmissionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogDialogTransmissionDtoValidator.cs
@@ -1,5 +1,7 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are validated for backwards compatibility
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -13,6 +15,7 @@ internal sealed class CreateDialogDialogTransmissionDtoValidator : AbstractValid
         IValidator<TransmissionContentDto?> contentValidator,
         IValidator<TransmissionAttachmentDto> attachmentValidator,
         IValidator<TransmissionNavigationalActionDto> navigationalActionValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -44,6 +47,15 @@ internal sealed class CreateDialogDialogTransmissionDtoValidator : AbstractValid
 
         RuleFor(x => x.AuthorizationAttribute)
             .IsValidAuthorizationAttribute();
+
+        RuleFor(x => x.AuthorizationAttribute)
+            .Null()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(TransmissionDto.AuthorizationContext)}'.")
+            .When(x => x.AuthorizationContext is not null);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.Attachments)
             .UniqueBy(x => x.Id);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogTransmissionAttachmentDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogTransmissionAttachmentDtoValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -11,6 +12,7 @@ internal sealed class CreateDialogTransmissionAttachmentDtoValidator : AbstractV
     public CreateDialogTransmissionAttachmentDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
         IValidator<TransmissionAttachmentUrlDto> urlValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -30,5 +32,9 @@ internal sealed class CreateDialogTransmissionAttachmentDtoValidator : AbstractV
 
         RuleFor(x => x.ExpiresAt)
             .IsInFuture(clock);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogTransmissionNavigationalActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Create/Validators/CreateDialogTransmissionNavigationalActionDtoValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -10,6 +11,7 @@ internal sealed class CreateDialogTransmissionNavigationalActionDtoValidator : A
 {
     public CreateDialogTransmissionNavigationalActionDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Title)
@@ -23,5 +25,9 @@ internal sealed class CreateDialogTransmissionNavigationalActionDtoValidator : A
 
         RuleFor(x => x.ExpiresAt)
             .IsInFuture(clock);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateTransmission/CreateTransmissionDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateTransmission/CreateTransmissionDto.cs
@@ -1,8 +1,10 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Common.Content;
 using Digdir.Domain.Dialogporten.Domain.Attachments;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.CreateTransmission;
@@ -41,7 +43,14 @@ public class CreateTransmissionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete($"Use '{nameof(AuthorizationContext)}' instead.")]
     public string? AuthorizationAttribute { get; set; }
+
+    /// <summary>
+    /// Describes the authorization inputs used when evaluating end user access to this transmission.
+    /// Cannot be combined with "authorizationAttribute".
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 
     /// <summary>
     /// Arbitrary URI/URN describing a service-specific transmission type.
@@ -132,6 +141,13 @@ public sealed class TransmissionAttachmentDto
     /// The UTC timestamp when the attachment expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Describes additional authorization inputs used when evaluating end user access to this attachment.
+    /// The XACML action defaults to "read". Access to the parent transmission is always required in addition;
+    /// this context can only further restrict access, never widen it.
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 }
 
 public sealed class TransmissionAttachmentUrlDto
@@ -172,4 +188,11 @@ public sealed class TransmissionNavigationalActionDto
     /// The UTC timestamp when the navigational action expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Describes additional authorization inputs used when evaluating end user access to this navigational action.
+    /// The XACML action defaults to "read". Access to the parent transmission is always required in addition; this
+    /// context can only further restrict access, never widen it.
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateTransmission/Mappers.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateTransmission/Mappers.cs
@@ -1,7 +1,10 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are mapped for backwards compatibility
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Domain.Attachments;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.CreateTransmission;
@@ -14,12 +17,13 @@ internal static class Mappers
             Id = source.Id ?? Guid.Empty,
             IdempotentKey = source.IdempotentKey,
             CreatedAt = source.CreatedAt,
-            AuthorizationAttribute = source.AuthorizationAttribute,
+            AuthorizationAttribute = source.AuthorizationAttribute.ToStoredTransmissionAttribute(source.AuthorizationContext),
             ExtendedType = source.ExtendedType,
             ExternalReference = source.ExternalReference,
             RelatedTransmissionId = source.RelatedTransmissionId,
             TypeId = source.Type,
             Sender = source.Sender.ToActor<DialogTransmissionSenderActor>(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogTransmissionAuthorizationContext>(),
             Content = source.Content.ToDialogTransmissionContentList() ?? [],
             Attachments = source.Attachments.Select(x => x.ToDialogTransmissionAttachment()).ToList(),
             NavigationalActions = source.NavigationalActions.Select(x => x.ToDialogTransmissionNavigationalAction()).ToList()
@@ -32,7 +36,8 @@ internal static class Mappers
             Name = source.Name,
             ExpiresAt = source.ExpiresAt,
             DisplayName = source.DisplayName.ToLocalizationSet<AttachmentDisplayName>(),
-            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList()
+            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<AttachmentAuthorizationContext>()
         };
 
     private static AttachmentUrl ToAttachmentUrl(this TransmissionAttachmentUrlDto source) =>
@@ -49,6 +54,7 @@ internal static class Mappers
         {
             Url = source.Url,
             ExpiresAt = source.ExpiresAt,
-            Title = source.Title.ToLocalizationSet<DialogTransmissionNavigationalActionTitle>()!
+            Title = source.Title.ToLocalizationSet<DialogTransmissionNavigationalActionTitle>()!,
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogTransmissionNavigationalActionAuthorizationContext>()
         };
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateTransmission/Validators/CreateTransmissionTransmissionAttachmentDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateTransmission/Validators/CreateTransmissionTransmissionAttachmentDtoValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -11,6 +12,7 @@ internal sealed class CreateTransmissionTransmissionAttachmentDtoValidator : Abs
     public CreateTransmissionTransmissionAttachmentDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
         IValidator<TransmissionAttachmentUrlDto> urlValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -27,5 +29,9 @@ internal sealed class CreateTransmissionTransmissionAttachmentDtoValidator : Abs
         RuleFor(x => x.Urls)
             .NotEmpty()
             .ForEach(x => x.SetValidator(urlValidator));
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateTransmission/Validators/CreateTransmissionTransmissionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateTransmission/Validators/CreateTransmissionTransmissionDtoValidator.cs
@@ -1,5 +1,7 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are validated for backwards compatibility
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -13,6 +15,7 @@ internal sealed class CreateTransmissionTransmissionDtoValidator : AbstractValid
         IValidator<TransmissionContentDto?> contentValidator,
         IValidator<TransmissionAttachmentDto> attachmentValidator,
         IValidator<TransmissionNavigationalActionDto> navigationalActionValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -48,6 +51,15 @@ internal sealed class CreateTransmissionTransmissionDtoValidator : AbstractValid
 
         RuleFor(x => x.AuthorizationAttribute)
             .IsValidAuthorizationAttribute();
+
+        RuleFor(x => x.AuthorizationAttribute)
+            .Null()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(CreateTransmissionDto.AuthorizationContext)}'.")
+            .When(x => x.AuthorizationContext is not null);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.Attachments)
             .UniqueBy(x => x.Id);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateTransmission/Validators/CreateTransmissionTransmissionNavigationalActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/CreateTransmission/Validators/CreateTransmissionTransmissionNavigationalActionDtoValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -10,6 +11,7 @@ internal sealed class CreateTransmissionTransmissionNavigationalActionDtoValidat
 {
     public CreateTransmissionTransmissionNavigationalActionDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Title)
@@ -23,5 +25,9 @@ internal sealed class CreateTransmissionTransmissionNavigationalActionDtoValidat
 
         RuleFor(x => x.ExpiresAt)
             .IsInFuture(clock);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Mappers.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Mappers.cs
@@ -1,4 +1,6 @@
 #pragma warning disable CS0618 // Obsolete legacy authorization fields are mapped for backwards compatibility
+using AuthorizationContextDto = Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts.AuthorizationContextDto;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
@@ -8,6 +10,7 @@ using Digdir.Domain.Dialogporten.Domain.Attachments;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 using Digdir.Domain.Dialogporten.Domain.Http;
 
@@ -73,12 +76,13 @@ public static class Mappers
             Id = source.Id ?? Guid.Empty,
             IdempotentKey = source.IdempotentKey,
             CreatedAt = source.CreatedAt,
-            AuthorizationAttribute = source.AuthorizationAttribute,
+            AuthorizationAttribute = source.AuthorizationAttribute.ToStoredTransmissionAttribute(source.AuthorizationContext),
             ExtendedType = source.ExtendedType,
             ExternalReference = source.ExternalReference,
             RelatedTransmissionId = source.RelatedTransmissionId,
             TypeId = source.Type,
             Sender = source.Sender.ToActor<DialogTransmissionSenderActor>(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogTransmissionAuthorizationContext>(),
             Content = source.Content.ToDialogTransmissionContentList() ?? [],
             Attachments = source.Attachments.Select(x => x.ToDialogTransmissionAttachment()).ToList(),
             NavigationalActions = source.NavigationalActions.Select(x => x.ToDialogTransmissionNavigationalAction()).ToList()
@@ -91,7 +95,8 @@ public static class Mappers
             Name = source.Name,
             ExpiresAt = source.ExpiresAt,
             DisplayName = source.DisplayName.ToLocalizationSet<AttachmentDisplayName>(),
-            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList()
+            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<AttachmentAuthorizationContext>()
         };
 
     internal static void UpdateFrom(this DialogAttachment destination, AttachmentDto source)
@@ -100,6 +105,7 @@ public static class Mappers
         destination.Name = source.Name;
         destination.ExpiresAt = source.ExpiresAt;
         destination.DisplayName = source.DisplayName.ToLocalizationSet(destination.DisplayName);
+        destination.AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext(destination.AuthorizationContext);
     }
 
     internal static AttachmentUrl ToAttachmentUrl(this AttachmentUrlDto source) =>
@@ -123,20 +129,21 @@ public static class Mappers
         new()
         {
             Id = source.Id ?? Guid.Empty,
-            Action = source.Action,
+            Action = source.Action.ToStoredLegacyAction(),
             Url = source.Url,
             AuthorizationAttribute = source.AuthorizationAttribute,
             IsDeleteDialogAction = source.IsDeleteDialogAction,
             PriorityId = source.Priority,
             HttpMethodId = source.HttpMethod ?? HttpVerb.Values.GET,
             Title = source.Title.ToLocalizationSet<DialogGuiActionTitle>(),
-            Prompt = source.Prompt.ToLocalizationSet<DialogGuiActionPrompt>()
+            Prompt = source.Prompt.ToLocalizationSet<DialogGuiActionPrompt>(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogGuiActionAuthorizationContext>()
         };
 
     internal static void UpdateFrom(this DialogGuiAction destination, GuiActionDto source)
     {
         destination.Id = source.Id ?? destination.Id;
-        destination.Action = source.Action;
+        destination.Action = source.Action.ToStoredLegacyAction();
         destination.Url = source.Url;
         destination.AuthorizationAttribute = source.AuthorizationAttribute;
         destination.IsDeleteDialogAction = source.IsDeleteDialogAction;
@@ -144,24 +151,27 @@ public static class Mappers
         destination.HttpMethodId = source.HttpMethod ?? HttpVerb.Values.GET;
         destination.Title = source.Title.ToLocalizationSet(destination.Title);
         destination.Prompt = source.Prompt.ToLocalizationSet(destination.Prompt);
+        destination.AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext(destination.AuthorizationContext);
     }
 
     internal static DialogApiAction ToDialogApiAction(this ApiActionDto source) =>
         new()
         {
             Id = source.Id ?? Guid.Empty,
-            Action = source.Action,
+            Action = source.Action.ToStoredLegacyAction(),
             AuthorizationAttribute = source.AuthorizationAttribute,
             Name = source.Name,
-            Endpoints = source.Endpoints.Select(x => x.ToDialogApiActionEndpoint()).ToList()
+            Endpoints = source.Endpoints.Select(x => x.ToDialogApiActionEndpoint()).ToList(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogApiActionAuthorizationContext>()
         };
 
     internal static void UpdateFrom(this DialogApiAction destination, ApiActionDto source)
     {
         destination.Id = source.Id ?? destination.Id;
-        destination.Action = source.Action;
+        destination.Action = source.Action.ToStoredLegacyAction();
         destination.AuthorizationAttribute = source.AuthorizationAttribute;
         destination.Name = source.Name;
+        destination.AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext(destination.AuthorizationContext);
     }
 
     internal static DialogApiActionEndpoint ToDialogApiActionEndpoint(this ApiActionEndpointDto source) =>
@@ -198,7 +208,8 @@ public static class Mappers
             Name = source.Name,
             ExpiresAt = source.ExpiresAt,
             DisplayName = source.DisplayName.ToLocalizationSet<AttachmentDisplayName>(),
-            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList()
+            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<AttachmentAuthorizationContext>()
         };
 
     private static AttachmentUrl ToAttachmentUrl(this TransmissionAttachmentUrlDto source) =>
@@ -215,7 +226,8 @@ public static class Mappers
         {
             Url = source.Url,
             ExpiresAt = source.ExpiresAt,
-            Title = source.Title.ToLocalizationSet<DialogTransmissionNavigationalActionTitle>()!
+            Title = source.Title.ToLocalizationSet<DialogTransmissionNavigationalActionTitle>()!,
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogTransmissionNavigationalActionAuthorizationContext>()
         };
 
     private static ContentDto? ToUpdateContentDto(
@@ -263,7 +275,8 @@ public static class Mappers
                 MediaType = x.MediaType,
                 ConsumerType = x.ConsumerType
             }).ToList(),
-            ExpiresAt = source.ExpiresAt
+            ExpiresAt = source.ExpiresAt,
+            AuthorizationContext = source.AuthorizationContext.Copy()
         };
 
     private static AttachmentDto ToUpdateAttachmentDto(this Features.V1.EndUser.Dialogs.Queries.Get.DialogAttachmentDto source) =>
@@ -289,6 +302,7 @@ public static class Mappers
             Action = source.Action,
             Url = source.Url,
             AuthorizationAttribute = source.AuthorizationAttribute,
+            AuthorizationContext = source.AuthorizationContext.Copy(),
             IsDeleteDialogAction = source.IsDeleteDialogAction,
             HttpMethod = source.HttpMethod,
             Priority = source.Priority,
@@ -296,6 +310,9 @@ public static class Mappers
             Prompt = source.Prompt.CopyOptional()
         };
 
+    // Note: end user DTOs do not expose authorization contexts, so a PUT built from an end user GET
+    // converts a context-based action into a legacy one (the coalesced action + no context). This
+    // overload is only used by test flows; the production PATCH path uses the service owner DTO.
     private static GuiActionDto ToUpdateGuiActionDto(this Features.V1.EndUser.Dialogs.Queries.Get.DialogGuiActionDto source) =>
         new()
         {
@@ -316,6 +333,7 @@ public static class Mappers
             Id = source.Id,
             Action = source.Action,
             AuthorizationAttribute = source.AuthorizationAttribute,
+            AuthorizationContext = source.AuthorizationContext.Copy(),
             Name = source.Name,
             Endpoints = source.Endpoints.Select(x => x.ToUpdateApiActionEndpointDto()).ToList()
         };
@@ -378,4 +396,17 @@ public static class Mappers
 
     private static List<LocalizationDto>? CopyOptional(this IEnumerable<LocalizationDto>? source) =>
         source?.Select(x => new LocalizationDto { LanguageCode = x.LanguageCode, Value = x.Value }).ToList();
+
+    private static AuthorizationContextDto? Copy(this Queries.Get.AuthorizationContextDto? source) =>
+        source is null
+            ? null
+            : new AuthorizationContextDto
+            {
+                ServiceResource = source.ServiceResource,
+                AdditionalResourceAttribute = source.AdditionalResourceAttribute,
+                Parties = [.. source.Parties],
+                IncludeDialogParty = source.IncludeDialogParty,
+                Action = source.Action,
+                UnauthorizedPresentation = source.UnauthorizedPresentation
+            };
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Mappers.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Mappers.cs
@@ -246,22 +246,6 @@ public static class Mappers
                 MainContentReference = source.MainContentReference.Copy()
             };
 
-    private static ContentDto? ToUpdateContentDto(
-        this Features.V1.EndUser.Dialogs.Queries.Get.ContentDto? source) =>
-        source is null
-            ? null
-            : new ContentDto
-            {
-                Title = source.Title.Copy()!,
-                NonSensitiveTitle = null,
-                Summary = source.Summary.Copy(),
-                NonSensitiveSummary = null,
-                SenderName = source.SenderName.Copy(),
-                AdditionalInfo = source.AdditionalInfo.Copy(),
-                ExtendedStatus = source.ExtendedStatus.Copy(),
-                MainContentReference = source.MainContentReference.Copy()
-            };
-
     private static AttachmentDto ToUpdateAttachmentDto(this DialogAttachmentDto source) =>
         new()
         {
@@ -279,22 +263,6 @@ public static class Mappers
             AuthorizationContext = source.AuthorizationContext.Copy()
         };
 
-    private static AttachmentDto ToUpdateAttachmentDto(this Features.V1.EndUser.Dialogs.Queries.Get.DialogAttachmentDto source) =>
-        new()
-        {
-            Id = source.Id,
-            DisplayName = source.DisplayName.CopyRequired(),
-            Name = source.Name,
-            Urls = source.Urls.Select(x => new AttachmentUrlDto
-            {
-                Id = x.Id,
-                Url = x.Url,
-                MediaType = x.MediaType,
-                ConsumerType = x.ConsumerType
-            }).ToList(),
-            ExpiresAt = source.ExpiresAt
-        };
-
     private static GuiActionDto ToUpdateGuiActionDto(this DialogGuiActionDto source) =>
         new()
         {
@@ -303,23 +271,6 @@ public static class Mappers
             Url = source.Url,
             AuthorizationAttribute = source.AuthorizationAttribute,
             AuthorizationContext = source.AuthorizationContext.Copy(),
-            IsDeleteDialogAction = source.IsDeleteDialogAction,
-            HttpMethod = source.HttpMethod,
-            Priority = source.Priority,
-            Title = source.Title.CopyRequired(),
-            Prompt = source.Prompt.CopyOptional()
-        };
-
-    // Note: end user DTOs do not expose authorization contexts, so a PUT built from an end user GET
-    // converts a context-based action into a legacy one (the coalesced action + no context). This
-    // overload is only used by test flows; the production PATCH path uses the service owner DTO.
-    private static GuiActionDto ToUpdateGuiActionDto(this Features.V1.EndUser.Dialogs.Queries.Get.DialogGuiActionDto source) =>
-        new()
-        {
-            Id = source.Id,
-            Action = source.Action,
-            Url = source.Url,
-            AuthorizationAttribute = source.AuthorizationAttribute,
             IsDeleteDialogAction = source.IsDeleteDialogAction,
             HttpMethod = source.HttpMethod,
             Priority = source.Priority,
@@ -338,33 +289,8 @@ public static class Mappers
             Endpoints = source.Endpoints.Select(x => x.ToUpdateApiActionEndpointDto()).ToList()
         };
 
-    private static ApiActionDto ToUpdateApiActionDto(this Features.V1.EndUser.Dialogs.Queries.Get.DialogApiActionDto source) =>
-        new()
-        {
-            Id = source.Id,
-            Action = source.Action,
-            AuthorizationAttribute = source.AuthorizationAttribute,
-            Name = source.Name,
-            Endpoints = source.Endpoints.Select(x => x.ToUpdateApiActionEndpointDto()).ToList()
-        };
-
     private static ApiActionEndpointDto ToUpdateApiActionEndpointDto(
         this DialogApiActionEndpointDto source) =>
-        new()
-        {
-            Id = source.Id,
-            Version = source.Version,
-            Url = source.Url,
-            HttpMethod = source.HttpMethod,
-            DocumentationUrl = source.DocumentationUrl,
-            RequestSchema = source.RequestSchema,
-            ResponseSchema = source.ResponseSchema,
-            Deprecated = source.Deprecated,
-            SunsetAt = source.SunsetAt
-        };
-
-    private static ApiActionEndpointDto ToUpdateApiActionEndpointDto(
-        this Features.V1.EndUser.Dialogs.Queries.Get.DialogApiActionEndpointDto source) =>
         new()
         {
             Id = source.Id,

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/UpdateDialogDto.cs
@@ -1,4 +1,5 @@
-﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
+﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
@@ -6,6 +7,7 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Dia
 using Digdir.Domain.Dialogporten.Domain.Attachments;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Activities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 using Digdir.Domain.Dialogporten.Domain.Http;
 
@@ -141,7 +143,14 @@ public sealed class TransmissionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete($"Use '{nameof(AuthorizationContext)}' instead.")]
     public string? AuthorizationAttribute { get; set; }
+
+    /// <summary>
+    /// Describes the authorization inputs used when evaluating end user access to this transmission.
+    /// Cannot be combined with "authorizationAttribute".
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 
     /// <summary>
     /// Arbitrary URI/URN describing a service-specific transmission type.
@@ -312,7 +321,8 @@ public sealed class ApiActionDto
     /// which by default is the policy belonging to the service referred to by "serviceResource" in the dialog.
     /// </summary>
     /// <example>write</example>
-    public string Action { get; set; } = null!;
+    [Obsolete($"Use '{nameof(AuthorizationContext)}.{nameof(AuthorizationContextDto.Action)}' instead.")]
+    public string? Action { get; set; }
 
     /// <summary>
     /// Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service
@@ -328,7 +338,15 @@ public sealed class ApiActionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete($"Use '{nameof(AuthorizationContext)}' instead.")]
     public string? AuthorizationAttribute { get; set; }
+
+    /// <summary>
+    /// Describes the authorization inputs used when evaluating end user access to this action.
+    /// Cannot be combined with "authorizationAttribute" or "action"; the XACML action is given by
+    /// "authorizationContext.action".
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 
     /// <summary>
     /// The logical name of the operation the API action refers to.
@@ -406,7 +424,8 @@ public sealed class GuiActionDto
     /// <summary>
     /// The action identifier for the action, corresponding to the "action" attributeId used in the XACML service policy.
     /// </summary>
-    public string Action { get; set; } = null!;
+    [Obsolete($"Use '{nameof(AuthorizationContext)}.{nameof(AuthorizationContextDto.Action)}' instead.")]
+    public string? Action { get; set; }
 
     /// <summary>
     /// The fully qualified URL of the action, to which the user will be redirected when the action is triggered. Will be set to
@@ -432,7 +451,15 @@ public sealed class GuiActionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete($"Use '{nameof(AuthorizationContext)}' instead.")]
     public string? AuthorizationAttribute { get; set; }
+
+    /// <summary>
+    /// Describes the authorization inputs used when evaluating end user access to this action.
+    /// Cannot be combined with "authorizationAttribute" or "action"; the XACML action is given by
+    /// "authorizationContext.action".
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 
     /// <summary>
     /// Indicates whether the action results in the dialog being deleted. Used by frontends to implement custom UX
@@ -491,6 +518,13 @@ public sealed class AttachmentDto
     /// The UTC timestamp when the attachment expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Describes additional authorization inputs used when evaluating end user access to this attachment.
+    /// The XACML action defaults to "read". Access to the parent is always required in addition; this context
+    /// can only further restrict access, never widen it.
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 }
 
 public sealed class AttachmentUrlDto
@@ -549,6 +583,13 @@ public sealed class TransmissionAttachmentDto
     /// The UTC timestamp when the attachment expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Describes additional authorization inputs used when evaluating end user access to this attachment.
+    /// The XACML action defaults to "read". Access to the parent is always required in addition; this context
+    /// can only further restrict access, never widen it.
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 }
 
 public sealed class TransmissionAttachmentUrlDto
@@ -589,4 +630,11 @@ public sealed class TransmissionNavigationalActionDto
     /// The UTC timestamp when the navigational action expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Describes additional authorization inputs used when evaluating end user access to this navigational action.
+    /// The XACML action defaults to "read". Access to the parent transmission is always required in addition; this
+    /// context can only further restrict access, never widen it.
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogApiActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogApiActionDtoValidator.cs
@@ -1,4 +1,6 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are validated for backwards compatibility
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
 
@@ -7,14 +9,31 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialog
 internal sealed class UpdateDialogDialogApiActionDtoValidator : AbstractValidator<ApiActionDto>
 {
     public UpdateDialogDialogApiActionDtoValidator(
-        IValidator<ApiActionEndpointDto> apiActionEndpointValidator)
+        IValidator<ApiActionEndpointDto> apiActionEndpointValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator)
     {
         RuleFor(x => x.Action)
             .NotEmpty()
-            .MaximumLength(Constants.DefaultMaxStringLength);
+            .WithMessage($"'{{PropertyName}}' must not be empty when '{nameof(ApiActionDto.AuthorizationContext)}' is not supplied.")
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .When(x => x.AuthorizationContext is null);
+
+        RuleFor(x => x.Action)
+            .Empty()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(ApiActionDto.AuthorizationContext)}'; use '{nameof(ApiActionDto.AuthorizationContext)}.{nameof(AuthorizationContextDto.Action)}' instead.")
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.AuthorizationAttribute)
             .IsValidAuthorizationAttribute();
+
+        RuleFor(x => x.AuthorizationAttribute)
+            .Null()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(ApiActionDto.AuthorizationContext)}'.")
+            .When(x => x.AuthorizationContext is not null);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.Name)
             .MaximumLength(Constants.DefaultMaxStringLength);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogAttachmentDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogAttachmentDtoValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -11,6 +12,7 @@ internal sealed class UpdateDialogDialogAttachmentDtoValidator : AbstractValidat
     public UpdateDialogDialogAttachmentDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
         IValidator<AttachmentUrlDto> urlValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -30,5 +32,9 @@ internal sealed class UpdateDialogDialogAttachmentDtoValidator : AbstractValidat
         RuleFor(x => x.Urls)
             .NotEmpty()
             .ForEach(x => x.SetValidator(urlValidator));
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogGuiActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogGuiActionDtoValidator.cs
@@ -1,4 +1,6 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are validated for backwards compatibility
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using Digdir.Domain.Dialogporten.Domain.Http;
@@ -9,11 +11,19 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialog
 internal sealed class UpdateDialogDialogGuiActionDtoValidator : AbstractValidator<GuiActionDto>
 {
     public UpdateDialogDialogGuiActionDtoValidator(
-        IValidator<IEnumerable<LocalizationDto>> localizationsValidator)
+        IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator)
     {
         RuleFor(x => x.Action)
             .NotEmpty()
-            .MaximumLength(Constants.DefaultMaxStringLength);
+            .WithMessage($"'{{PropertyName}}' must not be empty when '{nameof(GuiActionDto.AuthorizationContext)}' is not supplied.")
+            .MaximumLength(Constants.DefaultMaxStringLength)
+            .When(x => x.AuthorizationContext is null);
+
+        RuleFor(x => x.Action)
+            .Empty()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(GuiActionDto.AuthorizationContext)}'; use '{nameof(GuiActionDto.AuthorizationContext)}.{nameof(AuthorizationContextDto.Action)}' instead.")
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.Url)
             .NotNull()
@@ -22,6 +32,15 @@ internal sealed class UpdateDialogDialogGuiActionDtoValidator : AbstractValidato
 
         RuleFor(x => x.AuthorizationAttribute)
             .IsValidAuthorizationAttribute();
+
+        RuleFor(x => x.AuthorizationAttribute)
+            .Null()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(GuiActionDto.AuthorizationContext)}'.")
+            .When(x => x.AuthorizationContext is not null);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.Priority)
             .IsInEnum();

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogTransmissionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogDialogTransmissionDtoValidator.cs
@@ -1,5 +1,7 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are validated for backwards compatibility
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -13,6 +15,7 @@ internal sealed class UpdateDialogDialogTransmissionDtoValidator : AbstractValid
         IValidator<TransmissionContentDto?> contentValidator,
         IValidator<TransmissionAttachmentDto> attachmentValidator,
         IValidator<TransmissionNavigationalActionDto> navigationalActionValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -44,6 +47,15 @@ internal sealed class UpdateDialogDialogTransmissionDtoValidator : AbstractValid
 
         RuleFor(x => x.AuthorizationAttribute)
             .IsValidAuthorizationAttribute();
+
+        RuleFor(x => x.AuthorizationAttribute)
+            .Null()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(TransmissionDto.AuthorizationContext)}'.")
+            .When(x => x.AuthorizationContext is not null);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.Attachments)
             .UniqueBy(x => x.Id);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogTransmissionAttachmentDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogTransmissionAttachmentDtoValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -11,6 +12,7 @@ internal sealed class UpdateDialogTransmissionAttachmentDtoValidator : AbstractV
     public UpdateDialogTransmissionAttachmentDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
         IValidator<TransmissionAttachmentUrlDto> urlValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -27,5 +29,9 @@ internal sealed class UpdateDialogTransmissionAttachmentDtoValidator : AbstractV
         RuleFor(x => x.Urls)
             .NotEmpty()
             .ForEach(x => x.SetValidator(urlValidator));
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogTransmissionNavigationalActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/Update/Validators/UpdateDialogTransmissionNavigationalActionDtoValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -10,6 +11,7 @@ internal sealed class UpdateDialogTransmissionNavigationalActionDtoValidator : A
 {
     public UpdateDialogTransmissionNavigationalActionDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Title)
@@ -23,5 +25,9 @@ internal sealed class UpdateDialogTransmissionNavigationalActionDtoValidator : A
 
         RuleFor(x => x.ExpiresAt)
             .IsInFuture(clock);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/Mappers.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/Mappers.cs
@@ -1,7 +1,10 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are mapped for backwards compatibility
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Domain.Attachments;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.UpdateTransmission;
@@ -17,12 +20,14 @@ internal static class Mappers
         }
 
         destination.IdempotentKey = source.IdempotentKey;
-        destination.AuthorizationAttribute = source.AuthorizationAttribute;
+        destination.AuthorizationAttribute = source.AuthorizationAttribute.ToStoredTransmissionAttribute(source.AuthorizationContext);
         destination.ExtendedType = source.ExtendedType;
         destination.ExternalReference = source.ExternalReference;
         destination.RelatedTransmissionId = source.RelatedTransmissionId;
         destination.TypeId = source.Type;
         destination.Sender = source.Sender.ToActor<DialogTransmissionSenderActor>();
+        destination.AuthorizationContext = source.AuthorizationContext
+            .ToAuthorizationContext(destination.AuthorizationContext);
         destination.Content = source.Content.ToDialogTransmissionContentList(destination.Content) ?? [];
         destination.NavigationalActions = source.NavigationalActions
             .Select(x => x.ToDialogTransmissionNavigationalAction())
@@ -36,7 +41,8 @@ internal static class Mappers
             Name = source.Name,
             ExpiresAt = source.ExpiresAt,
             DisplayName = source.DisplayName.ToLocalizationSet<AttachmentDisplayName>(),
-            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList()
+            Urls = source.Urls.Select(x => x.ToAttachmentUrl()).ToList(),
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<AttachmentAuthorizationContext>()
         };
 
     // Urls are merged separately by the handler.
@@ -45,6 +51,8 @@ internal static class Mappers
         destination.Name = source.Name;
         destination.ExpiresAt = source.ExpiresAt;
         destination.DisplayName = source.DisplayName.ToLocalizationSet(destination.DisplayName);
+        destination.AuthorizationContext = source.AuthorizationContext
+            .ToAuthorizationContext(destination.AuthorizationContext);
     }
 
     internal static AttachmentUrl ToAttachmentUrl(this TransmissionAttachmentUrlDto source) =>
@@ -70,6 +78,7 @@ internal static class Mappers
         {
             Url = source.Url,
             ExpiresAt = source.ExpiresAt,
-            Title = source.Title.ToLocalizationSet<DialogTransmissionNavigationalActionTitle>()!
+            Title = source.Title.ToLocalizationSet<DialogTransmissionNavigationalActionTitle>()!,
+            AuthorizationContext = source.AuthorizationContext.ToAuthorizationContext<DialogTransmissionNavigationalActionAuthorizationContext>()
         };
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/UpdateTransmissionCommand.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/UpdateTransmissionCommand.cs
@@ -103,7 +103,7 @@ internal sealed class UpdateTransmissionCommandHandler : IRequestHandler<UpdateT
                 delete: DeleteDelegate.Default);
 
         // Authorization of referenced service resources must happen after the incoming DTO has been
-        // mapped onto the aggregate, so that incoming authorization attributes are covered.
+        // mapped onto the aggregate, so that incoming authorization attributes/contexts are covered.
         var authorizeResult = await _serviceResourceAuthorizer.AuthorizeServiceResources(dialog, cancellationToken);
         if (authorizeResult.Value is Forbidden forbidden)
         {
@@ -218,6 +218,14 @@ internal sealed class UpdateTransmissionCommandHandler : IRequestHandler<UpdateT
                         .ThenInclude(x => x.Localizations)
             .Include(x => x.Transmissions)
                 .ThenInclude(x => x.Sender)
+            .Include(x => x.Transmissions)
+                .ThenInclude(x => x.AuthorizationContext)
+            .Include(x => x.Transmissions)
+                .ThenInclude(x => x.Attachments)
+                    .ThenInclude(x => x.AuthorizationContext)
+            .Include(x => x.Transmissions)
+                .ThenInclude(x => x.NavigationalActions)
+                    .ThenInclude(x => x.AuthorizationContext)
             .IgnoreQueryFilters()
             .WhereIf(!isAdmin, x => x.Org == org)
             .FirstOrDefaultAsync(x => x.Id == dialogId, cancellationToken);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/UpdateTransmissionDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/UpdateTransmissionDto.cs
@@ -1,8 +1,10 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Common.Content;
 using Digdir.Domain.Dialogporten.Domain.Attachments;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.UpdateTransmission;
@@ -33,7 +35,14 @@ public class UpdateTransmissionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete($"Use '{nameof(AuthorizationContext)}' instead.")]
     public string? AuthorizationAttribute { get; set; }
+
+    /// <summary>
+    /// Describes the authorization inputs used when evaluating end user access to this transmission.
+    /// Cannot be combined with "authorizationAttribute".
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 
     /// <summary>
     /// Arbitrary URI/URN describing a service-specific transmission type.
@@ -124,6 +133,13 @@ public sealed class TransmissionAttachmentDto
     /// The UTC timestamp when the attachment expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Describes additional authorization inputs used when evaluating end user access to this attachment.
+    /// The XACML action defaults to "read". Access to the parent transmission is always required in addition;
+    /// this context can only further restrict access, never widen it.
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 }
 
 public sealed class TransmissionAttachmentUrlDto
@@ -170,4 +186,11 @@ public sealed class TransmissionNavigationalActionDto
     /// The UTC timestamp when the navigational action expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Describes additional authorization inputs used when evaluating end user access to this navigational action.
+    /// The XACML action defaults to "read". Access to the parent transmission is always required in addition; this
+    /// context can only further restrict access, never widen it.
+    /// </summary>
+    public AuthorizationContextDto? AuthorizationContext { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/Validators/UpdateTransmissionTransmissionAttachmentDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/Validators/UpdateTransmissionTransmissionAttachmentDtoValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -11,6 +12,7 @@ internal sealed class UpdateTransmissionTransmissionAttachmentDtoValidator : Abs
     public UpdateTransmissionTransmissionAttachmentDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
         IValidator<TransmissionAttachmentUrlDto> urlValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Id)
@@ -27,5 +29,9 @@ internal sealed class UpdateTransmissionTransmissionAttachmentDtoValidator : Abs
         RuleFor(x => x.Urls)
             .NotEmpty()
             .ForEach(x => x.SetValidator(urlValidator));
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/Validators/UpdateTransmissionTransmissionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/Validators/UpdateTransmissionTransmissionDtoValidator.cs
@@ -1,4 +1,6 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are validated for backwards compatibility
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -11,7 +13,8 @@ internal sealed class UpdateTransmissionTransmissionDtoValidator : AbstractValid
         IValidator<ActorDto> actorValidator,
         IValidator<TransmissionContentDto?> contentValidator,
         IValidator<TransmissionAttachmentDto> attachmentValidator,
-        IValidator<TransmissionNavigationalActionDto> navigationalActionValidator)
+        IValidator<TransmissionNavigationalActionDto> navigationalActionValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator)
     {
         // CreatedAt is not validated for InPast,
         // Dialog.VisibleFrom could have set the transmission
@@ -38,6 +41,15 @@ internal sealed class UpdateTransmissionTransmissionDtoValidator : AbstractValid
 
         RuleFor(x => x.AuthorizationAttribute)
             .IsValidAuthorizationAttribute();
+
+        RuleFor(x => x.AuthorizationAttribute)
+            .Null()
+            .WithMessage($"'{{PropertyName}}' cannot be combined with '{nameof(UpdateTransmissionDto.AuthorizationContext)}'.")
+            .When(x => x.AuthorizationContext is not null);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
 
         RuleFor(x => x.Attachments)
             .UniqueBy(x => x.Id);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/Validators/UpdateTransmissionTransmissionNavigationalActionDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Commands/UpdateTransmission/Validators/UpdateTransmissionTransmissionNavigationalActionDtoValidator.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.FluentValidation;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Domain.Common;
 using FluentValidation;
@@ -10,6 +11,7 @@ internal sealed class UpdateTransmissionTransmissionNavigationalActionDtoValidat
 {
     public UpdateTransmissionTransmissionNavigationalActionDtoValidator(
         IValidator<IEnumerable<LocalizationDto>> localizationsValidator,
+        IValidator<AuthorizationContextDto> authorizationContextValidator,
         IClock clock)
     {
         RuleFor(x => x.Title)
@@ -23,5 +25,9 @@ internal sealed class UpdateTransmissionTransmissionNavigationalActionDtoValidat
 
         RuleFor(x => x.ExpiresAt)
             .IsInFuture(clock);
+
+        RuleFor(x => x.AuthorizationContext)
+            .SetValidator(authorizationContextValidator!)
+            .When(x => x.AuthorizationContext is not null);
     }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Swagger/OpenApiTypeNameOverrides.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Swagger/OpenApiTypeNameOverrides.cs
@@ -23,6 +23,7 @@ internal static class OpenApiTypeNameOverrides
         ["DigdirDomainDialogportenApplicationCommon_Link"] = "Links",
         ["Http_HttpVerb"] = "HttpVerb",
         ["ProblemDetails_Error"] = "ProblemDetailsError",
+        ["V1CommonAuthorizationContexts_AuthorizationContext"] = "AuthorizationContextInput",
         ["V1CommonContent_ContentValue"] = "ContentValue",
         ["V1CommonLocalizations_Localization"] = "Localization",
         // The service resource metadata item types are shared by the public metadata endpoint and the

--- a/src/Digdir.Tool.Dialogporten.GenerateFakeData/DialogGenerator.cs
+++ b/src/Digdir.Tool.Dialogporten.GenerateFakeData/DialogGenerator.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are used for backwards compatibility
 using Bogus;
 using System.Globalization;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/ApplicationFlow/IFlowStepExtensions.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/ApplicationFlow/IFlowStepExtensions.cs
@@ -329,6 +329,17 @@ public static class IFlowStepExtensions
                     IdempotentKey = transmission.IdempotentKey,
                     CreatedAt = transmission.CreatedAt,
                     AuthorizationAttribute = transmission.AuthorizationAttribute,
+                    AuthorizationContext = transmission.AuthorizationContext is null
+                        ? null
+                        : new()
+                        {
+                            ServiceResource = transmission.AuthorizationContext.ServiceResource,
+                            AdditionalResourceAttribute = transmission.AuthorizationContext.AdditionalResourceAttribute,
+                            Parties = [.. transmission.AuthorizationContext.Parties],
+                            IncludeDialogParty = transmission.AuthorizationContext.IncludeDialogParty,
+                            Action = transmission.AuthorizationContext.Action,
+                            UnauthorizedPresentation = transmission.AuthorizationContext.UnauthorizedPresentation
+                        },
                     ExtendedType = transmission.ExtendedType,
                     ExternalReference = transmission.ExternalReference,
                     RelatedTransmissionId = transmission.RelatedTransmissionId,
@@ -350,13 +361,15 @@ public static class IFlowStepExtensions
                             MediaType = x.MediaType,
                             ConsumerType = x.ConsumerType
                         }).ToList(),
-                        ExpiresAt = x.ExpiresAt
+                        ExpiresAt = x.ExpiresAt,
+                        AuthorizationContext = x.AuthorizationContext.ToUpdateTransmissionChildContext()
                     }).ToList(),
                     NavigationalActions = transmission.NavigationalActions.Select(x => new TransmissionNavigationalActionDto
                     {
                         Title = x.Title,
                         Url = x.Url,
                         ExpiresAt = x.ExpiresAt,
+                        AuthorizationContext = x.AuthorizationContext.ToUpdateTransmissionChildContext()
                     }).ToList(),
                 };
 
@@ -696,4 +709,19 @@ public static class IFlowStepExtensions
     }
 
     private static GetDialogQuerySO CreateGetServiceOwnerDialogQuery(Guid id) => new() { DialogId = id };
+
+    private static Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts.AuthorizationContextDto? ToUpdateTransmissionChildContext(
+        this Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get.AuthorizationContextDto? source) =>
+        source is null
+            ? null
+            : new()
+            {
+                ServiceResource = source.ServiceResource,
+                AdditionalResourceAttribute = source.AdditionalResourceAttribute,
+                Parties = [.. source.Parties],
+                IncludeDialogParty = source.IncludeDialogParty,
+                Action = source.Action,
+                UnauthorizedPresentation = source.UnauthorizedPresentation
+            };
+
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogAuthorizationContextTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogAuthorizationContextTests.cs
@@ -135,6 +135,26 @@ public class CreateDialogAuthorizationContextTests(DialogApplication application
     }
 
     [Fact]
+    public async Task Create_Should_Normalize_A_Whitespace_Legacy_Action_To_The_Sentinel()
+    {
+        await FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddGuiAction(guiAction =>
+                {
+                    // Passes the exclusivity rule, which is expressed with FluentValidation's Empty() and
+                    // therefore counts a whitespace-only string as empty. Persisted verbatim it would read
+                    // back through EffectiveLegacyAction as a legacy action that shadows the context's.
+                    guiAction.Action = " ";
+                    guiAction.AuthorizationContext = CreateContext();
+                }))
+            .ExecuteAndAssert<CreateDialogSuccess>();
+
+        var guiAction = (await Application.GetDbEntities<DialogGuiAction>()).Should().ContainSingle().Subject;
+        guiAction.Action.Should().BeEmpty();
+        guiAction.EffectiveLegacyAction.Should().BeNull();
+    }
+
+    [Fact]
     public Task Create_Should_Fail_When_Transmission_Combines_AuthorizationAttribute_And_Context() =>
         FlowBuilder.For(Application)
             .CreateSimpleDialog((x, _) =>

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogAuthorizationContextTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogAuthorizationContextTests.cs
@@ -242,6 +242,42 @@ public class CreateDialogAuthorizationContextTests(DialogApplication application
             .ExecuteAndAssert<CreateDialogSuccess>();
 
     [Fact]
+    public Task Create_Should_Fail_When_Context_Parties_Is_Explicit_Null_And_No_DialogParty() =>
+        // An explicit JSON "parties": null replaces the DTO's [] initializer, reaching the validator and
+        // mapper as an actual null; the DTO normalizes it to [] so this fails validation cleanly instead of
+        // throwing (a NullReferenceException surfaced as a 500).
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = CreateContext(c =>
+                    {
+                        c.Action = null;
+                        c.Parties = null!;
+                        c.IncludeDialogParty = false;
+                    });
+                }))
+            .ExecuteAndAssert<ValidationError>(x =>
+                x.Errors.Should().Contain(e => e.ErrorMessage.Contains("at least one party")));
+
+    [Fact]
+    public Task Create_Should_Succeed_When_Context_Parties_Is_Explicit_Null_But_Includes_DialogParty() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = CreateContext(c =>
+                    {
+                        c.Action = null;
+                        c.Parties = null!;
+                        c.IncludeDialogParty = true;
+                    });
+                }))
+            .ExecuteAndAssert<CreateDialogSuccess>();
+
+    [Fact]
     public Task Create_Should_Fail_When_Context_Party_Is_Invalid() =>
         FlowBuilder.For(Application)
             .CreateSimpleDialog((x, _) =>

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogAuthorizationContextTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/CreateDialogAuthorizationContextTests.cs
@@ -1,0 +1,340 @@
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
+using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
+using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Commands.Create;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common.ApplicationFlow;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.Common.Extensions;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
+using AwesomeAssertions;
+using DialogDtoSO = Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Queries.Get.DialogDto;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.ServiceOwner.Dialogs.Commands.Create;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class CreateDialogAuthorizationContextTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    private const string OtherParty = "urn:altinn:organization:identifier-no:991825827";
+
+    private static AuthorizationContextDto CreateContext(Action<AuthorizationContextDto>? modify = null)
+    {
+        var context = new AuthorizationContextDto
+        {
+            ServiceResource = "urn:altinn:resource:some-other-service",
+            AdditionalResourceAttribute = "urn:altinn:task:Task_1",
+            Parties = [OtherParty],
+            IncludeDialogParty = true,
+            Action = "read",
+            UnauthorizedPresentation = AuthorizationContextUnauthorizedPresentation.Values.Excluded
+        };
+        modify?.Invoke(context);
+        return context;
+    }
+
+    private static AuthorizationContextDto CreateChildContext(Action<AuthorizationContextDto>? modify = null)
+    {
+        var context = new AuthorizationContextDto
+        {
+            AdditionalResourceAttribute = "urn:altinn:subresource:secret",
+            Parties = [OtherParty],
+            UnauthorizedPresentation = AuthorizationContextUnauthorizedPresentation.Values.Disabled
+        };
+        modify?.Invoke(context);
+        return context;
+    }
+
+    [Fact]
+    public Task Create_With_AuthorizationContext_On_All_Carriers_Should_RoundTrip() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.AuthorizationContext = CreateContext();
+                });
+                x.AddApiAction(apiAction =>
+                {
+                    apiAction.Action = null;
+                    apiAction.AuthorizationContext = CreateContext(c => c.Action = "write");
+                });
+                x.AddAttachment(attachment => attachment.AuthorizationContext = CreateChildContext());
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = CreateContext(c => c.Action = null);
+                    transmission.AddAttachment(attachment => attachment.AuthorizationContext = CreateChildContext());
+                    transmission.AddNavigationalAction(navigationalAction => navigationalAction.AuthorizationContext = CreateChildContext());
+                });
+            })
+            .GetServiceOwnerDialog()
+            .ExecuteAndAssert<DialogDtoSO>(x =>
+            {
+                var guiAction = x.GuiActions.Single();
+                // Read back as the empty-string sentinel, not null: the column stays NOT NULL
+                guiAction.Action.Should().BeEmpty();
+                guiAction.AuthorizationAttribute.Should().BeNull();
+                guiAction.AuthorizationContext.Should().NotBeNull();
+                guiAction.AuthorizationContext!.ServiceResource.Should().Be("urn:altinn:resource:some-other-service");
+                guiAction.AuthorizationContext.AdditionalResourceAttribute.Should().Be("urn:altinn:task:Task_1");
+                guiAction.AuthorizationContext.Parties.Should().BeEquivalentTo([OtherParty]);
+                guiAction.AuthorizationContext.IncludeDialogParty.Should().BeTrue();
+                guiAction.AuthorizationContext.Action.Should().Be("read");
+                guiAction.AuthorizationContext.UnauthorizedPresentation.Should().Be(AuthorizationContextUnauthorizedPresentation.Values.Excluded);
+
+                var apiAction = x.ApiActions.Single();
+                apiAction.Action.Should().BeEmpty();
+                apiAction.AuthorizationContext.Should().NotBeNull();
+                apiAction.AuthorizationContext!.Action.Should().Be("write");
+
+                var attachment = x.Attachments.Single();
+                attachment.AuthorizationContext.Should().NotBeNull();
+                attachment.AuthorizationContext!.AdditionalResourceAttribute.Should().Be("urn:altinn:subresource:secret");
+                attachment.AuthorizationContext.UnauthorizedPresentation.Should().Be(AuthorizationContextUnauthorizedPresentation.Values.Disabled);
+
+                var transmission = x.Transmissions.Single();
+                // The "dp-excluded" rollback sentinel is persisted but suppressed on read
+                transmission.AuthorizationAttribute.Should().BeNull();
+                transmission.AuthorizationContext.Should().NotBeNull();
+                transmission.AuthorizationContext!.Action.Should().BeNull();
+                transmission.Attachments.Should().ContainSingle(a => a.AuthorizationContext != null);
+                transmission.NavigationalActions.Should().ContainSingle(a => a.AuthorizationContext != null);
+            });
+
+    [Fact]
+    public async Task Create_Should_Persist_Sentinels_Rather_Than_Nulls_For_Context_Carrying_Entities()
+    {
+        await FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.AuthorizationContext = CreateContext();
+                });
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = CreateContext(c => c.Action = null);
+                });
+            })
+            .ExecuteAndAssert<CreateDialogSuccess>();
+
+        // Empty rather than null, so the Action column stays NOT NULL and code predating authorization
+        // contexts can still materialize the row - and denies the action, since nothing is named "".
+        var guiActions = await Application.GetDbEntities<DialogGuiAction>();
+        guiActions.Should().ContainSingle().Which.Action.Should().BeEmpty();
+
+        // The rollback sentinel, so that same code keeps the transmission hidden instead of falling
+        // through to the dialog's main resource. Inert while authorization contexts are understood.
+        var transmissions = await Application.GetDbEntities<DialogTransmission>();
+        transmissions.Should().ContainSingle()
+            .Which.AuthorizationAttribute.Should().Be(Constants.ExcludedTransmissionAttribute);
+    }
+
+    [Fact]
+    public Task Create_Should_Fail_When_Transmission_Combines_AuthorizationAttribute_And_Context() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = "element1";
+                    transmission.AuthorizationContext = CreateContext(c => c.Action = null);
+                }))
+            .ExecuteAndAssert<ValidationError>(x =>
+                x.Errors.Should().Contain(e => e.ErrorMessage.Contains("cannot be combined")));
+
+    [Fact]
+    public Task Create_Should_Fail_When_ApiAction_Combines_Action_And_Context() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddApiAction(apiAction =>
+                {
+                    apiAction.Action = "Test action";
+                    apiAction.AuthorizationContext = CreateContext();
+                }))
+            .ExecuteAndAssert<ValidationError>(x =>
+                x.Errors.Should().Contain(e => e.ErrorMessage.Contains("cannot be combined")));
+
+    [Fact]
+    public Task Create_Should_Fail_When_GuiAction_Combines_AuthorizationAttribute_And_Context() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.AuthorizationAttribute = "element1";
+                    guiAction.AuthorizationContext = CreateContext();
+                }))
+            .ExecuteAndAssert<ValidationError>(x =>
+                x.Errors.Should().Contain(e => e.ErrorMessage.Contains("cannot be combined")));
+
+    [Fact]
+    public Task Create_Should_Succeed_When_ApiAction_Context_Is_Missing_Action() =>
+        // The context action is optional everywhere and defaults to "read"
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddApiAction(apiAction =>
+                {
+                    apiAction.Action = null;
+                    apiAction.AuthorizationContext = CreateContext(c => c.Action = null);
+                }))
+            .ExecuteAndAssert<CreateDialogSuccess>(x => x.DialogId.Should().NotBeEmpty());
+
+    [Fact]
+    public Task Create_Should_Fail_When_GuiAction_Has_Neither_Action_Nor_Context() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddGuiAction(guiAction => guiAction.Action = null))
+            .ExecuteAndAssert<ValidationError>(x =>
+                x.Errors.Should().Contain(e => e.PropertyName.Contains("Action")));
+
+    [Fact]
+    public Task Create_Should_Fail_When_UnauthorizedPresentation_Is_Not_Supplied() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = CreateContext(c =>
+                    {
+                        c.Action = null;
+                        // Simulates an omitted "unauthorizedPresentation" in the JSON payload
+                        c.UnauthorizedPresentation = default;
+                    });
+                }))
+            .ExecuteAndAssert<ValidationError>(x =>
+                x.Errors.Should().Contain(e => e.ErrorMessage.Contains("required")));
+
+    [Fact]
+    public Task Create_Should_Fail_When_Context_Has_No_Parties_And_No_DialogParty() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = CreateContext(c =>
+                    {
+                        c.Action = null;
+                        c.Parties = [];
+                        c.IncludeDialogParty = false;
+                    });
+                }))
+            .ExecuteAndAssert<ValidationError>(x =>
+                x.Errors.Should().Contain(e => e.ErrorMessage.Contains("at least one party")));
+
+    [Fact]
+    public Task Create_Should_Succeed_When_Context_Has_No_Parties_But_Includes_DialogParty() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = CreateContext(c =>
+                    {
+                        c.Action = null;
+                        c.Parties = [];
+                        c.IncludeDialogParty = true;
+                    });
+                }))
+            .ExecuteAndAssert<CreateDialogSuccess>();
+
+    [Fact]
+    public Task Create_Should_Fail_When_Context_Party_Is_Invalid() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = CreateContext(c =>
+                    {
+                        c.Action = null;
+                        c.Parties = ["not-a-party"];
+                    });
+                }))
+            .ExecuteAndAssert<ValidationError>();
+
+    [Fact]
+    public Task Create_Should_Fail_When_Context_Has_Too_Many_Parties() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = CreateContext(c =>
+                    {
+                        c.Action = null;
+                        c.Parties = Enumerable.Range(0, AuthorizationContext.MaxNumberOfParties + 1)
+                            .Select(i => $"urn:altinn:organization:identifier-no:{910000000 + i}")
+                            .ToList();
+                    });
+                }))
+            .ExecuteAndAssert<ValidationError>(x =>
+                x.Errors.Should().Contain(e => e.ErrorMessage.Contains("cannot contain more than")));
+
+    [Fact]
+    public Task Create_Should_Fail_When_AdditionalResourceAttribute_Contains_Resource_Reference() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = CreateContext(c =>
+                    {
+                        c.Action = null;
+                        c.AdditionalResourceAttribute = "urn:altinn:resource:sneaky-resource";
+                    });
+                }))
+            .ExecuteAndAssert<ValidationError>(x =>
+                x.Errors.Should().Contain(e => e.ErrorMessage.Contains("ServiceResource")));
+
+    [Fact]
+    public Task Update_Should_Replace_Context_On_GuiAction() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.AuthorizationContext = CreateContext();
+                }))
+            .UpdateDialog(x =>
+            {
+                var guiAction = x.Dto.GuiActions.Single();
+                guiAction.AuthorizationContext.Should().NotBeNull();
+                guiAction.AuthorizationContext!.Parties = [OtherParty, "urn:altinn:organization:identifier-no:310778737"];
+                guiAction.AuthorizationContext.UnauthorizedPresentation = AuthorizationContextUnauthorizedPresentation.Values.Disabled;
+            })
+            .GetServiceOwnerDialog()
+            .ExecuteAndAssert<DialogDtoSO>(x =>
+            {
+                var guiAction = x.GuiActions.Single();
+                guiAction.AuthorizationContext.Should().NotBeNull();
+                guiAction.AuthorizationContext!.Parties.Should().HaveCount(2);
+                guiAction.AuthorizationContext.UnauthorizedPresentation.Should().Be(AuthorizationContextUnauthorizedPresentation.Values.Disabled);
+            });
+
+    [Fact]
+    public Task Update_Should_Remove_Context_And_Allow_Legacy_Fields_Again() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.AuthorizationContext = CreateContext();
+                }))
+            .UpdateDialog(x =>
+            {
+                var guiAction = x.Dto.GuiActions.Single();
+                guiAction.AuthorizationContext = null;
+                guiAction.Action = "read";
+            })
+            .GetServiceOwnerDialog()
+            .ExecuteAndAssert<DialogDtoSO>(x =>
+            {
+                var guiAction = x.GuiActions.Single();
+                guiAction.AuthorizationContext.Should().BeNull();
+                guiAction.Action.Should().Be("read");
+            });
+}

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/Snapshots/CreateDialogSnapshotTests.Create_Complex_Dialog_Then_Get_Verify_Snapshot.verified.json
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Create/Snapshots/CreateDialogSnapshotTests.Create_Complex_Dialog_Then_Get_Verify_Snapshot.verified.json
@@ -142,7 +142,9 @@
           "consumerType": "Api"
         }
       ],
-      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+      "authorizationContext": null,
+      "isAuthorized": true
     }
   ],
   "transmissions": [
@@ -151,6 +153,7 @@
       "idempotentKey": null,
       "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
       "authorizationAttribute": "urn:altinn:resource:ttd-dialogporten-automated-tests-correspondence",
+      "authorizationContext": null,
       "isAuthorized": true,
       "extendedType": null,
       "externalReference": "first-transmission",
@@ -193,6 +196,7 @@
       "idempotentKey": "idempotent-key",
       "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
       "authorizationAttribute": "someunavailablesubresource",
+      "authorizationContext": null,
       "isAuthorized": false,
       "extendedType": "https://digdir.com/transmission-type",
       "externalReference": "second-transmission",
@@ -260,7 +264,9 @@
               "consumerType": "Api"
             }
           ],
-          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+          "authorizationContext": null,
+          "isAuthorized": false
         }
       ],
       "navigationalActions": [
@@ -272,7 +278,9 @@
             }
           ],
           "url": "https://altinn.no/create-dialog-transmission-navigation",
-          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+          "authorizationContext": null,
+          "isAuthorized": false
         }
       ]
     }
@@ -283,6 +291,7 @@
       "action": "read",
       "url": "https://digdir.no/",
       "authorizationAttribute": "urn:altinn:resource:ttd-dialogporten-automated-tests-correspondence",
+      "authorizationContext": null,
       "isAuthorized": true,
       "isDeleteDialogAction": false,
       "priority": "Primary",
@@ -300,6 +309,7 @@
       "action": "read",
       "url": "https://digdir.no/",
       "authorizationAttribute": null,
+      "authorizationContext": null,
       "isAuthorized": true,
       "isDeleteDialogAction": false,
       "priority": "Secondary",
@@ -323,6 +333,7 @@
       "id": "00000000-0000-0000-0000-000000000000",
       "action": "some_unauthorized_action",
       "authorizationAttribute": "urn:altinn:resource:ttd-dialogporten-automated-tests-correspondence",
+      "authorizationContext": null,
       "isAuthorized": false,
       "name": "confirm",
       "endpoints": [

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Update/Snapshots/UpdateDialogSnapshotTests.Patch_Dialog_Then_Get_Verify_Snapshot.verified.json
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Update/Snapshots/UpdateDialogSnapshotTests.Patch_Dialog_Then_Get_Verify_Snapshot.verified.json
@@ -123,7 +123,9 @@
           "consumerType": "Gui"
         }
       ],
-      "expiresAt": null
+      "expiresAt": null,
+      "authorizationContext": null,
+      "isAuthorized": null
     },
     {
       "id": "00000000-0000-0000-0000-000000000000",
@@ -142,7 +144,9 @@
           "consumerType": "Gui"
         }
       ],
-      "expiresAt": null
+      "expiresAt": null,
+      "authorizationContext": null,
+      "isAuthorized": null
     },
     {
       "id": "00000000-0000-0000-0000-000000000000",
@@ -161,7 +165,9 @@
           "consumerType": "Gui"
         }
       ],
-      "expiresAt": null
+      "expiresAt": null,
+      "authorizationContext": null,
+      "isAuthorized": null
     }
   ],
   "transmissions": [
@@ -170,6 +176,7 @@
       "idempotentKey": null,
       "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
       "authorizationAttribute": "urn:altinn:resource:ttd-dialogporten-automated-tests-correspondence",
+      "authorizationContext": null,
       "isAuthorized": null,
       "extendedType": null,
       "externalReference": null,
@@ -247,7 +254,9 @@
               "consumerType": "Gui"
             }
           ],
-          "expiresAt": null
+          "expiresAt": null,
+          "authorizationContext": null,
+          "isAuthorized": null
         }
       ],
       "navigationalActions": []
@@ -257,6 +266,7 @@
       "idempotentKey": null,
       "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
       "authorizationAttribute": "urn:altinn:resource:ttd-altinn-events-automated-tests",
+      "authorizationContext": null,
       "isAuthorized": null,
       "extendedType": null,
       "externalReference": null,
@@ -321,7 +331,9 @@
               "consumerType": "Gui"
             }
           ],
-          "expiresAt": null
+          "expiresAt": null,
+          "authorizationContext": null,
+          "isAuthorized": null
         }
       ],
       "navigationalActions": []
@@ -331,6 +343,7 @@
       "idempotentKey": null,
       "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
       "authorizationAttribute": "someunavailablesubresource",
+      "authorizationContext": null,
       "isAuthorized": null,
       "extendedType": null,
       "externalReference": null,
@@ -395,7 +408,9 @@
               "consumerType": "Gui"
             }
           ],
-          "expiresAt": null
+          "expiresAt": null,
+          "authorizationContext": null,
+          "isAuthorized": null
         }
       ],
       "navigationalActions": []
@@ -407,6 +422,7 @@
       "action": "read",
       "url": "https://digdir.no/",
       "authorizationAttribute": null,
+      "authorizationContext": null,
       "isAuthorized": null,
       "isDeleteDialogAction": false,
       "priority": "Primary",
@@ -424,6 +440,7 @@
       "action": "read",
       "url": "https://digdir.no/",
       "authorizationAttribute": null,
+      "authorizationContext": null,
       "isAuthorized": null,
       "isDeleteDialogAction": false,
       "priority": "Secondary",
@@ -447,6 +464,7 @@
       "id": "00000000-0000-0000-0000-000000000000",
       "action": "some_unauthorized_action",
       "authorizationAttribute": null,
+      "authorizationContext": null,
       "isAuthorized": null,
       "name": "confirm",
       "endpoints": [

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Update/Snapshots/UpdateDialogSnapshotTests.Put_Dialog_Then_Get_Verify_Snapshot.verified.json
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Dialogs/Commands/Update/Snapshots/UpdateDialogSnapshotTests.Put_Dialog_Then_Get_Verify_Snapshot.verified.json
@@ -138,7 +138,9 @@
           "consumerType": "Api"
         }
       ],
-      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+      "authorizationContext": null,
+      "isAuthorized": null
     }
   ],
   "transmissions": [
@@ -147,6 +149,7 @@
       "idempotentKey": "put-transmission-key",
       "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
       "authorizationAttribute": "urn:altinn:resource:ttd-dialogporten-automated-tests-correspondence",
+      "authorizationContext": null,
       "isAuthorized": null,
       "extendedType": "urn:test:update:transmission-type",
       "externalReference": "put-transmission-external-reference",
@@ -208,7 +211,9 @@
               "consumerType": "Gui"
             }
           ],
-          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+          "authorizationContext": null,
+          "isAuthorized": null
         }
       ],
       "navigationalActions": [
@@ -220,7 +225,9 @@
             }
           ],
           "url": "https://example.com/put-transmission-navigation",
-          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+          "authorizationContext": null,
+          "isAuthorized": null
         }
       ]
     }
@@ -231,6 +238,7 @@
       "action": "read",
       "url": "https://example.com/put-gui-action",
       "authorizationAttribute": "urn:altinn:resource:ttd-dialogporten-automated-tests-correspondence",
+      "authorizationContext": null,
       "isAuthorized": null,
       "isDeleteDialogAction": false,
       "priority": "Primary",
@@ -254,6 +262,7 @@
       "id": "00000000-0000-0000-0000-000000000000",
       "action": "read",
       "authorizationAttribute": "urn:altinn:resource:ttd-dialogporten-automated-tests-correspondence",
+      "authorizationContext": null,
       "isAuthorized": null,
       "name": "put-api-action",
       "endpoints": [

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Get/Snapshots/GetDialogTests.Get_Dialog_Verify_Snapshot.verified.json
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Dialogs/Queries/Get/Snapshots/GetDialogTests.Get_Dialog_Verify_Snapshot.verified.json
@@ -142,7 +142,9 @@
           "consumerType": "Api"
         }
       ],
-      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+      "authorizationContext": null,
+      "isAuthorized": true
     }
   ],
   "transmissions": [
@@ -151,6 +153,7 @@
       "idempotentKey": null,
       "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
       "authorizationAttribute": "urn:altinn:resource:ttd-dialogporten-automated-tests-correspondence",
+      "authorizationContext": null,
       "isAuthorized": true,
       "extendedType": null,
       "externalReference": "first-transmission",
@@ -193,6 +196,7 @@
       "idempotentKey": "idempotent-key",
       "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
       "authorizationAttribute": "someunavailablesubresource",
+      "authorizationContext": null,
       "isAuthorized": false,
       "extendedType": "https://digdir.com/transmission-type",
       "externalReference": "second-transmission",
@@ -260,7 +264,9 @@
               "consumerType": "Api"
             }
           ],
-          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+          "authorizationContext": null,
+          "isAuthorized": false
         }
       ],
       "navigationalActions": [
@@ -272,7 +278,9 @@
             }
           ],
           "url": "https://altinn.no/get-dialog-transmission-navigation",
-          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+          "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+          "authorizationContext": null,
+          "isAuthorized": false
         }
       ]
     }
@@ -283,6 +291,7 @@
       "action": "read",
       "url": "https://digdir.no/",
       "authorizationAttribute": "urn:altinn:resource:ttd-dialogporten-automated-tests-correspondence",
+      "authorizationContext": null,
       "isAuthorized": true,
       "isDeleteDialogAction": false,
       "priority": "Primary",
@@ -300,6 +309,7 @@
       "action": "read",
       "url": "https://digdir.no/",
       "authorizationAttribute": null,
+      "authorizationContext": null,
       "isAuthorized": true,
       "isDeleteDialogAction": false,
       "priority": "Secondary",
@@ -323,6 +333,7 @@
       "id": "00000000-0000-0000-0000-000000000000",
       "action": "some_unauthorized_action",
       "authorizationAttribute": "urn:altinn:resource:ttd-dialogporten-automated-tests-correspondence",
+      "authorizationContext": null,
       "isAuthorized": false,
       "name": "confirm",
       "endpoints": [

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Transmissions/Commands/Snapshots/CreateTransmissionTests.Create_Transmissions_Verify_Snapshot.verified.json
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Transmissions/Commands/Snapshots/CreateTransmissionTests.Create_Transmissions_Verify_Snapshot.verified.json
@@ -4,6 +4,7 @@
     "idempotentKey": null,
     "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
     "authorizationAttribute": null,
+    "authorizationContext": null,
     "extendedType": "https://digdir.com/transmission-type",
     "externalReference": "second-transmission",
     "relatedTransmissionId": "00000000-0000-0000-0000-000000000000",
@@ -45,7 +46,8 @@
             "consumerType": "Gui"
           }
         ],
-        "expiresAt": null
+        "expiresAt": null,
+        "authorizationContext": null
       }
     ],
     "navigationalActions": [
@@ -57,7 +59,8 @@
           }
         ],
         "url": "https://digdir.com/second-action-url",
-        "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+        "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+        "authorizationContext": null
       }
     ]
   },
@@ -66,6 +69,7 @@
     "idempotentKey": null,
     "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
     "authorizationAttribute": null,
+    "authorizationContext": null,
     "extendedType": null,
     "externalReference": "first-transmission",
     "relatedTransmissionId": null,
@@ -125,7 +129,8 @@
             "consumerType": "Gui"
           }
         ],
-        "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+        "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+        "authorizationContext": null
       }
     ],
     "navigationalActions": [
@@ -137,7 +142,8 @@
           }
         ],
         "url": "https://digdir.com/first-action-url",
-        "expiresAt": null
+        "expiresAt": null,
+        "authorizationContext": null
       }
     ]
   }

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Transmissions/Commands/Snapshots/UpdateTransmissionTests.Update_Transmission_Verify_Snapshot.verified.json
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Transmissions/Commands/Snapshots/UpdateTransmissionTests.Update_Transmission_Verify_Snapshot.verified.json
@@ -3,6 +3,7 @@
   "idempotentKey": null,
   "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
   "authorizationAttribute": null,
+  "authorizationContext": null,
   "extendedType": "https://digdir.com/updated-transmission-type",
   "externalReference": "updated-external-reference",
   "relatedTransmissionId": null,
@@ -68,7 +69,8 @@
           "consumerType": "Api"
         }
       ],
-      "expiresAt": null
+      "expiresAt": null,
+      "authorizationContext": null
     },
     {
       "id": "00000000-0000-0000-0000-000000000000",
@@ -87,7 +89,8 @@
           "consumerType": "Gui"
         }
       ],
-      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+      "authorizationContext": null
     }
   ],
   "navigationalActions": [
@@ -99,7 +102,8 @@
         }
       ],
       "url": "https://digdir.com/updated-action-url",
-      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+      "authorizationContext": null
     }
   ]
 }

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Transmissions/Queries/Snapshots/GetTransmissionTests.Get_Transmission_Verify_Snapshot.verified.json
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Transmissions/Queries/Snapshots/GetTransmissionTests.Get_Transmission_Verify_Snapshot.verified.json
@@ -3,6 +3,7 @@
   "idempotentKey": "idempotent-key",
   "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
   "authorizationAttribute": null,
+  "authorizationContext": null,
   "extendedType": "https://digdir.com/transmission-type",
   "externalReference": "second-transmission",
   "relatedTransmissionId": "00000000-0000-0000-0000-000000000000",
@@ -62,7 +63,8 @@
           "consumerType": "Gui"
         }
       ],
-      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+      "authorizationContext": null
     }
   ],
   "navigationalActions": [
@@ -74,7 +76,8 @@
         }
       ],
       "url": "https://digdir.com/action-url",
-      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+      "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+      "authorizationContext": null
     }
   ]
 }

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Transmissions/Queries/Snapshots/SearchTransmissionTests.Search_Transmissions_Verify_Snapshot.verified.json
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Features/V1/ServiceOwner/Transmissions/Queries/Snapshots/SearchTransmissionTests.Search_Transmissions_Verify_Snapshot.verified.json
@@ -4,6 +4,7 @@
     "idempotentKey": "idempotent-key",
     "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
     "authorizationAttribute": null,
+    "authorizationContext": null,
     "extendedType": "https://digdir.com/transmission-type",
     "externalReference": "second-transmission",
     "relatedTransmissionId": "00000000-0000-0000-0000-000000000000",
@@ -63,7 +64,8 @@
             "consumerType": "Gui"
           }
         ],
-        "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+        "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+        "authorizationContext": null
       }
     ],
     "navigationalActions": [
@@ -75,7 +77,8 @@
           }
         ],
         "url": "https://digdir.com/action-url",
-        "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00"
+        "expiresAt": "0000-00-00T00:00:00.000000\u002B00:00",
+        "authorizationContext": null
       }
     ]
   },
@@ -84,6 +87,7 @@
     "idempotentKey": null,
     "createdAt": "0000-00-00T00:00:00.000000\u002B00:00",
     "authorizationAttribute": null,
+    "authorizationContext": null,
     "extendedType": null,
     "externalReference": "first-transmission",
     "relatedTransmissionId": null,


### PR DESCRIPTION
**Hand-written except the regenerated `docs/schema/V1` snapshots and the E2E `.verified.json` snapshots (not CI-gated, refreshed for the E2E layer).** Layer 7/13 of the `authorizationContext` stack (#3978).

Makes `authorizationContext` writable on create, update, create-transmission and update-transmission, for all six carrier surfaces:

| Surface | Previously |
|---|---|
| `apiActions` | `authorizationAttribute` (now deprecated) |
| `guiActions` | `authorizationAttribute` (now deprecated) |
| `transmissions` | `authorizationAttribute` (now deprecated) |
| `attachments` (dialog) | **nothing** — inherited the dialog's context |
| `transmissions[].attachments` | **nothing** — inherited the transmission's context |
| `transmissions[].navigationalActions` | **nothing** — inherited the transmission's context |

The shared input DTO, validator and mapper live in `Features/V1/Common/AuthorizationContexts/`; the 18 validator changes wire in the invariants:

- `authorizationContext` and the legacy fields (`action` / `authorizationAttribute`) are **mutually exclusive per entity** — a partly-migrated payload is a 400, never an ambiguity. The rule is "empty", not "null": a service-owner GET echoes the empty-string `action` sentinel stored on context-carrying entities, so a GET → PUT round trip has to survive it. Request DTOs stay nullable, so callers may keep omitting the field entirely;
- the context `action` is optional on every carrier and defaults to `read` — one `AuthorizationContextDto` shape serves all six carrier surfaces;
- at least one party (or `includeDialogParty`), max 3 parties, `unauthorizedPresentation` required (`Disabled` or `Excluded`), `additionalResourceAttribute` must not smuggle a `urn:altinn:resource:` reference.

The write mappers translate the two absent-legacy-field cases into what is actually persisted: `""` for the action, and the `dp-excluded` sentinel into a context-carrying transmission's `authorizationAttribute`. Both exist **only** so that code predating authorization contexts fails closed on these entities after a rollback; neither is consulted while contexts are understood, and layer 6 suppresses the transmission one on every read.

This layer also completes `UpdateTransmissionCommand`: incoming contexts are mapped onto the aggregate before the `AuthorizeServiceResources` call that layer 1 relocated — which is why that fix sits at the bottom of the stack.

Two fixes fold in here:

- an explicit `"parties": null` is normalized to an empty list in the DTO's setter. It is reachable at minimum through the JsonPatch update endpoint (Newtonsoft, not the STJ pipeline), where it replaced the `[]` initializer and made the validator's `Must(x => x.Count <= …)` throw a `NullReferenceException` — a 500;
- the unreachable end-user overloads in the update mappers are deleted. No `ToUpdateDialogDto` overload takes an end-user `DialogDto`, so nothing could reach them; the comment claiming a test flow used one was wrong.

**Review focus:** `AuthorizationContextDtoValidator` (the invariants above) and the update-path mappers (create/replace/remove semantics on nested carriers). `CreateDialogAuthorizationContextTests` covers round-trip and every validation rule.

Part of #3978.
