### PR TITLE
feat: issue per-context dialog tokens

### DIFF
--- a/docs/schema/V1/openapi.v1.serviceowner.verified.json
+++ b/docs/schema/V1/openapi.v1.serviceowner.verified.json
@@ -177,7 +177,7 @@
             "type": "string"
           },
           "additionalResourceAttribute": {
-            "description": "An additional resource attribute to be matched within the effective service policy, e.g. a task or\nsubresource. Cannot contain a service resource reference; use \u0022serviceResource\u0022 for that.",
+            "description": "An additional resource attribute to be matched within the effective service policy, e.g. a task or\nsubresource. Cannot contain a service resource reference; use \u0022serviceResource\u0022 for that. References\nto an app (\u0022urn:altinn:app\u0022) or an organization (\u0022urn:altinn:org\u0022) are not allowed either; both are\nderived from the effective service resource.",
             "example": "urn:altinn:task:Task_1\nurn:altinn:subresource:mycustomresource",
             "nullable": true,
             "type": "string"

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -7553,7 +7553,7 @@
   "paths": {
     "/api/v1/.well-known/jwks.json": {
       "get": {
-        "description": "This endpoint can be used by client integrations supporting automatic discovery of \u0022OAuth 2.0 Authorization Server\u0022 metadata, enabling verification of dialog tokens issued by Dialogporten.\n\nDialog tokens carry the JOSE \u0022typ\u0022 header \u0022JWT\u0022. Receiving services must validate the \u0022typ\u0022 header and reject a token whose type they do not expect: other token types signed with these keys carry an explicit type per RFC 8725.",
+        "description": "This endpoint can be used by client integrations supporting automatic discovery of \u0022OAuth 2.0 Authorization Server\u0022 metadata, enabling verification of dialog tokens issued by Dialogporten.\n\nDialogporten issues two token types, both signed with these keys and distinguished by the JOSE \u0022typ\u0022 header: the dialog token, which carries \u0022JWT\u0022, and \u0022dialogcontexttoken\u002Bjwt\u0022, a narrower token scoped to a single authorization-context-carrying entity. Receiving services must validate the \u0022typ\u0022 header and reject a token whose type they do not expect; in particular, a service expecting a dialog token must reject \u0022dialogcontexttoken\u002Bjwt\u0022.",
         "operationId": "V1WellKnownJwksGet_Jwks",
         "responses": {
           "200": {
@@ -7594,7 +7594,7 @@
     },
     "/api/v1/.well-known/oauth-authorization-server": {
       "get": {
-        "description": "This endpoint can be used by client integrations supporting automatic discovery of \u0022OAuth 2.0 Authorization Server\u0022 metadata, enabling verification of dialog tokens issued by Dialogporten.\n\nDialog tokens carry the JOSE \u0022typ\u0022 header \u0022JWT\u0022. Receiving services must validate the \u0022typ\u0022 header and reject a token whose type they do not expect: other token types signed with the same keys carry an explicit type per RFC 8725.",
+        "description": "This endpoint can be used by client integrations supporting automatic discovery of \u0022OAuth 2.0 Authorization Server\u0022 metadata, enabling verification of dialog tokens issued by Dialogporten.\n\nDialogporten issues two token types, both signed with the same keys and distinguished by the JOSE \u0022typ\u0022 header: the dialog token, which carries \u0022JWT\u0022, and \u0022dialogcontexttoken\u002Bjwt\u0022, a narrower token scoped to a single authorization-context-carrying entity. Receiving services must validate the \u0022typ\u0022 header and reject a token whose type they do not expect; in particular, a service expecting a dialog token must reject \u0022dialogcontexttoken\u002Bjwt\u0022.",
         "operationId": "V1WellKnownOauthAuthorizationServerGet_OauthAuthorizationServer",
         "responses": {
           "200": {

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -489,7 +489,7 @@
             "type": "string"
           },
           "additionalResourceAttribute": {
-            "description": "An additional resource attribute to be matched within the effective service policy, e.g. a task or\nsubresource. Cannot contain a service resource reference; use \u0022serviceResource\u0022 for that.",
+            "description": "An additional resource attribute to be matched within the effective service policy, e.g. a task or\nsubresource. Cannot contain a service resource reference; use \u0022serviceResource\u0022 for that. References\nto an app (\u0022urn:altinn:app\u0022) or an organization (\u0022urn:altinn:org\u0022) are not allowed either; both are\nderived from the effective service resource.",
             "example": "urn:altinn:task:Task_1\nurn:altinn:subresource:mycustomresource",
             "nullable": true,
             "type": "string"

--- a/scripts/e2e/.env
+++ b/scripts/e2e/.env
@@ -10,7 +10,7 @@ LocalDevelopment__UseLocalDevelopmentNameRegister=false
 LocalDevelopment__UseLocalDevelopmentPartyNameRegistry=false
 LocalDevelopment__UseLocalDevelopmentAltinnAuthorization=false
 LocalDevelopment__UseLocalDevelopmentCloudEventBus=true
-# Must stay false: the E2E tests verify dialog tokens against the JWKS endpoint, and the
+# Must stay false: the E2E tests verify dialog and context tokens against the JWKS endpoint, and the
 # local decorator returns the literal string "local-development-jws" instead of a signed compact JWS.
 LocalDevelopment__UseLocalDevelopmentCompactJwsGenerator=false
 LocalDevelopment__DisableCache=false

--- a/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/IServiceResourceAuthorizer.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/Authorization/IServiceResourceAuthorizer.cs
@@ -65,6 +65,21 @@ internal sealed class ServiceResourceAuthorizer : IServiceResourceAuthorizer
             return new Forbidden($"Not allowed to reference the following unowned resources: [{string.Join(", ", notOwnedResources)}].");
         }
 
+        var appReferences = GetAdditionalResourceAppReferences(dialog).ToList();
+        if (appReferences.Count != 0)
+        {
+            var currentUserOrg = await _userResourceRegistry.GetCurrentUserOrgShortName(cancellationToken);
+            var notOwnedApps = appReferences
+                .Where(x => !string.Equals(x.Org, currentUserOrg, StringComparison.OrdinalIgnoreCase))
+                .Select(x => x.Reference)
+                .ToList();
+
+            if (notOwnedApps.Count != 0)
+            {
+                return new Forbidden($"Not allowed to reference the following unowned apps: [{string.Join(", ", notOwnedApps)}].");
+            }
+        }
+
         if (!_userResourceRegistry.UserCanModifyResourceType(dialog.ServiceResourceType))
         {
             return new Forbidden($"User cannot create or modify a dialog with resource type {dialog.ServiceResourceType}.");
@@ -123,4 +138,30 @@ internal sealed class ServiceResourceAuthorizer : IServiceResourceAuthorizer
     private static bool IsPrimaryResource(string? resource) =>
         resource is not null
         && resource.StartsWith(Domain.Common.Constants.ServiceResourcePrefix, StringComparison.OrdinalIgnoreCase);
+
+    // Defense-in-depth, mirroring the resource-prefix sweep above: AuthorizationContextDtoValidator already
+    // rejects the app namespace (and any value that would implicitly expand into an app identity) outright,
+    // so nothing should reach this in practice. Apps aren't resource-registry entries, so ownership is
+    // org-based rather than an id lookup; a reference whose org can't be parsed out (a malformed
+    // 'app_{org}_{appId}' value) is treated as not owned.
+    private static IEnumerable<(string Reference, string? Org)> GetAdditionalResourceAppReferences(DialogEntity dialog) =>
+        GetAuthorizationContexts(dialog)
+            .Select(context => context.AdditionalResourceAttribute)
+            .Where(x => x is not null)
+            .Select(x => x!)
+            .Where(x => x.StartsWith(Domain.Common.Constants.AppResourcePrefix, StringComparison.OrdinalIgnoreCase))
+            .Select(x => (Reference: x, Org: ExtractAppOrg(x)));
+
+    private static string? ExtractAppOrg(string value)
+    {
+        var lastColonIndex = value.LastIndexOf(':');
+        var tail = lastColonIndex == -1 ? value : value[(lastColonIndex + 1)..];
+        if (!tail.StartsWith(Domain.Common.Constants.AppResourceIdPrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var parts = tail.Split('_');
+        return parts.Length >= 3 ? parts[1] : null;
+    }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Common/ICompactJwsGenerator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/ICompactJwsGenerator.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Text;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using NSec.Cryptography;
@@ -25,6 +26,15 @@ public sealed class Ed25519Generator : ICompactJwsGenerator
         InitSigningKey();
     }
 
+    // The default encoder escapes '+' as the JSON escape u002B, which would leave a structured token type such as
+    // "dialogcontexttoken+jwt" escaped in the header. That is legal JSON, but a needless trap for a receiver
+    // comparing the raw header bytes, so the header is written unescaped. Safe here because every value in it
+    // (alg, typ, kid) is ours, and none contains characters requiring escaping.
+    private static readonly JsonSerializerOptions HeaderSerializerOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
     public string GetCompactJws(Dictionary<string, object?> claims, string tokenType)
     {
         var header = JsonSerializer.SerializeToUtf8Bytes(new
@@ -32,7 +42,7 @@ public sealed class Ed25519Generator : ICompactJwsGenerator
             alg = "EdDSA",
             typ = tokenType,
             kid = _kid
-        });
+        }, HeaderSerializerOptions);
 
         var payload = JsonSerializer.SerializeToUtf8Bytes(claims);
 

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IDialogTokenGenerator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IDialogTokenGenerator.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Globalization;
-using System.Text;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
@@ -13,6 +12,17 @@ namespace Digdir.Domain.Dialogporten.Application.Common;
 public interface IDialogTokenGenerator
 {
     string GetDialogToken(DialogEntity dialog, DialogDetailsAuthorizationResult authorizationResult, string issuerVersion);
+
+    /// <summary>
+    /// Generates a token scoped to a single authorization-context-carrying entity, asserting the single
+    /// PDP-verified grant (action, effective resource) along with the parties it was permitted for.
+    /// </summary>
+    string GetDialogContextToken(
+        DialogEntity dialog,
+        AuthorizedCheck authorizedCheck,
+        Guid entityId,
+        string entityType,
+        string issuerVersion);
 }
 
 internal sealed class DialogTokenGenerator : IDialogTokenGenerator
@@ -53,8 +63,42 @@ internal sealed class DialogTokenGenerator : IDialogTokenGenerator
     public string GetDialogToken(DialogEntity dialog, DialogDetailsAuthorizationResult authorizationResult,
         string issuerVersion)
     {
+        var claims = GetBaseClaims(dialog);
+        claims[DialogTokenClaimTypes.Actions] = GetAuthorizedActions(authorizationResult);
+        AddIssuerAndLifetimeClaims(claims, issuerVersion);
+
+        return _compactJwsGenerator.GetCompactJws(claims, DialogTokenTypes.DialogToken);
+    }
+
+    public string GetDialogContextToken(
+        DialogEntity dialog,
+        AuthorizedCheck authorizedCheck,
+        Guid entityId,
+        string entityType,
+        string issuerVersion)
+    {
+        var claims = GetBaseClaims(dialog);
+        claims[DialogTokenClaimTypes.EntityId] = entityId;
+        claims[DialogTokenClaimTypes.EntityType] = entityType;
+        claims[DialogTokenClaimTypes.Actions] = authorizedCheck.Check.Action;
+
+        // The effective resource for the grant; absent when the check applies to the dialog's own resource.
+        var resource = authorizedCheck.Check.Resource.ServiceResource
+                       ?? authorizedCheck.Check.Resource.AdditionalResourceAttribute;
+        if (resource is not null)
+        {
+            claims[DialogTokenClaimTypes.EffectiveResource] = resource;
+        }
+
+        claims[DialogTokenClaimTypes.PermittedParties] = authorizedCheck.PermittedParties;
+        AddIssuerAndLifetimeClaims(claims, issuerVersion);
+
+        return _compactJwsGenerator.GetCompactJws(claims, DialogTokenTypes.DialogContextToken);
+    }
+
+    private Dictionary<string, object?> GetBaseClaims(DialogEntity dialog)
+    {
         var claimsPrincipal = _user.GetPrincipal();
-        var now = _clock.UtcNowOffset.ToUnixTimeSeconds();
         var endUserPartyIdentifier = claimsPrincipal.GetEndUserPartyIdentifier();
 
         var claims = new Dictionary<string, object?>(15)
@@ -89,13 +133,17 @@ internal sealed class DialogTokenGenerator : IDialogTokenGenerator
         claims[DialogTokenClaimTypes.DialogParty] = dialog.Party;
         claims[DialogTokenClaimTypes.ServiceResource] = dialog.ServiceResource;
         claims[DialogTokenClaimTypes.DialogId] = dialog.Id;
-        claims[DialogTokenClaimTypes.Actions] = GetAuthorizedActions(authorizationResult);
+
+        return claims;
+    }
+
+    private void AddIssuerAndLifetimeClaims(Dictionary<string, object?> claims, string issuerVersion)
+    {
+        var now = _clock.UtcNowOffset.ToUnixTimeSeconds();
         claims[DialogTokenClaimTypes.Issuer] = _applicationSettings.Dialogporten.BaseUri.AbsoluteUri.TrimEnd('/') + issuerVersion;
         claims[DialogTokenClaimTypes.IssuedAt] = now;
         claims[DialogTokenClaimTypes.NotBefore] = now;
         claims[DialogTokenClaimTypes.Expires] = now + (long)_tokenLifetime.TotalSeconds;
-
-        return _compactJwsGenerator.GetCompactJws(claims, DialogTokenTypes.DialogToken);
     }
 
     private static string GetAuthorizedActions(DialogDetailsAuthorizationResult authorizationResult)
@@ -155,6 +203,21 @@ public static class DialogTokenTypes
     /// already carried in the "iss" claim.
     /// </summary>
     public const string DialogToken = "JWT";
+
+    public const string DialogContextToken = "dialogcontexttoken+jwt";
+}
+
+/// <summary>
+/// Entity type discriminators for the <see cref="DialogTokenClaimTypes.EntityType"/> claim in context tokens.
+/// </summary>
+public static class DialogContextTokenEntityTypes
+{
+    public const string ApiAction = "apiaction";
+    public const string GuiAction = "guiaction";
+    public const string Attachment = "attachment";
+    public const string Transmission = "transmission";
+    public const string TransmissionAttachment = "transmissionattachment";
+    public const string TransmissionNavigationalAction = "navigationalaction";
 }
 
 public static class DialogTokenClaimTypes
@@ -173,4 +236,10 @@ public static class DialogTokenClaimTypes
     public const string ServiceResource = "s";
     public const string DialogId = "i";
     public const string Actions = "a";
+
+    // Context-token-only claims
+    public const string EntityId = "e";
+    public const string EntityType = "t";
+    public const string EffectiveResource = "r";
+    public const string PermittedParties = "pp";
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IDialogTokenGenerator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IDialogTokenGenerator.cs
@@ -81,6 +81,11 @@ internal sealed class DialogTokenGenerator : IDialogTokenGenerator
         var claims = GetBaseClaims(dialog);
         claims[DialogTokenClaimTypes.EntityId] = entityId;
         claims[DialogTokenClaimTypes.EntityType] = entityType;
+
+        // A context token asserts exactly one check, so "a" carries that single action verbatim. Note that
+        // this is a different shape from the dialog token's "a", which is a ';'-separated list of
+        // "action[,attribute]" entries - a recipient sharing parsing code between the two must switch on the
+        // JOSE "typ" header rather than assume the list format.
         claims[DialogTokenClaimTypes.Actions] = authorizedCheck.Check.Action;
 
         // Both are emitted independently, exactly mirroring the resource attributes the PDP request carried

--- a/src/Digdir.Domain.Dialogporten.Application/Common/IDialogTokenGenerator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Common/IDialogTokenGenerator.cs
@@ -15,7 +15,8 @@ public interface IDialogTokenGenerator
 
     /// <summary>
     /// Generates a token scoped to a single authorization-context-carrying entity, asserting the single
-    /// PDP-verified grant (action, effective resource) along with the parties it was permitted for.
+    /// PDP-verified grant (action, resource override and/or additional resource attribute) along with the
+    /// parties it was permitted for.
     /// </summary>
     string GetDialogContextToken(
         DialogEntity dialog,
@@ -82,12 +83,19 @@ internal sealed class DialogTokenGenerator : IDialogTokenGenerator
         claims[DialogTokenClaimTypes.EntityType] = entityType;
         claims[DialogTokenClaimTypes.Actions] = authorizedCheck.Check.Action;
 
-        // The effective resource for the grant; absent when the check applies to the dialog's own resource.
-        var resource = authorizedCheck.Check.Resource.ServiceResource
-                       ?? authorizedCheck.Check.Resource.AdditionalResourceAttribute;
-        if (resource is not null)
+        // Both are emitted independently, exactly mirroring the resource attributes the PDP request carried
+        // for this check: the resource override (falling back to the dialog's own resource, already carried
+        // in "s", when absent) with the additional attribute layered on top, if any. A recipient can
+        // reconstruct the same PDP request from "s"/"r"/"ra" alone.
+        var resourceSpec = authorizedCheck.Check.Resource;
+        if (resourceSpec.ServiceResource is not null)
         {
-            claims[DialogTokenClaimTypes.EffectiveResource] = resource;
+            claims[DialogTokenClaimTypes.EffectiveResource] = resourceSpec.ServiceResource;
+        }
+
+        if (resourceSpec.AdditionalResourceAttribute is not null)
+        {
+            claims[DialogTokenClaimTypes.AdditionalResourceAttribute] = resourceSpec.AdditionalResourceAttribute;
         }
 
         claims[DialogTokenClaimTypes.PermittedParties] = authorizedCheck.PermittedParties;
@@ -241,5 +249,6 @@ public static class DialogTokenClaimTypes
     public const string EntityId = "e";
     public const string EntityType = "t";
     public const string EffectiveResource = "r";
+    public const string AdditionalResourceAttribute = "ra";
     public const string PermittedParties = "pp";
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/DialogDetailsAuthorizationResult.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/DialogDetailsAuthorizationResult.cs
@@ -12,15 +12,31 @@ public sealed class DialogDetailsAuthorizationResult
     /// </summary>
     public List<AuthorizedCheck> AuthorizedChecks { get; init; } = [];
 
+    // Context-heavy dialogs can carry one distinct check per transmission, and the predicates below are
+    // evaluated per entity when decorating query results — linear scans over AuthorizedChecks would make
+    // decoration quadratic. Index the checks once on first use instead. Instances may be shared between
+    // concurrent requests via the PDP cache; the benign race of building the index twice is acceptable as
+    // each builder publishes a fully constructed, thereafter immutable structure.
+    private LookupIndex? _lookupIndex;
+
+    private LookupIndex GetIndex() => _lookupIndex ??= new LookupIndex(AuthorizedChecks);
+
     /// <summary>
     /// Whether the given check (built by <see cref="AuthorizationCheckBuilder"/> from the same entity/dialog
     /// pair as the request) was authorized for at least one of its parties.
     /// </summary>
     public bool HasAccess(AuthorizationCheck check) =>
-        AuthorizedChecks.Any(x => x.Check == check);
+        GetIndex().AuthorizedByCheck.ContainsKey(check);
+
+    /// <summary>
+    /// The authorized check matching the given check, carrying the subset of parties the PDP permitted,
+    /// or null if the check was not authorized for any party.
+    /// </summary>
+    public AuthorizedCheck? GetAuthorizedCheck(AuthorizationCheck check) =>
+        GetIndex().AuthorizedByCheck.GetValueOrDefault(check);
 
     public bool HasAccessToMainResource() =>
-        AuthorizedChecks.Any(x => x.Check.Resource.Kind == AuthorizationResourceSpecKind.Main);
+        GetIndex().MainResourceActions.Count > 0;
 
     /// <summary>
     /// Whether the requested action was permitted on the exact resource the legacy entity refers to:
@@ -28,28 +44,45 @@ public sealed class DialogDetailsAuthorizationResult
     /// </summary>
     public bool HasAccessToAction(string requestedAction, string? authorizationAttribute) =>
         authorizationAttribute is null
-            ? AuthorizedChecks.Any(x =>
-                x.Check.Action == requestedAction
-                && x.Check.Resource.Kind == AuthorizationResourceSpecKind.Main)
-            : AuthorizedChecks.Any(x =>
-                x.Check.Action == requestedAction
-                && x.Check.Resource.Kind == AuthorizationResourceSpecKind.Legacy
-                && x.Check.Resource.LegacyAuthorizationAttribute == authorizationAttribute);
+            ? GetIndex().MainResourceActions.Contains(requestedAction)
+            : GetIndex().LegacyAttributeActions.Contains((requestedAction, authorizationAttribute));
 
     public bool HasReadAccessToMainResource() =>
-        AuthorizedChecks.Any(x => x.Check is
-        {
-            Action: Constants.ReadAction,
-            Resource.Kind: AuthorizationResourceSpecKind.Main
-        });
+        GetIndex().MainResourceActions.Contains(Constants.ReadAction);
 
-    public bool HasReadAccessToDialogTransmission(string? authorizationAttribute)
-    {
-        return authorizationAttribute is not null
-            ? AuthorizedChecks.Any(x =>
-                x.Check.Action is Constants.ReadAction
-                && x.Check.Resource.Kind == AuthorizationResourceSpecKind.Legacy
-                && x.Check.Resource.LegacyAuthorizationAttribute == authorizationAttribute)
+    public bool HasReadAccessToDialogTransmission(string? authorizationAttribute) =>
+        authorizationAttribute is not null
+            ? GetIndex().LegacyAttributeActions.Contains((Constants.ReadAction, authorizationAttribute))
             : HasAccessToMainResource();
+
+    private sealed class LookupIndex
+    {
+        public Dictionary<AuthorizationCheck, AuthorizedCheck> AuthorizedByCheck { get; }
+        public HashSet<string> MainResourceActions { get; }
+        public HashSet<(string Action, string Attribute)> LegacyAttributeActions { get; }
+
+        public LookupIndex(List<AuthorizedCheck> authorizedChecks)
+        {
+            AuthorizedByCheck = new Dictionary<AuthorizationCheck, AuthorizedCheck>(authorizedChecks.Count);
+            MainResourceActions = new HashSet<string>(StringComparer.Ordinal);
+            LegacyAttributeActions = [];
+
+            foreach (var authorizedCheck in authorizedChecks)
+            {
+                var check = authorizedCheck.Check;
+                AuthorizedByCheck.TryAdd(check, authorizedCheck);
+                switch (check.Resource)
+                {
+                    case { Kind: AuthorizationResourceSpecKind.Main }:
+                        MainResourceActions.Add(check.Action);
+                        break;
+                    case { Kind: AuthorizationResourceSpecKind.Legacy, LegacyAuthorizationAttribute: { } attribute }:
+                        LegacyAttributeActions.Add((check.Action, attribute));
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/DialogDetailsAuthorizationResult.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/DialogDetailsAuthorizationResult.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Serialization;
 using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 
 namespace Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
@@ -17,6 +18,12 @@ public sealed class DialogDetailsAuthorizationResult
     // decoration quadratic. Index the checks once on first use instead. Instances may be shared between
     // concurrent requests via the PDP cache; the benign race of building the index twice is acceptable as
     // each builder publishes a fully constructed, thereafter immutable structure.
+    //
+    // Excluded from the PDP cache's MessagePack serialization (ContractlessStandardResolverAllowPrivate
+    // includes private fields): LookupIndex has no constructor parameter matching its members, which makes
+    // the dynamic formatter throw on every write — even when this field is null — silently disabling the
+    // cache. The index is cheap to rebuild lazily from AuthorizedChecks after deserialization.
+    [IgnoreDataMember]
     private LookupIndex? _lookupIndex;
 
     private LookupIndex GetIndex() => _lookupIndex ??= new LookupIndex(AuthorizedChecks);

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDto.cs
@@ -14,7 +14,9 @@ public sealed class AuthorizationContextDto
 
     /// <summary>
     /// An additional resource attribute to be matched within the effective service policy, e.g. a task or
-    /// subresource. Cannot contain a service resource reference; use "serviceResource" for that.
+    /// subresource. Cannot contain a service resource reference; use "serviceResource" for that. References
+    /// to an app ("urn:altinn:app") or an organization ("urn:altinn:org") are not allowed either; both are
+    /// derived from the effective service resource.
     /// </summary>
     /// <example>
     /// urn:altinn:task:Task_1

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDtoValidator.cs
@@ -17,7 +17,11 @@ internal sealed class AuthorizationContextDtoValidator : AbstractValidator<Autho
         RuleFor(x => x.AdditionalResourceAttribute)
             .IsValidAuthorizationAttribute()
             .Must(x => x is null || !x.StartsWith(Constants.ServiceResourcePrefix, StringComparison.OrdinalIgnoreCase))
-            .WithMessage($"'{{PropertyName}}' cannot contain a service resource reference ('{Constants.ServiceResourcePrefix}...'); use 'ServiceResource' instead.");
+            .WithMessage($"'{{PropertyName}}' cannot contain a service resource reference ('{Constants.ServiceResourcePrefix}...'); use 'ServiceResource' instead.")
+            .Must(x => x is null || (!ExpandsToAppIdentity(x) && !HasAppPrefix(x)))
+            .WithMessage($"'{{PropertyName}}' cannot reference an app (the '{Constants.AppResourcePrefix}' namespace, or a value " +
+                         $"expanding into an '{Constants.AppResourceIdPrefix}{{org}}_{{appId}}' identifier); 'ServiceResource' already " +
+                         "carries the resource-registry entry for an app, and there is no equivalent per-app override for this field.");
 
         RuleFor(x => x.Parties)
             .Must(x => x.Count <= AuthorizationContext.MaxNumberOfParties)
@@ -47,4 +51,20 @@ internal sealed class AuthorizationContextDtoValidator : AbstractValidator<Autho
                          $"'{AuthorizationContextUnauthorizedPresentation.Values.Disabled}' or " +
                          $"'{AuthorizationContextUnauthorizedPresentation.Values.Excluded}'.");
     }
+
+    // Downstream PDP request construction reinterprets the segment after the last colon as an Altinn app
+    // identity whenever it starts with the app id prefix, regardless of the namespace the caller stated (e.g.
+    // "urn:altinn:task:app_other_sensitive-app" silently becomes an app/org attribute for a different app).
+    // AdditionalResourceAttribute has no legitimate app use case - ServiceResource is the field for
+    // referencing an app-backed resource-registry entry - so both the explicit app namespace and any value
+    // that would implicitly expand into one are rejected outright.
+    private static bool ExpandsToAppIdentity(string value)
+    {
+        var lastColonIndex = value.LastIndexOf(':');
+        var tail = lastColonIndex == -1 ? value : value[(lastColonIndex + 1)..];
+        return tail.StartsWith(Constants.AppResourceIdPrefix, StringComparison.Ordinal);
+    }
+
+    private static bool HasAppPrefix(string value) =>
+        value.StartsWith(Constants.AppResourcePrefix, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDtoValidator.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDtoValidator.cs
@@ -21,7 +21,15 @@ internal sealed class AuthorizationContextDtoValidator : AbstractValidator<Autho
             .Must(x => x is null || (!ExpandsToAppIdentity(x) && !HasAppPrefix(x)))
             .WithMessage($"'{{PropertyName}}' cannot reference an app (the '{Constants.AppResourcePrefix}' namespace, or a value " +
                          $"expanding into an '{Constants.AppResourceIdPrefix}{{org}}_{{appId}}' identifier); 'ServiceResource' already " +
-                         "carries the resource-registry entry for an app, and there is no equivalent per-app override for this field.");
+                         "carries the resource-registry entry for an app, and there is no equivalent per-app override for this field.")
+            // The org namespace is rejected for the same reason as the app namespace above: it is the other
+            // half of an app identity. An app-backed service resource already renders as an urn:altinn:app +
+            // urn:altinn:org pair, so a caller-supplied org would put a second, caller-chosen org value in the
+            // same resource category, where any-of attribute matching lets it satisfy a policy target
+            // belonging to another organization.
+            .Must(x => x is null || !x.StartsWith(Constants.OrgResourcePrefix, StringComparison.OrdinalIgnoreCase))
+            .WithMessage($"'{{PropertyName}}' cannot reference an organization (the '{Constants.OrgResourcePrefix}' namespace); " +
+                         "the organization owning the effective resource is derived from the resource itself.");
 
         RuleFor(x => x.Parties)
             .Must(x => x.Count <= AuthorizationContext.MaxNumberOfParties)

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Common/DialogContextTokenExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Common/DialogContextTokenExtensions.cs
@@ -1,0 +1,42 @@
+using Digdir.Domain.Dialogporten.Application.Common;
+using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
+using static Digdir.Domain.Dialogporten.Application.Features.V1.Common.Authorization.Constants;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
+
+/// <summary>
+/// Shared context token issuance for the end user queries that expose authorization-context-carrying entities
+/// (get-dialog, get-transmission and search-transmissions), so all of them apply the same issue/omit rules.
+/// </summary>
+internal static class DialogContextTokenExtensions
+{
+    /// <summary>
+    /// Issues a token scoped to a single entity's PDP-verified grant, or null when the entity has no authorization
+    /// context, is unauthorized, or its check cannot be found among the authorized checks. Reuses the check already
+    /// computed for the authorization request — no additional PDP calls.
+    /// </summary>
+    public static string? GetContextTokenOrNull(
+        this IDialogTokenGenerator dialogTokenGenerator,
+        DialogEntity dialog,
+        DialogDetailsAuthorizationResult authorization,
+        bool isAuthorized,
+        AuthorizationContext? context,
+        AuthorizationCheck? check,
+        Guid entityId,
+        string entityType)
+    {
+        if (!isAuthorized || context is null || check is null)
+        {
+            return null;
+        }
+
+        // IsAuthorized for a context-carrying entity implies its check was authorized, so this
+        // lookup cannot miss; guard anyway to fail closed rather than throw.
+        var authorizedCheck = authorization.GetAuthorizedCheck(check);
+        return authorizedCheck is null
+            ? null
+            : dialogTokenGenerator.GetDialogContextToken(dialog, authorizedCheck, entityId, entityType, DialogTokenIssuerVersion);
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Domain/Common/Constants.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Common/Constants.cs
@@ -12,6 +12,7 @@ public static class Constants
     public const int MinIdempotentKeyLength = 3;
 
     public const string ServiceResourcePrefix = "urn:altinn:resource:";
+    public const string AppResourcePrefix = "urn:altinn:app:";
     public const string AppResourceIdPrefix = "app_";
     public const string ServiceContextInstanceIdPrefix = "urn:altinn:integration:storage:";
 

--- a/src/Digdir.Domain.Dialogporten.Domain/Common/Constants.cs
+++ b/src/Digdir.Domain.Dialogporten.Domain/Common/Constants.cs
@@ -14,6 +14,7 @@ public static class Constants
     public const string ServiceResourcePrefix = "urn:altinn:resource:";
     public const string AppResourcePrefix = "urn:altinn:app:";
     public const string AppResourceIdPrefix = "app_";
+    public const string OrgResourcePrefix = "urn:altinn:org:";
     public const string ServiceContextInstanceIdPrefix = "urn:altinn:integration:storage:";
 
     public const string IsSilentUpdate = "IsSilentUpdate";

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/WellKnown/Jwks/Get/GetJwksEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/WellKnown/Jwks/Get/GetJwksEndpointSummary.cs
@@ -10,7 +10,7 @@ public sealed class GetJwksEndpointSummary : Summary<GetJwksEndpoint>
         Description = """
                       This endpoint can be used by client integrations supporting automatic discovery of "OAuth 2.0 Authorization Server" metadata, enabling verification of dialog tokens issued by Dialogporten.
 
-                      Dialog tokens carry the JOSE "typ" header "JWT". Receiving services must validate the "typ" header and reject a token whose type they do not expect: other token types signed with these keys carry an explicit type per RFC 8725.
+                      Dialogporten issues two token types, both signed with these keys and distinguished by the JOSE "typ" header: the dialog token, which carries "JWT", and "dialogcontexttoken+jwt", a narrower token scoped to a single authorization-context-carrying entity. Receiving services must validate the "typ" header and reject a token whose type they do not expect; in particular, a service expecting a dialog token must reject "dialogcontexttoken+jwt".
                       """;
         Responses[StatusCodes.Status200OK] = "The OAuth 2.0 Authorization Server Metadata";
     }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/WellKnown/OauthAuthorizationServer/Get/GetOauthAuthorizationServerEndpointSummary.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Endpoints/V1/WellKnown/OauthAuthorizationServer/Get/GetOauthAuthorizationServerEndpointSummary.cs
@@ -10,7 +10,7 @@ public sealed class GetOauthAuthorizationServerEndpointSummary : Summary<GetOaut
         Description = """
                       This endpoint can be used by client integrations supporting automatic discovery of "OAuth 2.0 Authorization Server" metadata, enabling verification of dialog tokens issued by Dialogporten.
 
-                      Dialog tokens carry the JOSE "typ" header "JWT". Receiving services must validate the "typ" header and reject a token whose type they do not expect: other token types signed with the same keys carry an explicit type per RFC 8725.
+                      Dialogporten issues two token types, both signed with the same keys and distinguished by the JOSE "typ" header: the dialog token, which carries "JWT", and "dialogcontexttoken+jwt", a narrower token scoped to a single authorization-context-carrying entity. Receiving services must validate the "typ" header and reject a token whose type they do not expect; in particular, a service expecting a dialog token must reject "dialogcontexttoken+jwt".
                       """;
         Responses[StatusCodes.Status200OK] = "The OAuth 2.0 Authorization Server Metadata";
     }

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Common/Authorization/ServiceResourceAuthorizerTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Common/Authorization/ServiceResourceAuthorizerTests.cs
@@ -16,6 +16,7 @@ public class ServiceResourceAuthorizerTests
 {
     private const string OwnedResource = "urn:altinn:resource:owned-service";
     private const string UnownedResource = "urn:altinn:resource:unowned-service";
+    private const string CurrentUserOrg = "ownerorg";
 
     [Fact]
     public async Task AuthorizeServiceResources_Should_Allow_Owned_Context_Resources()
@@ -85,6 +86,61 @@ public class ServiceResourceAuthorizerTests
     }
 
     [Fact]
+    public async Task AuthorizeServiceResources_Should_Allow_App_Reference_Owned_By_Current_Org()
+    {
+        var dialog = CreateDialog();
+        dialog.Transmissions.Add(new DialogTransmission
+        {
+            AuthorizationContext = new DialogTransmissionAuthorizationContext
+            {
+                AdditionalResourceAttribute = $"urn:altinn:app:app_{CurrentUserOrg}_myapp"
+            }
+        });
+
+        var result = await CreateSut().AuthorizeServiceResources(dialog, CancellationToken.None);
+
+        Assert.IsType<Success>(result.Value);
+    }
+
+    [Fact]
+    public async Task AuthorizeServiceResources_Should_Forbid_App_Reference_Owned_By_Another_Org()
+    {
+        const string appReference = "urn:altinn:app:app_otherorg_myapp";
+        var dialog = CreateDialog();
+        dialog.Transmissions.Add(new DialogTransmission
+        {
+            AuthorizationContext = new DialogTransmissionAuthorizationContext
+            {
+                AdditionalResourceAttribute = appReference
+            }
+        });
+
+        var result = await CreateSut().AuthorizeServiceResources(dialog, CancellationToken.None);
+
+        var forbidden = Assert.IsType<Forbidden>(result.Value);
+        Assert.Contains(appReference, forbidden.Reasons.Single());
+    }
+
+    [Fact]
+    public async Task AuthorizeServiceResources_Should_Forbid_App_Reference_With_Unparsable_Org()
+    {
+        // "app_onlytwoparts" has too few '_'-separated segments to yield an org; treated as not owned.
+        const string appReference = "urn:altinn:app:app_onlytwoparts";
+        var dialog = CreateDialog();
+        dialog.Transmissions.Add(new DialogTransmission
+        {
+            AuthorizationContext = new DialogTransmissionAuthorizationContext
+            {
+                AdditionalResourceAttribute = appReference
+            }
+        });
+
+        var result = await CreateSut().AuthorizeServiceResources(dialog, CancellationToken.None);
+
+        Assert.IsType<Forbidden>(result.Value);
+    }
+
+    [Fact]
     public async Task AuthorizeServiceResources_Should_Forbid_Unowned_Legacy_AuthorizationAttribute()
     {
         var dialog = CreateDialog();
@@ -117,6 +173,8 @@ public class ServiceResourceAuthorizerTests
         userResourceRegistry.IsCurrentUserServiceOwnerAdmin().Returns(false);
         userResourceRegistry.GetCurrentUserResourceIds(Arg.Any<CancellationToken>())
             .Returns([OwnedResource]);
+        userResourceRegistry.GetCurrentUserOrgShortName(Arg.Any<CancellationToken>())
+            .Returns(CurrentUserOrg);
         userResourceRegistry.UserCanModifyResourceType(Arg.Any<string>()).Returns(true);
 
         return new ServiceResourceAuthorizer(

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Common/DialogTokenGeneratorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Common/DialogTokenGeneratorTests.cs
@@ -80,7 +80,8 @@ public class DialogTokenGeneratorTests
         Assert.Equal(entityId, _capturedClaims[DialogTokenClaimTypes.EntityId]);
         Assert.Equal(DialogContextTokenEntityTypes.GuiAction, _capturedClaims[DialogTokenClaimTypes.EntityType]);
         Assert.Equal("sign", _capturedClaims[DialogTokenClaimTypes.Actions]);
-        Assert.Equal("urn:altinn:task:Task_1", _capturedClaims[DialogTokenClaimTypes.EffectiveResource]);
+        Assert.False(_capturedClaims.ContainsKey(DialogTokenClaimTypes.EffectiveResource));
+        Assert.Equal("urn:altinn:task:Task_1", _capturedClaims[DialogTokenClaimTypes.AdditionalResourceAttribute]);
         Assert.Equal(dialog.Party, _capturedClaims[DialogTokenClaimTypes.DialogParty]);
         Assert.Equal(dialog.ServiceResource, _capturedClaims[DialogTokenClaimTypes.ServiceResource]);
         Assert.Equal(dialog.Id, _capturedClaims[DialogTokenClaimTypes.DialogId]);
@@ -91,7 +92,7 @@ public class DialogTokenGeneratorTests
     }
 
     [Fact]
-    public void ContextTokenShouldPreferServiceResourceAsEffectiveResource()
+    public void ContextTokenShouldCarryServiceResourceAsEffectiveResource()
     {
         // Arrange
         var generator = CreateGenerator();
@@ -107,10 +108,33 @@ public class DialogTokenGeneratorTests
         // Assert
         Assert.NotNull(_capturedClaims);
         Assert.Equal("urn:altinn:resource:other-service", _capturedClaims[DialogTokenClaimTypes.EffectiveResource]);
+        Assert.False(_capturedClaims.ContainsKey(DialogTokenClaimTypes.AdditionalResourceAttribute));
     }
 
     [Fact]
-    public void ContextTokenShouldOmitResourceClaimWhenCheckTargetsDialogResource()
+    public void ContextTokenShouldCarryBothResourceOverrideAndAdditionalAttributeWhenBothPresent()
+    {
+        // A recipient must be able to reconstruct the exact same PDP request from the token alone, so
+        // neither field may be dropped when both are set on the same check.
+        // Arrange
+        var generator = CreateGenerator();
+        var check = new AuthorizationCheck(
+            "sign",
+            AuthorizationResourceSpec.FromContext("urn:altinn:resource:other-service", "urn:altinn:task:Task_1"),
+            [OtherParty]);
+
+        // Act
+        generator.GetDialogContextToken(CreateDialog(), AuthorizedCheck.FullyPermitted(check),
+            Guid.NewGuid(), DialogContextTokenEntityTypes.Transmission, IssuerVersion);
+
+        // Assert
+        Assert.NotNull(_capturedClaims);
+        Assert.Equal("urn:altinn:resource:other-service", _capturedClaims[DialogTokenClaimTypes.EffectiveResource]);
+        Assert.Equal("urn:altinn:task:Task_1", _capturedClaims[DialogTokenClaimTypes.AdditionalResourceAttribute]);
+    }
+
+    [Fact]
+    public void ContextTokenShouldOmitResourceClaimsWhenCheckTargetsDialogResource()
     {
         // Arrange
         var generator = CreateGenerator();
@@ -126,6 +150,7 @@ public class DialogTokenGeneratorTests
         // Assert
         Assert.NotNull(_capturedClaims);
         Assert.False(_capturedClaims.ContainsKey(DialogTokenClaimTypes.EffectiveResource));
+        Assert.False(_capturedClaims.ContainsKey(DialogTokenClaimTypes.AdditionalResourceAttribute));
     }
 
     private static DialogEntity CreateDialog() => new()

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Common/DialogTokenGeneratorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Common/DialogTokenGeneratorTests.cs
@@ -1,0 +1,171 @@
+using System.Security.Claims;
+using Digdir.Domain.Dialogporten.Application.Common;
+using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
+using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using NSubstitute;
+
+namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Common;
+
+public class DialogTokenGeneratorTests
+{
+    private const string IssuerVersion = "/api/v1";
+    private const string DialogParty = "urn:altinn:organization:identifier-no:991825827";
+    private const string OtherParty = "urn:altinn:organization:identifier-no:912345678";
+
+    private Dictionary<string, object?>? _capturedClaims;
+    private string? _capturedTokenType;
+
+    [Fact]
+    public void DialogTokenShouldOmitContextGrantsAndUseDialogTokenType()
+    {
+        // Arrange
+        var generator = CreateGenerator();
+        var dialog = CreateDialog();
+
+        var contextCheck = new AuthorizationCheck(
+            "sign",
+            AuthorizationResourceSpec.FromContext(null, "urn:altinn:task:Task_1"),
+            [DialogParty, OtherParty]);
+
+        var authorizationResult = new DialogDetailsAuthorizationResult
+        {
+            AuthorizedChecks =
+            [
+                AuthorizedCheck.FullyPermitted(new AuthorizationCheck(
+                    "read", AuthorizationResourceSpec.Main, [DialogParty])),
+                AuthorizedCheck.FullyPermitted(new AuthorizationCheck(
+                    "write",
+                    AuthorizationResourceSpec.FromLegacyAuthorizationAttribute("urn:altinn:task:Task_1"),
+                    [DialogParty])),
+                // Fully permitted, including for the dialog party — must still not appear in "a"
+                AuthorizedCheck.FullyPermitted(contextCheck)
+            ]
+        };
+
+        // Act
+        generator.GetDialogToken(dialog, authorizationResult, IssuerVersion);
+
+        // Assert
+        Assert.Equal(DialogTokenTypes.DialogToken, _capturedTokenType);
+        Assert.NotNull(_capturedClaims);
+        Assert.Equal("read;write,urn:altinn:task:Task_1", _capturedClaims[DialogTokenClaimTypes.Actions]);
+        Assert.False(_capturedClaims.ContainsKey(DialogTokenClaimTypes.EntityId));
+        Assert.False(_capturedClaims.ContainsKey(DialogTokenClaimTypes.PermittedParties));
+    }
+
+    [Fact]
+    public void ContextTokenShouldCarryEntityGrantAndPermittedParties()
+    {
+        // Arrange
+        var generator = CreateGenerator();
+        var dialog = CreateDialog();
+        var entityId = Guid.NewGuid();
+
+        var check = new AuthorizationCheck(
+            "sign",
+            AuthorizationResourceSpec.FromContext(null, "urn:altinn:task:Task_1"),
+            [DialogParty, OtherParty]);
+
+        // Only a subset of the parties was permitted by the PDP
+        var authorizedCheck = new AuthorizedCheck(check, [OtherParty]);
+
+        // Act
+        generator.GetDialogContextToken(dialog, authorizedCheck, entityId,
+            DialogContextTokenEntityTypes.GuiAction, IssuerVersion);
+
+        // Assert
+        Assert.Equal(DialogTokenTypes.DialogContextToken, _capturedTokenType);
+        Assert.NotNull(_capturedClaims);
+        Assert.Equal(entityId, _capturedClaims[DialogTokenClaimTypes.EntityId]);
+        Assert.Equal(DialogContextTokenEntityTypes.GuiAction, _capturedClaims[DialogTokenClaimTypes.EntityType]);
+        Assert.Equal("sign", _capturedClaims[DialogTokenClaimTypes.Actions]);
+        Assert.Equal("urn:altinn:task:Task_1", _capturedClaims[DialogTokenClaimTypes.EffectiveResource]);
+        Assert.Equal(dialog.Party, _capturedClaims[DialogTokenClaimTypes.DialogParty]);
+        Assert.Equal(dialog.ServiceResource, _capturedClaims[DialogTokenClaimTypes.ServiceResource]);
+        Assert.Equal(dialog.Id, _capturedClaims[DialogTokenClaimTypes.DialogId]);
+
+        var permittedParties = Assert.IsAssignableFrom<IReadOnlyList<string>>(
+            _capturedClaims[DialogTokenClaimTypes.PermittedParties]);
+        Assert.Equal([OtherParty], permittedParties);
+    }
+
+    [Fact]
+    public void ContextTokenShouldPreferServiceResourceAsEffectiveResource()
+    {
+        // Arrange
+        var generator = CreateGenerator();
+        var check = new AuthorizationCheck(
+            "read",
+            AuthorizationResourceSpec.FromContext("urn:altinn:resource:other-service", null),
+            [OtherParty]);
+
+        // Act
+        generator.GetDialogContextToken(CreateDialog(), AuthorizedCheck.FullyPermitted(check),
+            Guid.NewGuid(), DialogContextTokenEntityTypes.Transmission, IssuerVersion);
+
+        // Assert
+        Assert.NotNull(_capturedClaims);
+        Assert.Equal("urn:altinn:resource:other-service", _capturedClaims[DialogTokenClaimTypes.EffectiveResource]);
+    }
+
+    [Fact]
+    public void ContextTokenShouldOmitResourceClaimWhenCheckTargetsDialogResource()
+    {
+        // Arrange
+        var generator = CreateGenerator();
+        var check = new AuthorizationCheck(
+            "read",
+            AuthorizationResourceSpec.FromContext(null, null),
+            [OtherParty]);
+
+        // Act
+        generator.GetDialogContextToken(CreateDialog(), AuthorizedCheck.FullyPermitted(check),
+            Guid.NewGuid(), DialogContextTokenEntityTypes.Attachment, IssuerVersion);
+
+        // Assert
+        Assert.NotNull(_capturedClaims);
+        Assert.False(_capturedClaims.ContainsKey(DialogTokenClaimTypes.EffectiveResource));
+    }
+
+    private static DialogEntity CreateDialog() => new()
+    {
+        Id = Guid.NewGuid(),
+        Party = DialogParty,
+        ServiceResource = "urn:altinn:resource:some-service"
+    };
+
+    private DialogTokenGenerator CreateGenerator()
+    {
+        var settings = new ApplicationSettings
+        {
+            Dialogporten = new DialogportenSettings
+            {
+                BaseUri = new Uri("https://unittest"),
+                Ed25519KeyPairs = new Ed25519KeyPairs
+                {
+                    Primary = new Ed25519KeyPair { Kid = "kid1", PrivateComponent = "", PublicComponent = "" },
+                    Secondary = new Ed25519KeyPair { Kid = "kid2", PrivateComponent = "", PublicComponent = "" }
+                }
+            }
+        };
+
+        var user = Substitute.For<IUser>();
+        user.GetPrincipal().Returns(new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("pid", "22834498646"),
+            new Claim("acr", "idporten-loa-high")
+        ])));
+
+        var clock = Substitute.For<IClock>();
+        clock.UtcNowOffset.Returns(DateTimeOffset.UnixEpoch);
+
+        var jwsGenerator = Substitute.For<ICompactJwsGenerator>();
+        jwsGenerator.GetCompactJws(
+                Arg.Do<Dictionary<string, object?>>(claims => _capturedClaims = claims),
+                Arg.Do<string>(tokenType => _capturedTokenType = tokenType))
+            .Returns("jws");
+
+        return new DialogTokenGenerator(new OptionsMock<ApplicationSettings>(settings), user, clock, jwsGenerator);
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Ed25519GeneratorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Ed25519GeneratorTests.cs
@@ -1,5 +1,8 @@
+using System.Text;
+using System.Text.Json;
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Unit.Tests.Common;
+using Base64Url = System.Buffers.Text.Base64Url;
 
 namespace Digdir.Domain.Dialogporten.Application.Unit.Tests;
 
@@ -9,7 +12,45 @@ public class CompactJwsGeneratorTests
     public void ValidJwsIsGenerated()
     {
         // Arrange
-        var settings = new ApplicationSettings
+        var generator = new Ed25519Generator(new OptionsMock<ApplicationSettings>(GetSettings()));
+
+        var payload = new Dictionary<string, object?>
+        {
+            { "sub", "1234567890" },
+            { "name", "John Doe" },
+            { "iat", 1516239022 }
+        };
+
+        // Act
+        var jws = generator.GetCompactJws(payload, DialogTokenTypes.DialogToken);
+
+        // Assert
+        Assert.True(generator.VerifyCompactJws(jws));
+    }
+
+    [Theory]
+    [InlineData(DialogTokenTypes.DialogToken)]
+    [InlineData(DialogTokenTypes.DialogContextToken)]
+    public void HeaderCarriesTheTokenTypeUnescaped(string tokenType)
+    {
+        // Arrange
+        var generator = new Ed25519Generator(new OptionsMock<ApplicationSettings>(GetSettings()));
+
+        // Act
+        var jws = generator.GetCompactJws([], tokenType);
+
+        // Assert
+        var header = Encoding.UTF8.GetString(Base64Url.DecodeFromChars(jws.Split('.')[0]));
+
+        // Literal, not the "+" escape the default JSON encoder would emit: a receiver comparing the raw
+        // header bytes must see the type exactly as it is documented.
+        Assert.Contains($"\"typ\":\"{tokenType}\"", header, StringComparison.Ordinal);
+        Assert.Equal(tokenType, JsonDocument.Parse(header).RootElement.GetProperty("typ").GetString());
+    }
+
+    private static ApplicationSettings GetSettings()
+    {
+        return new ApplicationSettings
         {
             Dialogporten = new DialogportenSettings
             {
@@ -31,20 +72,5 @@ public class CompactJwsGeneratorTests
                 }
             }
         };
-        var options = new OptionsMock<ApplicationSettings>(settings);
-        var generator = new Ed25519Generator(options);
-
-        var payload = new Dictionary<string, object?>
-        {
-            { "sub", "1234567890" },
-            { "name", "John Doe" },
-            { "iat", 1516239022 }
-        };
-
-        // Act
-        var jws = generator.GetCompactJws(payload, DialogTokenTypes.DialogToken);
-
-        // Assert
-        Assert.True(generator.VerifyCompactJws(jws));
     }
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/Common/AuthorizationContexts/AuthorizationContextDtoValidatorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/Common/AuthorizationContexts/AuthorizationContextDtoValidatorTests.cs
@@ -1,0 +1,41 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
+
+namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Features.V1.Common.AuthorizationContexts;
+
+public class AuthorizationContextDtoValidatorTests
+{
+    private readonly AuthorizationContextDtoValidator _validator = new();
+
+    [Theory]
+    [InlineData("urn:altinn:task:Task_1")] // does not expand into an app identity (no 'app_' tail)
+    [InlineData("urn:altinn:subresource:mycustomresource")]
+    [InlineData(null)]
+    public void Should_Allow_Non_App_AdditionalResourceAttribute(string? additionalResourceAttribute)
+    {
+        var result = _validator.Validate(CreateDto(additionalResourceAttribute));
+
+        Assert.True(result.IsValid, string.Join(", ", result.Errors));
+    }
+
+    [Theory]
+    [InlineData("urn:altinn:app:app_org_myapp")] // explicit app namespace - ServiceResource is the field for apps
+    [InlineData("urn:altinn:task:app_other_sensitive-app")] // app_ tail smuggled under a different namespace
+    [InlineData("urn:altinn:integration:app_other_sensitive-app")]
+    [InlineData("urn:altinn:app:not-an-app-id")] // app namespace stated even though the value isn't app_-shaped
+    public void Should_Reject_AdditionalResourceAttribute_That_References_An_App(string additionalResourceAttribute)
+    {
+        // AdditionalResourceAttribute has no app use case: ServiceResource already carries the resource-registry
+        // entry for an app, and app/org expansion must never happen for this field, however it's spelled.
+        var result = _validator.Validate(CreateDto(additionalResourceAttribute));
+
+        Assert.False(result.IsValid);
+    }
+
+    private static AuthorizationContextDto CreateDto(string? additionalResourceAttribute) => new()
+    {
+        AdditionalResourceAttribute = additionalResourceAttribute,
+        IncludeDialogParty = true,
+        UnauthorizedPresentation = AuthorizationContextUnauthorizedPresentation.Values.Disabled
+    };
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/Common/AuthorizationContexts/AuthorizationContextDtoValidatorTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Features/V1/Common/AuthorizationContexts/AuthorizationContextDtoValidatorTests.cs
@@ -32,6 +32,19 @@ public class AuthorizationContextDtoValidatorTests
         Assert.False(result.IsValid);
     }
 
+    [Theory]
+    [InlineData("urn:altinn:org:brg")]
+    [InlineData("URN:ALTINN:ORG:brg")]
+    public void Should_Reject_AdditionalResourceAttribute_That_References_An_Organization(string additionalResourceAttribute)
+    {
+        // The org namespace is the other half of an app identity: an app-backed service resource already
+        // renders as an app/org pair, so a caller-supplied org lands as a second org value in the same
+        // resource category and can satisfy another organization's policy target.
+        var result = _validator.Validate(CreateDto(additionalResourceAttribute));
+
+        Assert.False(result.IsValid);
+    }
+
     private static AuthorizationContextDto CreateDto(string? additionalResourceAttribute) => new()
     {
         AdditionalResourceAttribute = additionalResourceAttribute,

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DialogDetailsAuthorizationResultSerializationTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/DialogDetailsAuthorizationResultSerializationTests.cs
@@ -1,0 +1,35 @@
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
+using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
+using MessagePack;
+using MessagePack.Resolvers;
+using Xunit;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests;
+
+// Pins round-tripping through the exact resolver the PDP cache (Altinn.Authorization, InfrastructureExtensions)
+// is configured with. ContractlessStandardResolverAllowPrivate serializes private fields, so a lazily-built
+// private field on DialogDetailsAuthorizationResult can silently break every cache write unless excluded.
+public class DialogDetailsAuthorizationResultSerializationTests
+{
+    [Fact]
+    public void Should_Round_Trip_Through_The_Pdp_Cache_Resolver_After_The_Lookup_Index_Is_Built()
+    {
+        var check = new AuthorizationCheck("read", AuthorizationResourceSpec.Main, ["urn:altinn:person:identifier-no:12345678901"]);
+        var result = new DialogDetailsAuthorizationResult
+        {
+            AuthorizedChecks = [AuthorizedCheck.FullyPermitted(check)]
+        };
+
+        // Force the lazily-built index into existence before serializing, mirroring production usage where a
+        // cached instance may have already answered queries before being written back to the distributed cache.
+        Assert.True(result.HasAccess(check));
+
+        var testToken = TestContext.Current.CancellationToken;
+        var bytes = MessagePackSerializer.Serialize(result, ContractlessStandardResolverAllowPrivate.Options, testToken);
+        var roundTripped = MessagePackSerializer.Deserialize<DialogDetailsAuthorizationResult>(
+            bytes, ContractlessStandardResolverAllowPrivate.Options, testToken);
+
+        Assert.True(roundTripped.HasAccess(check));
+        Assert.True(roundTripped.HasReadAccessToMainResource());
+    }
+}


### PR DESCRIPTION
**Hand-written except the regenerated `docs/schema/V1/swagger.verified.json` (WellKnown endpoint descriptions).** Layer 8/13 of the `authorizationContext` stack (#3978).

### Per-context dialog tokens (`dialogcontexttoken+jwt`)

The dialog token asserts exactly one party (`p`) and one resource for the whole dialog, so it cannot safely carry a grant obtained via a *different* party — encoding one would let the holder assert, against the dialog party, an authority the PDP only granted for someone else.

So context grants are not expressed through the dialog token at all. Instead each authorized context-carrying entity is issued its own narrower token, distinguished by the JOSE `typ` header per RFC 8725:

| Claim | Meaning |
|---|---|
| `e` | id of the entity the token was issued for |
| `t` | entity type (`apiaction`, `guiaction`, `attachment`, `transmission`, `transmissionattachment`, `navigationalaction`) |
| `a` | the single action this grant covers |
| `r` | the effective resource, when it differs from the dialog's own (omitted otherwise) |
| `ra` | additional resource attribute layered on the effective resource, when present
| `pp` | the parties the PDP **actually permitted** for this check |
| `p`, `s`, `i`, `c`, `l`, `iss`, `iat`, `nbf`, `exp`, `jti` | as on the dialog token |

`pp` is the security-relevant claim: it is the PDP's answer for this one check, never the dialog party and never a superset. `p` continues to describe the dialog, not the grant — receiving services must read `pp`, not `p`, when deciding what the holder was permitted.

**This is additive.** The dialog token's `a` claim is frozen at legacy semantics: context-carrying entities are excluded from it entirely. A consumer that has only ever used `authorizationAttribute` sees no change in the dialog token's shape — `DialogTokenGeneratorTests` pins both directions.

Also here: `DialogDetailsAuthorizationResult` gains `GetAuthorizedCheck` (token issuance reuses the already-computed check — no extra PDP calls) and an internal lookup index, since context-heavy dialogs are decorated per entity and linear scans would make that quadratic.

Also in this layer: the JOSE header is serialized with the relaxed encoder. The default one escapes `+`, which would leave the structured type in the header as `dialogcontexttoken\u002Bjwt` — legal JSON, but a needless trap for a receiver comparing the raw header bytes. `CompactJwsGeneratorTests` pins the literal form for both token types.

Also in this layer: `additionalResourceAttribute` now rejects `urn:altinn:org` references as well as `urn:altinn:resource` and `urn:altinn:app` ones. The field is rendered verbatim into the PDP resource category, so a caller-supplied org would add a second, caller-chosen org value next to the one an app-backed resource already contributes — and any-of attribute matching would let it satisfy a policy target belonging to another organization. Everything an app or an organization contributes to the evaluation is derived from the effective service resource.

The tokens are not surfaced on any DTO yet — that is the next layer.

Part of #3978.
