### PR TITLE
feat: expose authorization-context results and contextToken on the end-user read surface and GraphQL

### DIFF
--- a/docs/schema/V1/openapi.v1.enduser.verified.json
+++ b/docs/schema/V1/openapi.v1.enduser.verified.json
@@ -335,7 +335,7 @@
             "type": "string"
           },
           "dialogToken": {
-            "description": "The dialog token. May be used (if supported) against external URLs referred to in this dialog\u0027s apiActions,\ntransmissions or attachments. It should also be used for front-channel embeds.",
+            "description": "The dialog token. May be used (if supported) against external URLs referred to in this dialog\u0027s apiActions,\ntransmissions or attachments. It should also be used for front-channel embeds.\n            \nEntities carrying an authorization context are the exception: they are issued their own, narrower\n\u0022contextToken\u0022 which must be used instead of this token, as the dialog token does not assert their grant.\nSee the \u0022contextToken\u0022 property on the individual entities.",
             "nullable": true,
             "type": "string"
           },
@@ -353,6 +353,38 @@
                 "$ref": "#/components/schemas/DialogEndUserContext"
               }
             ]
+          },
+          "excludedApiActions": {
+            "description": "API actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. An API action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedAttachments": {
+            "description": "Dialog-level attachments that exist but are withheld from the authenticated user, listed by id and\ncreation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedGuiActions": {
+            "description": "GUI actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. A GUI action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedTransmissions": {
+            "description": "Transmissions that exist but are withheld from the authenticated user, listed by id and creation\ntime only. A transmission is excluded rather than returned with isAuthorized=false when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022; its children go with it.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "expiresAt": {
             "description": "The expiration date for the dialog. This is the last date when the dialog is available for the end user.\n            \nAfter this date is passed, the dialog will be considered expired and no longer available for the end user in any\nAPI. If not supplied, the dialog will be considered to never expire. This field can be changed by the service\nowner after the dialog has been created.",
@@ -728,8 +760,15 @@
             "type": "string"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
+          },
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s endpoints.",
             "nullable": true,
             "type": "string"
           },
@@ -820,6 +859,11 @@
       "DialogAttachment": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "nullable": true,
+            "type": "string"
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -838,6 +882,10 @@
             "description": "The unique identifier for the attachment in UUIDv7 format.",
             "format": "guid",
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -976,8 +1024,15 @@
             "type": "string"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
+          },
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s URL.",
             "nullable": true,
             "type": "string"
           },
@@ -1380,10 +1435,12 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -1393,10 +1450,31 @@
               }
             ]
           },
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "nullable": true,
+            "type": "string"
+          },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
             "format": "date-time",
             "type": "string"
+          },
+          "excludedAttachments": {
+            "description": "Transmission-level attachments that exist but are withheld from the authenticated user, listed by id\nand creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedNavigationalActions": {
+            "description": "Navigational actions that exist but are withheld from the authenticated user, listed by id and\ncreation time only. A navigational action is excluded rather than returned with isAuthorized=false\nwhen its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "extendedType": {
             "description": "Arbitrary URI/URN describing a service-specific transmission type.\n            \nRefer to the service-specific documentation provided by the service owner for details (if in use).",
@@ -1458,6 +1536,11 @@
       "DialogTransmissionAttachment": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "nullable": true,
+            "type": "string"
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -1476,6 +1559,10 @@
             "description": "The unique identifier for the attachment in UUIDv7 format.",
             "format": "guid",
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1497,6 +1584,11 @@
       "DialogTransmissionAttachmentDetails": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "nullable": true,
+            "type": "string"
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -1515,6 +1607,10 @@
             "description": "The unique identifier for the attachment in UUIDv7 format.",
             "format": "guid",
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1671,9 +1767,11 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "The authorization attribute associated with the transmission.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
           },
           "content": {
             "description": "The content of the transmission.",
@@ -1682,6 +1780,11 @@
                 "$ref": "#/components/schemas/DialogTransmissionContentDetails"
               }
             ]
+          },
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "nullable": true,
+            "type": "string"
           },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
@@ -1693,6 +1796,22 @@
             "format": "date-time",
             "nullable": true,
             "type": "string"
+          },
+          "excludedAttachments": {
+            "description": "Attachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedNavigationalActions": {
+            "description": "Navigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "extendedType": {
             "description": "The extended type URI for the transmission.",
@@ -1750,11 +1869,20 @@
       "DialogTransmissionNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "nullable": true,
+            "type": "string"
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
             "nullable": true,
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -1776,11 +1904,20 @@
       "DialogTransmissionNavigationalActionDetails": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "nullable": true,
+            "type": "string"
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
             "nullable": true,
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -1802,6 +1939,11 @@
       "DialogTransmissionSearchAttachment": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "nullable": true,
+            "type": "string"
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -1820,6 +1962,10 @@
             "description": "The unique identifier for the attachment in UUIDv7 format.",
             "format": "guid",
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1913,9 +2059,11 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "The authorization attribute associated with the transmission.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
           },
           "content": {
             "description": "The content of the transmission.",
@@ -1924,6 +2072,11 @@
                 "$ref": "#/components/schemas/DialogTransmissionSearchContent"
               }
             ]
+          },
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "nullable": true,
+            "type": "string"
           },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
@@ -1935,6 +2088,22 @@
             "format": "date-time",
             "nullable": true,
             "type": "string"
+          },
+          "excludedAttachments": {
+            "description": "Attachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedNavigationalActions": {
+            "description": "Navigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "extendedType": {
             "description": "The extended type URI for the transmission.",
@@ -1992,11 +2161,20 @@
       "DialogTransmissionSearchNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "nullable": true,
+            "type": "string"
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
             "nullable": true,
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -2089,6 +2267,23 @@
           "maxServiceResourceFilterValues": {
             "format": "int32",
             "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ExcludedElement": {
+        "additionalProperties": false,
+        "description": "A stub standing in for an element the authenticated user is not authorized for, and whose authorization\ncontext asks for it to be excluded rather than disabled. The element is removed from the collection it\nbelongs to and recorded here instead, so that a client can tell \u0022this existed and you cannot see it\u0022\napart from \u0022this does not exist\u0022 without being shown anything about it.",
+        "properties": {
+          "createdAt": {
+            "description": "The UTC timestamp when the excluded element was created. Lets a client order exclusions against the\nelements it can see, e.g. to tell where in a transmission thread something is missing.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "The identifier of the excluded element, matching the id it would have had in its own collection.",
+            "format": "guid",
+            "type": "string"
           }
         },
         "type": "object"

--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -48,8 +48,13 @@ type ApiAction {
   action: String!
   "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service policy, which by default is the policy belonging to the service referred to by 'serviceResource' in the dialog. Can also be used to refer to other service policies."
   authorizationAttribute: String
+    @deprecated(
+      reason: "Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute."
+    )
   "True if the authenticated user is authorized for this action. If not, the action will not be available and all endpoints will be replaced with a fixed placeholder."
   isAuthorized: Boolean!
+  "A token asserting the authenticated user's authorization for this specific action, as determined by its authorization context. Only present when the action has an authorization context and the user is authorized. Should be used instead of the dialog token against this action's endpoints."
+  contextToken: String
   "The logical name of the operation the API action refers to."
   name: String
   "The endpoints associated with the action."
@@ -88,6 +93,10 @@ type Attachment {
   urls: [AttachmentUrl!]!
   "The UTC timestamp when the attachment expires and is no longer available."
   expiresAt: DateTime
+  "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be replaced with 'urn:dialogporten:unauthorized'."
+  isAuthorized: Boolean!
+  "A token asserting the authenticated user's authorization for this specific attachment, as determined by its authorization context. Only present when the attachment has an authorization context and the user is authorized. Should be used instead of the dialog token against this attachment's URLs."
+  contextToken: String
 }
 
 type AttachmentUrl {
@@ -210,7 +219,7 @@ type Dialog {
   updatedAt: DateTime!
   "The date and time when the dialog content was last updated. Example: 2022-12-31T23:59:59Z"
   contentUpdatedAt: DateTime!
-  "The dialog token. May be used (if supported) against external URLs referred to in this dialog's apiActions, transmissions or attachments. It should also be used for front-channel embeds."
+  "The dialog token. May be used (if supported) against external URLs referred to in this dialog's apiActions, transmissions or attachments. It should also be used for front-channel embeds. Entities carrying an authorization context are the exception: they are issued their own, narrower 'contextToken' which must be used instead of this token, as the dialog token does not assert their grant."
   dialogToken: String
   "The aggregated status of the dialog."
   status: DialogStatus!
@@ -236,10 +245,16 @@ type Dialog {
   content: Content!
   "The attachments associated with the dialog (on an aggregate level)."
   attachments: [Attachment!]!
+  "Dialog-level attachments that exist but are withheld from the authenticated user, listed by id and creation time only. An attachment is excluded rather than shown with masked URLs when its authorization context sets unauthorizedPresentation to 'excluded'. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently."
+  excludedAttachments: [ExcludedElement!]
   "The GUI actions associated with the dialog. Should be used in browser-based interactive frontends."
   guiActions: [GuiAction!]!
+  "GUI actions that exist but are withheld from the authenticated user, listed by id and creation time only. A GUI action is excluded rather than returned with isAuthorized=false when its authorization context sets unauthorizedPresentation to 'excluded'. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently."
+  excludedGuiActions: [ExcludedElement!]
   "The API actions associated with the dialog. Should be used in specialized, non-browser-based integrations."
   apiActions: [ApiAction!]!
+  "API actions that exist but are withheld from the authenticated user, listed by id and creation time only. An API action is excluded rather than returned with isAuthorized=false when its authorization context sets unauthorizedPresentation to 'excluded'. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently."
+  excludedApiActions: [ExcludedElement!]
   "An immutable list of activities associated with the dialog."
   activities: [Activity!]!
   "The list of seen log entries for the dialog newer than the dialog UpdatedAt date."
@@ -257,6 +272,8 @@ type Dialog {
   isContentSeen: Boolean!
   "The immutable list of transmissions associated with the dialog."
   transmissions: [Transmission!]!
+  "Transmissions that exist but are withheld from the authenticated user, listed by id and creation time only. A transmission is excluded rather than returned with isAuthorized=false when its authorization context sets unauthorizedPresentation to 'excluded'; its children go with it. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently."
+  excludedTransmissions: [ExcludedElement!]
   "Metadata about the dialog owned by end-users."
   endUserContext: EndUserContext!
 }
@@ -369,6 +386,13 @@ type EndUserSearchLimits {
   maxExtendedStatusFilterValues: Int!
 }
 
+type ExcludedElement {
+  "The identifier of the excluded element, matching the id it would have had in its own collection."
+  id: UUID!
+  "The date and time when the excluded element was created. Lets a client order exclusions against the elements it can see, e.g. to tell where in a transmission thread something is missing."
+  createdAt: DateTime!
+}
+
 type GuiAction {
   "The unique identifier for the action in UUIDv7 format."
   id: UUID!
@@ -378,8 +402,13 @@ type GuiAction {
   url: URL!
   "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service policy, which by default is the policy belonging to the service referred to by 'serviceResource' in the dialog. Can also be used to refer to other service policies."
   authorizationAttribute: String
+    @deprecated(
+      reason: "Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute."
+    )
   "Whether the user is authorized to perform the action."
   isAuthorized: Boolean!
+  "A token asserting the authenticated user's authorization for this specific action, as determined by its authorization context. Only present when the action has an authorization context and the user is authorized. Should be used instead of the dialog token against this action's URL."
+  contextToken: String
   "Indicates whether the action results in the dialog being deleted. Used by frontends to implement custom UX for delete actions."
   isDeleteDialogAction: Boolean!
   "Indicates a priority for the action, making it possible for frontends to adapt GUI elements based on action priority."
@@ -649,8 +678,13 @@ type Transmission {
   createdAt: DateTime!
   "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service policy, which by default is the policy belonging to the service referred to by 'serviceResource' in the dialog. Can also be used to refer to other service policies. Example: mycustomresource, urn:altinn:subresource:mycustomresource, urn:altinn:task:Task_1, urn:altinn:resource:some-other-service-identifier"
   authorizationAttribute: String
+    @deprecated(
+      reason: "Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute."
+    )
   "Flag indicating if the authenticated user is authorized for this transmission. If not, embedded content and the attachments will not be available."
   isAuthorized: Boolean!
+  "A token asserting the authenticated user's authorization for this specific transmission, as determined by its authorization context. Only present when the transmission has an authorization context and the user is authorized. Should be used instead of the dialog token against URLs referred to by this transmission, including front-channel embeds."
+  contextToken: String
   "Arbitrary URI/URN describing a service-specific transmission type. Refer to the service-specific documentation provided by the service owner for details (if in use)."
   extendedType: URL
   "Arbitrary string with a service-specific reference to an external system or service."
@@ -667,8 +701,12 @@ type Transmission {
   content: TransmissionContent!
   "The transmission-level attachments."
   attachments: [Attachment!]!
+  "Attachments on this transmission that exist but are withheld from the authenticated user, listed by id and creation time only. An attachment is excluded rather than shown with masked URLs when its authorization context sets unauthorizedPresentation to 'excluded'. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently."
+  excludedAttachments: [ExcludedElement!]
   "The transmission-level navigational actions."
   navigationalActions: [TransmissionNavigationalAction!]!
+  "Navigational actions on this transmission that exist but are withheld from the authenticated user, listed by id and creation time only. A navigational action is excluded rather than returned with isAuthorized=false when its authorization context sets unauthorizedPresentation to 'excluded'. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently."
+  excludedNavigationalActions: [ExcludedElement!]
 }
 
 type TransmissionContent {
@@ -687,6 +725,10 @@ type TransmissionNavigationalAction {
   url: URL!
   "The UTC timestamp when the navigational action expires and is no longer available."
   expiresAt: DateTime
+  "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be replaced with 'urn:dialogporten:unauthorized'."
+  isAuthorized: Boolean!
+  "A token asserting the authenticated user's authorization for this specific navigational action, as determined by its authorization context. Only present when the navigational action has an authorization context and the user is authorized. Should be used instead of the dialog token against this action's URL."
+  contextToken: String
 }
 
 interface BulkSetSystemLabelError {

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -885,6 +885,23 @@
         },
         "type": "object"
       },
+      "V1EndUserCommon_ExcludedElement": {
+        "additionalProperties": false,
+        "description": "A stub standing in for an element the authenticated user is not authorized for, and whose authorization\ncontext asks for it to be excluded rather than disabled. The element is removed from the collection it\nbelongs to and recorded here instead, so that a client can tell \u0022this existed and you cannot see it\u0022\napart from \u0022this does not exist\u0022 without being shown anything about it.",
+        "properties": {
+          "createdAt": {
+            "description": "The UTC timestamp when the excluded element was created. Lets a client order exclusions against the\nelements it can see, e.g. to tell where in a transmission thread something is missing.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "The identifier of the excluded element, matching the id it would have had in its own collection.",
+            "format": "guid",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "V1EndUserCommonActors_Actor": {
         "additionalProperties": false,
         "properties": {
@@ -1032,7 +1049,7 @@
             "type": "string"
           },
           "dialogToken": {
-            "description": "The dialog token. May be used (if supported) against external URLs referred to in this dialog\u0027s apiActions,\ntransmissions or attachments. It should also be used for front-channel embeds.",
+            "description": "The dialog token. May be used (if supported) against external URLs referred to in this dialog\u0027s apiActions,\ntransmissions or attachments. It should also be used for front-channel embeds.\n            \nEntities carrying an authorization context are the exception: they are issued their own, narrower\n\u0022contextToken\u0022 which must be used instead of this token, as the dialog token does not assert their grant.\nSee the \u0022contextToken\u0022 property on the individual entities.",
             "nullable": true,
             "type": "string"
           },
@@ -1050,6 +1067,38 @@
                 "$ref": "#/components/schemas/V1EndUserDialogsQueriesGet_DialogEndUserContext"
               }
             ]
+          },
+          "excludedApiActions": {
+            "description": "API actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. An API action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedAttachments": {
+            "description": "Dialog-level attachments that exist but are withheld from the authenticated user, listed by id and\ncreation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedGuiActions": {
+            "description": "GUI actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. A GUI action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedTransmissions": {
+            "description": "Transmissions that exist but are withheld from the authenticated user, listed by id and creation\ntime only. A transmission is excluded rather than returned with isAuthorized=false when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022; its children go with it.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "expiresAt": {
             "description": "The expiration date for the dialog. This is the last date when the dialog is available for the end user.\n            \nAfter this date is passed, the dialog will be considered expired and no longer available for the end user in any\nAPI. If not supplied, the dialog will be considered to never expire. This field can be changed by the service\nowner after the dialog has been created.",
@@ -1258,8 +1307,15 @@
             "type": "string"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
+          },
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s endpoints.",
             "nullable": true,
             "type": "string"
           },
@@ -1350,6 +1406,11 @@
       "V1EndUserDialogsQueriesGet_DialogAttachment": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "nullable": true,
+            "type": "string"
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -1368,6 +1429,10 @@
             "description": "The unique identifier for the attachment in UUIDv7 format.",
             "format": "guid",
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1445,8 +1510,15 @@
             "type": "string"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
+            "nullable": true,
+            "type": "string",
+            "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
+          },
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s URL.",
             "nullable": true,
             "type": "string"
           },
@@ -1563,10 +1635,12 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service\npolicy, which by default is the policy belonging to the service referred to by \u0022serviceResource\u0022 in the dialog.\n            \nCan also be used to refer to other service policies.",
             "example": "mycustomresource\n/* equivalent to the above */\nurn:altinn:subresource:mycustomresource\nurn:altinn:task:Task_1\n/* refer to another service */\nurn:altinn:resource:some-other-service-identifier",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -1576,10 +1650,31 @@
               }
             ]
           },
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "nullable": true,
+            "type": "string"
+          },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
             "format": "date-time",
             "type": "string"
+          },
+          "excludedAttachments": {
+            "description": "Transmission-level attachments that exist but are withheld from the authenticated user, listed by id\nand creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedNavigationalActions": {
+            "description": "Navigational actions that exist but are withheld from the authenticated user, listed by id and\ncreation time only. A navigational action is excluded rather than returned with isAuthorized=false\nwhen its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "extendedType": {
             "description": "Arbitrary URI/URN describing a service-specific transmission type.\n            \nRefer to the service-specific documentation provided by the service owner for details (if in use).",
@@ -1641,6 +1736,11 @@
       "V1EndUserDialogsQueriesGet_DialogTransmissionAttachment": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "nullable": true,
+            "type": "string"
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -1659,6 +1759,10 @@
             "description": "The unique identifier for the attachment in UUIDv7 format.",
             "format": "guid",
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1743,11 +1847,20 @@
       "V1EndUserDialogsQueriesGet_DialogTransmissionNavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "nullable": true,
+            "type": "string"
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
             "nullable": true,
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -1844,6 +1957,11 @@
       "V1EndUserDialogsQueriesGetTransmission_Attachment": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "nullable": true,
+            "type": "string"
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -1862,6 +1980,10 @@
             "description": "The unique identifier for the attachment in UUIDv7 format.",
             "format": "guid",
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1946,11 +2068,20 @@
       "V1EndUserDialogsQueriesGetTransmission_NavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "nullable": true,
+            "type": "string"
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
             "nullable": true,
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -1981,9 +2112,11 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "The authorization attribute associated with the transmission.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
           },
           "content": {
             "description": "The content of the transmission.",
@@ -1992,6 +2125,11 @@
                 "$ref": "#/components/schemas/V1EndUserDialogsQueriesGetTransmission_Content"
               }
             ]
+          },
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "nullable": true,
+            "type": "string"
           },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
@@ -2003,6 +2141,22 @@
             "format": "date-time",
             "nullable": true,
             "type": "string"
+          },
+          "excludedAttachments": {
+            "description": "Attachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedNavigationalActions": {
+            "description": "Navigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "extendedType": {
             "description": "The extended type URI for the transmission.",
@@ -2476,6 +2630,11 @@
       "V1EndUserDialogsQueriesSearchTransmissions_Attachment": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "nullable": true,
+            "type": "string"
+          },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
             "items": {
@@ -2494,6 +2653,10 @@
             "description": "The unique identifier for the attachment in UUIDv7 format.",
             "format": "guid",
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -2578,11 +2741,20 @@
       "V1EndUserDialogsQueriesSearchTransmissions_NavigationalAction": {
         "additionalProperties": false,
         "properties": {
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "nullable": true,
+            "type": "string"
+          },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
             "format": "date-time",
             "nullable": true,
             "type": "string"
+          },
+          "isAuthorized": {
+            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean"
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -2613,9 +2785,11 @@
             "type": "array"
           },
           "authorizationAttribute": {
+            "deprecated": true,
             "description": "The authorization attribute associated with the transmission.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
           },
           "content": {
             "description": "The content of the transmission.",
@@ -2624,6 +2798,11 @@
                 "$ref": "#/components/schemas/V1EndUserDialogsQueriesSearchTransmissions_Content"
               }
             ]
+          },
+          "contextToken": {
+            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "nullable": true,
+            "type": "string"
           },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
@@ -2635,6 +2814,22 @@
             "format": "date-time",
             "nullable": true,
             "type": "string"
+          },
+          "excludedAttachments": {
+            "description": "Attachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excludedNavigationalActions": {
+            "description": "Navigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "items": {
+              "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "extendedType": {
             "description": "The extended type URI for the transmission.",

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Common/AuthorizationExclusion.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Common/AuthorizationExclusion.cs
@@ -1,0 +1,44 @@
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
+using Digdir.Library.Entity.Abstractions.Features.Creatable;
+using Digdir.Library.Entity.Abstractions.Features.Identifiable;
+
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
+
+internal static class AuthorizationExclusion
+{
+    /// <summary>
+    /// Splits a mapped collection into the elements to return and stubs for the ones to withhold. An element
+    /// is withheld when the user is not authorized for it and its authorization context asks for exclusion
+    /// rather than disabling.
+    ///
+    /// Removing rather than blanking in place keeps isAuthorized=false meaning exactly one thing (present but
+    /// not usable), and keeps every collection a shape the write API would accept — an in-place redaction
+    /// emitted empty titles, urls and endpoints, which the create validators reject.
+    /// </summary>
+    /// <param name="dtos">The mapped elements, in the same order as <paramref name="entities"/>.</param>
+    /// <param name="entities">The entities the elements were mapped from.</param>
+    /// <param name="isAuthorized">Reads the decorated authorization result off an element.</param>
+    /// <returns>
+    /// The elements to keep, and the stubs for the excluded ones — null when nothing was excluded, so the
+    /// property is omitted from the response entirely, which is the overwhelmingly common case.
+    /// </returns>
+    internal static (List<TDto> Retained, List<ExcludedElementDto>? Excluded) PartitionExcluded<TDto, TEntity>(
+        List<TDto> dtos,
+        IEnumerable<TEntity> entities,
+        Func<TDto, bool> isAuthorized)
+        where TEntity : IIdentifiableEntity, ICreatableEntity, IAuthorizationContextCarrier
+    {
+        var partitioned = dtos
+            .Zip(entities, (dto, entity) => (Dto: dto, Entity: entity))
+            .ToLookup(x => !isAuthorized(x.Dto) && x.Entity.ShouldExcludeWhenUnauthorized());
+
+        var excluded = partitioned[true]
+            .Select(x => new ExcludedElementDto { Id = x.Entity.Id, CreatedAt = x.Entity.CreatedAt })
+            .ToList();
+
+        return excluded.Count == 0
+            ? (dtos, null)
+            : (partitioned[false].Select(x => x.Dto).ToList(), excluded);
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Common/ExcludedElementDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Common/ExcludedElementDto.cs
@@ -1,0 +1,21 @@
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
+
+/// <summary>
+/// A stub standing in for an element the authenticated user is not authorized for, and whose authorization
+/// context asks for it to be excluded rather than disabled. The element is removed from the collection it
+/// belongs to and recorded here instead, so that a client can tell "this existed and you cannot see it"
+/// apart from "this does not exist" without being shown anything about it.
+/// </summary>
+public sealed class ExcludedElementDto
+{
+    /// <summary>
+    /// The identifier of the excluded element, matching the id it would have had in its own collection.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// The UTC timestamp when the excluded element was created. Lets a client order exclusions against the
+    /// elements it can see, e.g. to tell where in a transmission thread something is missing.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/DialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/DialogDto.cs
@@ -1,5 +1,6 @@
 ﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.Actors;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Common.Content;
 using Digdir.Domain.Dialogporten.Domain.Attachments;
@@ -161,6 +162,10 @@ public sealed class DialogDto
     /// <summary>
     /// The dialog token. May be used (if supported) against external URLs referred to in this dialog's apiActions,
     /// transmissions or attachments. It should also be used for front-channel embeds.
+    ///
+    /// Entities carrying an authorization context are the exception: they are issued their own, narrower
+    /// "contextToken" which must be used instead of this token, as the dialog token does not assert their grant.
+    /// See the "contextToken" property on the individual entities.
     /// </summary>
     public string? DialogToken { get; set; }
 
@@ -180,9 +185,33 @@ public sealed class DialogDto
     public List<DialogAttachmentDto> Attachments { get; set; } = [];
 
     /// <summary>
+    /// Dialog-level attachments that exist but are withheld from the authenticated user, listed by id and
+    /// creation time only. An attachment is excluded rather than shown with masked URLs when its
+    /// authorization context sets unauthorizedPresentation to "excluded".
+    ///
+    /// Exclusions are reported per collection: the full set for a dialog is "excludedAttachments",
+    /// "excludedTransmissions", "excludedGuiActions" and "excludedApiActions" on the dialog, plus
+    /// "excludedAttachments" and "excludedNavigationalActions" on each transmission. Merge all six when
+    /// answering "what changed that I am not allowed to see?"; reading only one under-reports silently.
+    /// </summary>
+    public List<ExcludedElementDto>? ExcludedAttachments { get; set; }
+
+    /// <summary>
     /// The immutable list of transmissions associated with the dialog.
     /// </summary>
     public List<DialogTransmissionDto> Transmissions { get; set; } = [];
+
+    /// <summary>
+    /// Transmissions that exist but are withheld from the authenticated user, listed by id and creation
+    /// time only. A transmission is excluded rather than returned with isAuthorized=false when its
+    /// authorization context sets unauthorizedPresentation to "excluded"; its children go with it.
+    ///
+    /// Exclusions are reported per collection: the full set for a dialog is "excludedAttachments",
+    /// "excludedTransmissions", "excludedGuiActions" and "excludedApiActions" on the dialog, plus
+    /// "excludedAttachments" and "excludedNavigationalActions" on each transmission. Merge all six when
+    /// answering "what changed that I am not allowed to see?"; reading only one under-reports silently.
+    /// </summary>
+    public List<ExcludedElementDto>? ExcludedTransmissions { get; set; }
 
     /// <summary>
     /// The GUI actions associated with the dialog. Should be used in browser-based interactive frontends.
@@ -190,9 +219,33 @@ public sealed class DialogDto
     public List<DialogGuiActionDto> GuiActions { get; set; } = [];
 
     /// <summary>
+    /// GUI actions that exist but are withheld from the authenticated user, listed by id and creation time
+    /// only. A GUI action is excluded rather than returned with isAuthorized=false when its authorization
+    /// context sets unauthorizedPresentation to "excluded".
+    ///
+    /// Exclusions are reported per collection: the full set for a dialog is "excludedAttachments",
+    /// "excludedTransmissions", "excludedGuiActions" and "excludedApiActions" on the dialog, plus
+    /// "excludedAttachments" and "excludedNavigationalActions" on each transmission. Merge all six when
+    /// answering "what changed that I am not allowed to see?"; reading only one under-reports silently.
+    /// </summary>
+    public List<ExcludedElementDto>? ExcludedGuiActions { get; set; }
+
+    /// <summary>
     /// The API actions associated with the dialog. Should be used in specialized, non-browser-based integrations.
     /// </summary>
     public List<DialogApiActionDto> ApiActions { get; set; } = [];
+
+    /// <summary>
+    /// API actions that exist but are withheld from the authenticated user, listed by id and creation time
+    /// only. An API action is excluded rather than returned with isAuthorized=false when its authorization
+    /// context sets unauthorizedPresentation to "excluded".
+    ///
+    /// Exclusions are reported per collection: the full set for a dialog is "excludedAttachments",
+    /// "excludedTransmissions", "excludedGuiActions" and "excludedApiActions" on the dialog, plus
+    /// "excludedAttachments" and "excludedNavigationalActions" on each transmission. Merge all six when
+    /// answering "what changed that I am not allowed to see?"; reading only one under-reports silently.
+    /// </summary>
+    public List<ExcludedElementDto>? ExcludedApiActions { get; set; }
 
     /// <summary>
     /// An immutable list of activities associated with the dialog.
@@ -267,6 +320,7 @@ public sealed class DialogTransmissionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete("Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute.")]
     public string? AuthorizationAttribute { get; set; }
 
     /// <summary>
@@ -274,6 +328,14 @@ public sealed class DialogTransmissionDto
     /// the attachments will not be available.
     /// </summary>
     public bool IsAuthorized { get; set; }
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific transmission, as determined by
+    /// its authorization context. Only present when the transmission has an authorization context and the user is
+    /// authorized. Should be used instead of the dialog token against URLs referred to by this transmission,
+    /// including front-channel embeds.
+    /// </summary>
+    public string? ContextToken { get; set; }
 
     /// <summary>
     /// Arbitrary URI/URN describing a service-specific transmission type.
@@ -318,9 +380,33 @@ public sealed class DialogTransmissionDto
     public List<DialogTransmissionAttachmentDto> Attachments { get; set; } = [];
 
     /// <summary>
+    /// Transmission-level attachments that exist but are withheld from the authenticated user, listed by id
+    /// and creation time only. An attachment is excluded rather than shown with masked URLs when its
+    /// authorization context sets unauthorizedPresentation to "excluded".
+    ///
+    /// Exclusions are reported per collection: the full set for a dialog is "excludedAttachments",
+    /// "excludedTransmissions", "excludedGuiActions" and "excludedApiActions" on the dialog, plus
+    /// "excludedAttachments" and "excludedNavigationalActions" on each transmission. Merge all six when
+    /// answering "what changed that I am not allowed to see?"; reading only one under-reports silently.
+    /// </summary>
+    public List<ExcludedElementDto>? ExcludedAttachments { get; set; }
+
+    /// <summary>
     /// The transmission-level navigational actions.
     /// </summary>
     public List<DialogTransmissionNavigationalActionDto> NavigationalActions { get; set; } = [];
+
+    /// <summary>
+    /// Navigational actions that exist but are withheld from the authenticated user, listed by id and
+    /// creation time only. A navigational action is excluded rather than returned with isAuthorized=false
+    /// when its authorization context sets unauthorizedPresentation to "excluded".
+    ///
+    /// Exclusions are reported per collection: the full set for a dialog is "excludedAttachments",
+    /// "excludedTransmissions", "excludedGuiActions" and "excludedApiActions" on the dialog, plus
+    /// "excludedAttachments" and "excludedNavigationalActions" on each transmission. Merge all six when
+    /// answering "what changed that I am not allowed to see?"; reading only one under-reports silently.
+    /// </summary>
+    public List<ExcludedElementDto>? ExcludedNavigationalActions { get; set; }
 }
 
 public sealed class DialogSeenLogDto
@@ -473,6 +559,7 @@ public sealed class DialogApiActionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete("Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute.")]
     public string? AuthorizationAttribute { get; set; }
 
     /// <summary>
@@ -480,6 +567,13 @@ public sealed class DialogApiActionDto
     /// and all endpoints will be replaced with a fixed placeholder.
     /// </summary>
     public bool IsAuthorized { get; set; }
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific action, as determined by its
+    /// authorization context. Only present when the action has an authorization context and the user is authorized.
+    /// Should be used instead of the dialog token against this action's endpoints.
+    /// </summary>
+    public string? ContextToken { get; set; }
 
     /// <summary>
     /// The logical name of the operation the API action refers to.
@@ -588,12 +682,20 @@ public sealed class DialogGuiActionDto
     /// /* refer to another service */
     /// urn:altinn:resource:some-other-service-identifier
     /// </example>
+    [Obsolete("Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute.")]
     public string? AuthorizationAttribute { get; set; }
 
     /// <summary>
     /// Whether the user is authorized to perform the action.
     /// </summary>
     public bool IsAuthorized { get; set; }
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific action, as determined by its
+    /// authorization context. Only present when the action has an authorization context and the user is authorized.
+    /// Should be used instead of the dialog token against this action's URL.
+    /// </summary>
+    public string? ContextToken { get; set; }
 
     /// <summary>
     /// Indicates whether the action results in the dialog being deleted. Used by frontends to implement custom UX
@@ -651,6 +753,19 @@ public sealed class DialogAttachmentDto
     /// The UTC timestamp when the attachment expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be
+    /// replaced with "urn:dialogporten:unauthorized".
+    /// </summary>
+    public bool IsAuthorized { get; set; } = true;
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific attachment, as determined by its
+    /// authorization context. Only present when the attachment has an authorization context and the user is
+    /// authorized. Should be used instead of the dialog token against this attachment's URLs.
+    /// </summary>
+    public string? ContextToken { get; set; }
 }
 
 public sealed class DialogAttachmentUrlDto
@@ -710,6 +825,19 @@ public sealed class DialogTransmissionAttachmentDto
     /// The UTC timestamp when the attachment expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be
+    /// replaced with "urn:dialogporten:unauthorized".
+    /// </summary>
+    public bool IsAuthorized { get; set; } = true;
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific attachment, as determined by its
+    /// authorization context. Only present when the attachment has an authorization context and the user is
+    /// authorized. Should be used instead of the dialog token against this attachment's URLs.
+    /// </summary>
+    public string? ContextToken { get; set; }
 }
 
 public sealed class DialogTransmissionAttachmentUrlDto
@@ -766,4 +894,17 @@ public sealed class DialogTransmissionNavigationalActionDto
     /// The UTC timestamp when the navigational action expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be
+    /// replaced with "urn:dialogporten:unauthorized".
+    /// </summary>
+    public bool IsAuthorized { get; set; } = true;
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific navigational action, as determined
+    /// by its authorization context. Only present when the navigational action has an authorization context and the
+    /// user is authorized. Should be used instead of the dialog token against this action's URL.
+    /// </summary>
+    public string? ContextToken { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -1,5 +1,7 @@
-﻿using System.Diagnostics;
+﻿#pragma warning disable CS0618 // Obsolete legacy authorization fields are mapped for backwards compatibility
+using System.Diagnostics;
 using Digdir.Domain.Dialogporten.Application.Common;
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 using Digdir.Domain.Dialogporten.Application.Common.Behaviours.FeatureMetric;
 using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 using Digdir.Domain.Dialogporten.Application.Externals;
@@ -9,10 +11,12 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using OneOf;
 using static Digdir.Domain.Dialogporten.Application.Features.V1.Common.Authorization.Constants;
+using static Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.AuthorizationExclusion;
 using Constants = Digdir.Domain.Dialogporten.Application.Common.Authorization.Constants;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Get;
@@ -96,6 +100,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
                 .OrderBy(x => x.CreatedAt).ThenBy(x => x.Id)
                 .Include(x => x.Urls.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
                 .Include(x => x.DisplayName!.Localizations.OrderBy(x => x.LanguageCode))
+                .Include(x => x.AuthorizationContext)
                 .IgnoreQueryFilters()
                 .AsSingleQuery()
                 .ToListAsync(cancellationToken: ct);
@@ -105,6 +110,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
                 .OrderBy(x => x.CreatedAt).ThenBy(x => x.Id)
                 .Include(x => x.Title!.Localizations.OrderBy(x => x.LanguageCode))
                 .Include(x => x.Prompt!.Localizations.OrderBy(x => x.LanguageCode))
+                .Include(x => x.AuthorizationContext)
                 .IgnoreQueryFilters()
                 .ToListAsync(cancellationToken: ct);
 
@@ -112,6 +118,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
                 .Where(x => x.DialogId == request.DialogId)
                 .OrderBy(x => x.CreatedAt).ThenBy(x => x.Id)
                 .Include(x => x.Endpoints.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
+                .Include(x => x.AuthorizationContext)
                 .IgnoreQueryFilters()
                 .ToListAsync(cancellationToken: ct);
 
@@ -128,6 +135,11 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
                     .ThenInclude(x => x.DisplayName!.Localizations.OrderBy(x => x.LanguageCode))
                 .Include(x => x.NavigationalActions.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
                     .ThenInclude(x => x.Title.Localizations.OrderBy(x => x.LanguageCode))
+                .Include(x => x.AuthorizationContext)
+                .Include(x => x.Attachments.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
+                    .ThenInclude(x => x.AuthorizationContext)
+                .Include(x => x.NavigationalActions.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
+                    .ThenInclude(x => x.AuthorizationContext)
                 .IgnoreQueryFilters()
                 .ToListAsync(cancellationToken: ct);
 
@@ -271,7 +283,8 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
             DialogTokenIssuerVersion
         );
 
-        DecorateWithAuthorization(dialogDto, authorizationResult);
+        DecorateWithAuthorization(dialog, dialogDto, authorizationResult);
+        ApplyExclusion(dialog, dialogDto);
         ReplaceUnauthorizedUrls(dialogDto);
         ReplaceExpiredAttachmentUrls(dialogDto);
 
@@ -305,25 +318,94 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
         return logDto;
     }
 
-    private static void DecorateWithAuthorization(DialogDto dto,
+    // Authorization is evaluated against the domain entities (which carry the authorization contexts);
+    // the DTO lists are mapped 1:1 in order from the entity lists, so pairwise zipping is safe.
+    // Each entity's check is built once and shared between the access decision and context token issuance.
+    // Each authorized entity carrying an authorization context gets a token scoped to that entity's single
+    // PDP-verified grant. Grants for contexts are expressed exclusively through these tokens — the dialog
+    // token is frozen at legacy semantics.
+    private void DecorateWithAuthorization(DialogEntity dialog, DialogDto dto,
         DialogDetailsAuthorizationResult authorization)
     {
-        foreach (var a in dto.ApiActions)
+        foreach (var (a, apiAction) in dto.ApiActions.Zip(dialog.ApiActions))
         {
-            a.IsAuthorized = authorization.HasAccessToAction(a.Action, a.AuthorizationAttribute);
+            var check = apiAction.GetAuthorizationCheck(dialog);
+            a.IsAuthorized = authorization.HasAccess(apiAction, check);
+            a.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorization, a.IsAuthorized,
+                apiAction.AuthorizationContext, check, apiAction.Id, DialogContextTokenEntityTypes.ApiAction);
         }
 
-        foreach (var g in dto.GuiActions)
+        foreach (var (g, guiAction) in dto.GuiActions.Zip(dialog.GuiActions))
         {
-            g.IsAuthorized = authorization.HasAccessToAction(g.Action, g.AuthorizationAttribute);
+            var check = guiAction.GetAuthorizationCheck(dialog);
+            g.IsAuthorized = authorization.HasAccess(guiAction, check);
+            g.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorization, g.IsAuthorized,
+                guiAction.AuthorizationContext, check, guiAction.Id, DialogContextTokenEntityTypes.GuiAction);
         }
 
         dto.Content.MainContentReference?.IsAuthorized = authorization.HasReadAccessToMainResource();
 
-        foreach (var t in dto.Transmissions)
+        foreach (var (a, attachment) in dto.Attachments.Zip(dialog.Attachments))
         {
-            t.IsAuthorized = authorization.HasReadAccessToDialogTransmission(t.AuthorizationAttribute);
+            var check = attachment.GetAuthorizationCheck(dialog);
+            a.IsAuthorized = authorization.HasAccess(attachment, check);
+            a.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorization, a.IsAuthorized,
+                attachment.AuthorizationContext, check, attachment.Id, DialogContextTokenEntityTypes.Attachment);
         }
+
+        foreach (var (t, transmission) in dto.Transmissions.Zip(dialog.Transmissions))
+        {
+            var transmissionCheck = transmission.GetAuthorizationCheck(dialog);
+            t.IsAuthorized = authorization.HasAccess(transmission, transmissionCheck);
+            t.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorization, t.IsAuthorized,
+                transmission.AuthorizationContext, transmissionCheck, transmission.Id,
+                DialogContextTokenEntityTypes.Transmission);
+
+            // Parent-first narrowing: transmission access is a precondition for its attachments and
+            // navigational actions; a child context can only further restrict access.
+            foreach (var (a, attachment) in t.Attachments.Zip(transmission.Attachments))
+            {
+                var check = attachment.GetAuthorizationCheck(dialog);
+                a.IsAuthorized = authorization.HasAccess(attachment, t.IsAuthorized, check);
+                a.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorization, a.IsAuthorized,
+                    attachment.AuthorizationContext, check, attachment.Id,
+                    DialogContextTokenEntityTypes.TransmissionAttachment);
+            }
+
+            foreach (var (n, navigationalAction) in t.NavigationalActions.Zip(transmission.NavigationalActions))
+            {
+                var check = navigationalAction.GetAuthorizationCheck(dialog);
+                n.IsAuthorized = authorization.HasAccess(navigationalAction, t.IsAuthorized, check);
+                n.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorization, n.IsAuthorized,
+                    navigationalAction.AuthorizationContext, check, navigationalAction.Id,
+                    DialogContextTokenEntityTypes.TransmissionNavigationalAction);
+            }
+        }
+    }
+
+    // Entities whose authorization context asks for unauthorizedPresentation = excluded are removed from
+    // the collection they belong to when the user is not authorized, and recorded in the sibling "excluded"
+    // list as id and creation time only. Excluding a transmission takes its children with it.
+    private static void ApplyExclusion(DialogEntity dialog, DialogDto dto)
+    {
+        (dto.ApiActions, dto.ExcludedApiActions) =
+            PartitionExcluded(dto.ApiActions, dialog.ApiActions, x => x.IsAuthorized);
+        (dto.GuiActions, dto.ExcludedGuiActions) =
+            PartitionExcluded(dto.GuiActions, dialog.GuiActions, x => x.IsAuthorized);
+        (dto.Attachments, dto.ExcludedAttachments) =
+            PartitionExcluded(dto.Attachments, dialog.Attachments, x => x.IsAuthorized);
+
+        foreach (var (t, transmission) in dto.Transmissions.Zip(dialog.Transmissions))
+        {
+            (t.Attachments, t.ExcludedAttachments) =
+                PartitionExcluded(t.Attachments, transmission.Attachments, x => x.IsAuthorized);
+            (t.NavigationalActions, t.ExcludedNavigationalActions) =
+                PartitionExcluded(t.NavigationalActions, transmission.NavigationalActions, x => x.IsAuthorized);
+        }
+
+        // Last, so the loop above can still pair transmission DTOs with their entities by position.
+        (dto.Transmissions, dto.ExcludedTransmissions) =
+            PartitionExcluded(dto.Transmissions, dialog.Transmissions, x => x.IsAuthorized);
     }
 
     private static void ReplaceUnauthorizedUrls(DialogDto dto)
@@ -347,16 +429,26 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
             dto.Content.MainContentReference.ReplaceUnauthorizedContentReference();
         }
 
+        foreach (var url in dto.Attachments.Where(a => !a.IsAuthorized).SelectMany(a => a.Urls))
+        {
+            url.Url = Constants.UnauthorizedUri;
+        }
+
         foreach (var dialogTransmission in dto.Transmissions.Where(e => !e.IsAuthorized))
         {
-            dialogTransmission.Content.ContentReference.ReplaceUnauthorizedContentReference();
-            var urls = dialogTransmission.Attachments.SelectMany(a => a.Urls).ToList();
-            foreach (var url in urls)
+            dialogTransmission.Content?.ContentReference.ReplaceUnauthorizedContentReference();
+        }
+
+        // Covers both children of unauthorized transmissions (never individually authorized) and
+        // individually unauthorized children within authorized transmissions.
+        foreach (var dialogTransmission in dto.Transmissions)
+        {
+            foreach (var url in dialogTransmission.Attachments.Where(a => !a.IsAuthorized).SelectMany(a => a.Urls))
             {
                 url.Url = Constants.UnauthorizedUri;
             }
 
-            foreach (var action in dialogTransmission.NavigationalActions)
+            foreach (var action in dialogTransmission.NavigationalActions.Where(a => !a.IsAuthorized))
             {
                 action.Url = Constants.UnauthorizedUri;
             }
@@ -366,6 +458,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
     private void ReplaceExpiredAttachmentUrls(DialogDto dto)
     {
         var expiredDialogAttachmentUrls = dto.Attachments
+            .Where(x => x.IsAuthorized)
             .Where(x => x.ExpiresAt < _clock.UtcNowOffset)
             .SelectMany(x => x.Urls);
 
@@ -377,6 +470,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
         var expiredTransmissionAttachmentUrls = dto.Transmissions
             .Where(x => x.IsAuthorized)
             .SelectMany(x => x.Attachments)
+            .Where(x => x.IsAuthorized)
             .Where(x => x.ExpiresAt < _clock.UtcNowOffset)
             .SelectMany(x => x.Urls);
 
@@ -388,6 +482,7 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
         var expiredTransmissionNavigationalActions = dto.Transmissions
             .Where(x => x.IsAuthorized)
             .SelectMany(x => x.NavigationalActions)
+            .Where(x => x.IsAuthorized)
             .Where(x => x.ExpiresAt < _clock.UtcNowOffset);
 
         foreach (var action in expiredTransmissionNavigationalActions)

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/Mappers.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/Mappers.cs
@@ -1,3 +1,4 @@
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
@@ -164,7 +165,7 @@ internal static class DialogApiActionMapExtensions
         internal DialogApiActionDto ToDto() => new()
         {
             Id = source.Id,
-            Action = source.Action,
+            Action = source.EffectiveLegacyAction ?? source.AuthorizationContext?.Action ?? Constants.ReadAction,
             AuthorizationAttribute = source.AuthorizationAttribute,
             Name = source.Name,
             Endpoints = source.Endpoints.Select(e => e.ToDto()).ToList()
@@ -198,7 +199,7 @@ internal static class DialogGuiActionMapExtensions
         internal DialogGuiActionDto ToDto() => new()
         {
             Id = source.Id,
-            Action = source.Action,
+            Action = source.EffectiveLegacyAction ?? source.AuthorizationContext?.Action ?? Constants.ReadAction,
             Url = source.Url,
             AuthorizationAttribute = source.AuthorizationAttribute,
             IsDeleteDialogAction = source.IsDeleteDialogAction,
@@ -218,7 +219,7 @@ internal static class DialogTransmissionMapExtensions
         {
             Id = source.Id,
             CreatedAt = source.CreatedAt,
-            AuthorizationAttribute = source.AuthorizationAttribute,
+            AuthorizationAttribute = source.EffectiveLegacyAuthorizationAttribute,
             ExtendedType = source.ExtendedType,
             ExternalReference = source.ExternalReference,
             RelatedTransmissionId = source.RelatedTransmissionId,

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetTransmission/GetTransmissionQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetTransmission/GetTransmissionQuery.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are mapped for backwards compatibility
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 using Digdir.Domain.Dialogporten.Application.Common.Behaviours.FeatureMetric;
@@ -8,10 +9,12 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using OneOf;
+using static Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.AuthorizationExclusion;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.GetTransmission;
 
@@ -27,19 +30,29 @@ public sealed partial class GetTransmissionResult : OneOfBase<TransmissionDto, E
 
 internal sealed class GetTransmissionQueryHandler : IRequestHandler<GetTransmissionQuery, GetTransmissionResult>
 {
+    private const string ExcludedTransmission =
+        "The transmission is not available to the authenticated user.";
+
     private readonly IDialogDbContext _dbContext;
     private readonly IAltinnAuthorization _altinnAuthorization;
     private readonly IClock _clock;
+    private readonly IDialogTokenGenerator _dialogTokenGenerator;
 
-    public GetTransmissionQueryHandler(IDialogDbContext dbContext, IAltinnAuthorization altinnAuthorization, IClock clock)
+    public GetTransmissionQueryHandler(
+        IDialogDbContext dbContext,
+        IAltinnAuthorization altinnAuthorization,
+        IClock clock,
+        IDialogTokenGenerator dialogTokenGenerator)
     {
         ArgumentNullException.ThrowIfNull(dbContext);
         ArgumentNullException.ThrowIfNull(altinnAuthorization);
         ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(dialogTokenGenerator);
 
         _dbContext = dbContext;
         _altinnAuthorization = altinnAuthorization;
         _clock = clock;
+        _dialogTokenGenerator = dialogTokenGenerator;
     }
 
     public async Task<GetTransmissionResult> Handle(GetTransmissionQuery request,
@@ -63,6 +76,14 @@ internal sealed class GetTransmissionQueryHandler : IRequestHandler<GetTransmiss
                 .Include(x => x.Transmissions)
                     .ThenInclude(x => x.Sender)
                     .ThenInclude(x => x.ActorNameEntity)
+                .Include(x => x.Transmissions.Where(x => x.Id == request.TransmissionId))
+                    .ThenInclude(x => x.AuthorizationContext)
+                .Include(x => x.Transmissions.Where(x => x.Id == request.TransmissionId))
+                    .ThenInclude(x => x.Attachments.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
+                    .ThenInclude(x => x.AuthorizationContext)
+                .Include(x => x.Transmissions.Where(x => x.Id == request.TransmissionId))
+                    .ThenInclude(x => x.NavigationalActions.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
+                    .ThenInclude(x => x.AuthorizationContext)
                 .Include(x => x.ServiceOwnerContext)
                     .ThenInclude(x => x.ServiceOwnerLabels)
                 .IgnoreQueryFilters()
@@ -104,28 +125,65 @@ internal sealed class GetTransmissionQueryHandler : IRequestHandler<GetTransmiss
         transmission.FilterTransmissionLocalizations(request.AcceptedLanguages);
         var dto = transmission.ToDto();
 
-        dto.IsAuthorized = authorizationResult.HasReadAccessToDialogTransmission(transmission.AuthorizationAttribute);
+        var transmissionCheck = transmission.GetAuthorizationCheck(dialog);
+        dto.IsAuthorized = authorizationResult.HasAccess(transmission, transmissionCheck);
+        dto.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorizationResult, dto.IsAuthorized,
+            transmission.AuthorizationContext, transmissionCheck,
+            transmission.Id, DialogContextTokenEntityTypes.Transmission);
 
-        if (dto.IsAuthorized)
+        if (!dto.IsAuthorized && transmission.ShouldExcludeWhenUnauthorized())
         {
-            ReplaceExpiredAttachmentUrls(dto);
-            ReplaceExpiredNavigationalActionUrls(dto);
-            return dto;
+            // 403 rather than the 404 the dialog-level check above returns: there, the dialog's very
+            // existence is what is withheld, whereas an excluded transmission is published by the dialog's
+            // own "excludedTransmissions" - denying that it exists would contradict the dialog response.
+            return new Forbidden(ExcludedTransmission);
         }
 
-        var urls = dto.Attachments.SelectMany(a => a.Urls).ToList();
-        foreach (var url in urls)
+        // Parent-first narrowing: transmission access is a precondition for its attachments and
+        // navigational actions; a child context can only further restrict access. The DTO lists are
+        // mapped 1:1 in order from the entity lists, so pairwise zipping is safe.
+        foreach (var (attachmentDto, attachment) in dto.Attachments.Zip(transmission.Attachments))
+        {
+            var check = attachment.GetAuthorizationCheck(dialog);
+            attachmentDto.IsAuthorized = authorizationResult.HasAccess(attachment, dto.IsAuthorized, check);
+            attachmentDto.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorizationResult,
+                attachmentDto.IsAuthorized, attachment.AuthorizationContext, check,
+                attachment.Id, DialogContextTokenEntityTypes.TransmissionAttachment);
+        }
+
+        foreach (var (navigationalActionDto, navigationalAction) in dto.NavigationalActions.Zip(transmission.NavigationalActions))
+        {
+            var check = navigationalAction.GetAuthorizationCheck(dialog);
+            navigationalActionDto.IsAuthorized = authorizationResult.HasAccess(navigationalAction, dto.IsAuthorized, check);
+            navigationalActionDto.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorizationResult,
+                navigationalActionDto.IsAuthorized, navigationalAction.AuthorizationContext, check,
+                navigationalAction.Id, DialogContextTokenEntityTypes.TransmissionNavigationalAction);
+        }
+
+        // After the loops, so each DTO could still be paired with its entity by position above.
+        (dto.Attachments, dto.ExcludedAttachments) =
+            PartitionExcluded(dto.Attachments, transmission.Attachments, x => x.IsAuthorized);
+        (dto.NavigationalActions, dto.ExcludedNavigationalActions) =
+            PartitionExcluded(dto.NavigationalActions, transmission.NavigationalActions, x => x.IsAuthorized);
+
+        foreach (var url in dto.Attachments.Where(a => !a.IsAuthorized).SelectMany(a => a.Urls))
         {
             url.Url = Constants.UnauthorizedUri;
         }
 
-        foreach (var action in dto.NavigationalActions)
+        foreach (var action in dto.NavigationalActions.Where(a => !a.IsAuthorized))
         {
             action.Url = Constants.UnauthorizedUri;
         }
 
-        dto.Content.ContentReference.ReplaceUnauthorizedContentReference();
+        if (!dto.IsAuthorized)
+        {
+            dto.Content.ContentReference.ReplaceUnauthorizedContentReference();
+            return dto;
+        }
 
+        ReplaceExpiredAttachmentUrls(dto);
+        ReplaceExpiredNavigationalActionUrls(dto);
         return dto;
     }
 
@@ -133,6 +191,7 @@ internal sealed class GetTransmissionQueryHandler : IRequestHandler<GetTransmiss
     {
         var expiredTransmissionAttachmentUrls = dto
             .Attachments
+            .Where(x => x.IsAuthorized)
             .Where(x => x.ExpiresAt < _clock.UtcNowOffset)
             .SelectMany(x => x.Urls);
 
@@ -145,6 +204,7 @@ internal sealed class GetTransmissionQueryHandler : IRequestHandler<GetTransmiss
     private void ReplaceExpiredNavigationalActionUrls(TransmissionDto dto)
     {
         var expiredNavigationalActions = dto.NavigationalActions
+            .Where(x => x.IsAuthorized)
             .Where(x => x.ExpiresAt < _clock.UtcNowOffset);
 
         foreach (var action in expiredNavigationalActions)

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetTransmission/Mapper.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetTransmission/Mapper.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are mapped for backwards compatibility
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.Actors;
@@ -14,7 +16,7 @@ internal static class TransmissionMapExtensions
         {
             Id = source.Id,
             CreatedAt = source.CreatedAt,
-            AuthorizationAttribute = source.AuthorizationAttribute,
+            AuthorizationAttribute = source.EffectiveLegacyAuthorizationAttribute,
             ExtendedType = source.ExtendedType,
             ExternalReference = source.ExternalReference,
             RelatedTransmissionId = source.RelatedTransmissionId,

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetTransmission/TransmissionDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetTransmission/TransmissionDto.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.Actors;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Common.Content;
 using Digdir.Domain.Dialogporten.Domain.Attachments;
@@ -22,6 +23,7 @@ public sealed class TransmissionDto
     /// <summary>
     /// The authorization attribute associated with the transmission.
     /// </summary>
+    [Obsolete("Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute.")]
     public string? AuthorizationAttribute { get; set; }
 
     /// <summary>
@@ -29,6 +31,14 @@ public sealed class TransmissionDto
     /// the attachments will not be available.
     /// </summary>
     public bool IsAuthorized { get; set; }
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific transmission, as determined by
+    /// its authorization context. Only present when the transmission has an authorization context and the user is
+    /// authorized. Should be used instead of the dialog token against URLs referred to by this transmission,
+    /// including front-channel embeds.
+    /// </summary>
+    public string? ContextToken { get; set; }
 
     /// <summary>
     /// The extended type URI for the transmission.
@@ -71,9 +81,33 @@ public sealed class TransmissionDto
     public List<AttachmentDto> Attachments { get; set; } = [];
 
     /// <summary>
+    /// Attachments on this transmission that exist but are withheld from the authenticated user, listed by
+    /// id and creation time only. An attachment is excluded rather than shown with masked URLs when its
+    /// authorization context sets unauthorizedPresentation to "excluded".
+    ///
+    /// Exclusions are reported per collection: the full set for a dialog is "excludedAttachments",
+    /// "excludedTransmissions", "excludedGuiActions" and "excludedApiActions" on the dialog itself, plus
+    /// "excludedAttachments" and "excludedNavigationalActions" on each transmission. Merge all six when
+    /// answering "what changed that I am not allowed to see?"; reading only one under-reports silently.
+    /// </summary>
+    public List<ExcludedElementDto>? ExcludedAttachments { get; set; }
+
+    /// <summary>
     /// The navigational actions associated with the transmission.
     /// </summary>
     public List<NavigationalActionDto> NavigationalActions { get; set; } = [];
+
+    /// <summary>
+    /// Navigational actions on this transmission that exist but are withheld from the authenticated user,
+    /// listed by id and creation time only. A navigational action is excluded rather than returned with
+    /// isAuthorized=false when its authorization context sets unauthorizedPresentation to "excluded".
+    ///
+    /// Exclusions are reported per collection: the full set for a dialog is "excludedAttachments",
+    /// "excludedTransmissions", "excludedGuiActions" and "excludedApiActions" on the dialog itself, plus
+    /// "excludedAttachments" and "excludedNavigationalActions" on each transmission. Merge all six when
+    /// answering "what changed that I am not allowed to see?"; reading only one under-reports silently.
+    /// </summary>
+    public List<ExcludedElementDto>? ExcludedNavigationalActions { get; set; }
 }
 
 public sealed class ContentDto : ITransmissionContentDto
@@ -121,6 +155,19 @@ public sealed class AttachmentDto
     /// The UTC timestamp when the attachment expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be
+    /// replaced with "urn:dialogporten:unauthorized".
+    /// </summary>
+    public bool IsAuthorized { get; set; } = true;
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific attachment, as determined by its
+    /// authorization context. Only present when the attachment has an authorization context and the user is
+    /// authorized. Should be used instead of the dialog token against this attachment's URLs.
+    /// </summary>
+    public string? ContextToken { get; set; }
 }
 
 public sealed class AttachmentUrlDto
@@ -177,4 +224,17 @@ public sealed class NavigationalActionDto
     /// The UTC timestamp when the navigational action expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be
+    /// replaced with "urn:dialogporten:unauthorized".
+    /// </summary>
+    public bool IsAuthorized { get; set; } = true;
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific navigational action, as determined
+    /// by its authorization context. Only present when the navigational action has an authorization context and the
+    /// user is authorized. Should be used instead of the dialog token against this action's URL.
+    /// </summary>
+    public string? ContextToken { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchTransmissions/Mapper.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchTransmissions/Mapper.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are mapped for backwards compatibility
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.Actors;
@@ -14,7 +16,7 @@ internal static class TransmissionMapExtensions
         {
             Id = source.Id,
             CreatedAt = source.CreatedAt,
-            AuthorizationAttribute = source.AuthorizationAttribute,
+            AuthorizationAttribute = source.EffectiveLegacyAuthorizationAttribute,
             ExtendedType = source.ExtendedType,
             ExternalReference = source.ExternalReference,
             RelatedTransmissionId = source.RelatedTransmissionId,

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchTransmissions/SearchTransmissionQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchTransmissions/SearchTransmissionQuery.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Obsolete legacy authorization fields are mapped for backwards compatibility
 using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Authorization;
 using Digdir.Domain.Dialogporten.Application.Common.Behaviours.FeatureMetric;
@@ -8,9 +9,11 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using OneOf;
+using static Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.AuthorizationExclusion;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.SearchTransmissions;
 
@@ -28,16 +31,23 @@ internal sealed class SearchTransmissionQueryHandler : IRequestHandler<SearchTra
     private readonly IDialogDbContext _db;
     private readonly IAltinnAuthorization _altinnAuthorization;
     private readonly IClock _clock;
+    private readonly IDialogTokenGenerator _dialogTokenGenerator;
 
-    public SearchTransmissionQueryHandler(IDialogDbContext db, IAltinnAuthorization altinnAuthorization, IClock clock)
+    public SearchTransmissionQueryHandler(
+        IDialogDbContext db,
+        IAltinnAuthorization altinnAuthorization,
+        IClock clock,
+        IDialogTokenGenerator dialogTokenGenerator)
     {
         ArgumentNullException.ThrowIfNull(db);
         ArgumentNullException.ThrowIfNull(altinnAuthorization);
         ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(dialogTokenGenerator);
 
         _db = db;
         _altinnAuthorization = altinnAuthorization;
         _clock = clock;
+        _dialogTokenGenerator = dialogTokenGenerator;
     }
 
     public async Task<SearchTransmissionResult> Handle(SearchTransmissionQuery request, CancellationToken cancellationToken)
@@ -60,6 +70,14 @@ internal sealed class SearchTransmissionQueryHandler : IRequestHandler<SearchTra
                 .Include(x => x.Transmissions)
                     .ThenInclude(x => x.Sender)
                     .ThenInclude(x => x.ActorNameEntity)
+                .Include(x => x.Transmissions)
+                    .ThenInclude(x => x.AuthorizationContext)
+                .Include(x => x.Transmissions)
+                    .ThenInclude(x => x.Attachments.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
+                    .ThenInclude(x => x.AuthorizationContext)
+                .Include(x => x.Transmissions)
+                    .ThenInclude(x => x.NavigationalActions.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id))
+                    .ThenInclude(x => x.AuthorizationContext)
                 .Include(x => x.ServiceOwnerContext)
                     .ThenInclude(x => x.ServiceOwnerLabels)
                 .IgnoreQueryFilters()
@@ -93,44 +111,87 @@ internal sealed class SearchTransmissionQueryHandler : IRequestHandler<SearchTra
 
         dialog.FilterDialogLocalizations(request.AcceptedLanguages);
 
-        var dto = dialog.Transmissions
+        var transmissions = dialog.Transmissions
             .OrderBy(x => x.CreatedAt)
             .ThenBy(x => x.Id)
-            .Select(t => t.ToDto())
             .ToList();
 
-        foreach (var transmission in dto)
+        var dtos = new List<TransmissionDto>(transmissions.Count);
+        foreach (var transmission in transmissions)
         {
-            transmission.IsAuthorized = authorizationResult.HasReadAccessToDialogTransmission(transmission.AuthorizationAttribute);
+            var dto = transmission.ToDto();
+            var transmissionCheck = transmission.GetAuthorizationCheck(dialog);
+            dto.IsAuthorized = authorizationResult.HasAccess(transmission, transmissionCheck);
+            dto.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorizationResult, dto.IsAuthorized,
+                transmission.AuthorizationContext, transmissionCheck,
+                transmission.Id, DialogContextTokenEntityTypes.Transmission);
 
-            if (transmission.IsAuthorized)
+            if (!dto.IsAuthorized && transmission.ShouldExcludeWhenUnauthorized())
             {
-                ReplaceExpiredAttachmentUrls(transmission);
-                ReplaceExpiredNavigationalActionUrls(transmission);
+                // Dropped rather than listed: this endpoint returns a bare JSON array, with nowhere to hang a
+                // top-level "excludedTransmissions" - and wrapping it in an envelope would break every client's
+                // deserializer. The dialog GET is the authoritative timeline and does publish the exclusion.
                 continue;
             }
 
-            var urls = transmission.Attachments.SelectMany(a => a.Urls).ToList();
-            foreach (var url in urls)
+            // Parent-first narrowing: transmission access is a precondition for its attachments and
+            // navigational actions; a child context can only further restrict access. The DTO lists are
+            // mapped 1:1 in order from the entity lists, so pairwise zipping is safe.
+            foreach (var (attachmentDto, attachment) in dto.Attachments.Zip(transmission.Attachments))
+            {
+                var check = attachment.GetAuthorizationCheck(dialog);
+                attachmentDto.IsAuthorized = authorizationResult.HasAccess(attachment, dto.IsAuthorized, check);
+                attachmentDto.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorizationResult,
+                    attachmentDto.IsAuthorized, attachment.AuthorizationContext, check,
+                    attachment.Id, DialogContextTokenEntityTypes.TransmissionAttachment);
+            }
+
+            foreach (var (navigationalActionDto, navigationalAction) in dto.NavigationalActions.Zip(transmission.NavigationalActions))
+            {
+                var check = navigationalAction.GetAuthorizationCheck(dialog);
+                navigationalActionDto.IsAuthorized = authorizationResult.HasAccess(navigationalAction, dto.IsAuthorized, check);
+                navigationalActionDto.ContextToken = _dialogTokenGenerator.GetContextTokenOrNull(dialog, authorizationResult,
+                    navigationalActionDto.IsAuthorized, navigationalAction.AuthorizationContext, check,
+                    navigationalAction.Id, DialogContextTokenEntityTypes.TransmissionNavigationalAction);
+            }
+
+            // After the loops, so each DTO could still be paired with its entity by position above.
+            (dto.Attachments, dto.ExcludedAttachments) =
+                PartitionExcluded(dto.Attachments, transmission.Attachments, x => x.IsAuthorized);
+            (dto.NavigationalActions, dto.ExcludedNavigationalActions) =
+                PartitionExcluded(dto.NavigationalActions, transmission.NavigationalActions, x => x.IsAuthorized);
+
+            foreach (var url in dto.Attachments.Where(a => !a.IsAuthorized).SelectMany(a => a.Urls))
             {
                 url.Url = Constants.UnauthorizedUri;
             }
 
-            foreach (var action in transmission.NavigationalActions)
+            foreach (var action in dto.NavigationalActions.Where(a => !a.IsAuthorized))
             {
                 action.Url = Constants.UnauthorizedUri;
             }
 
-            transmission.Content.ContentReference.ReplaceUnauthorizedContentReference();
+            if (!dto.IsAuthorized)
+            {
+                dto.Content.ContentReference.ReplaceUnauthorizedContentReference();
+            }
+            else
+            {
+                ReplaceExpiredAttachmentUrls(dto);
+                ReplaceExpiredNavigationalActionUrls(dto);
+            }
+
+            dtos.Add(dto);
         }
 
-        return dto;
+        return dtos;
     }
 
     private void ReplaceExpiredAttachmentUrls(TransmissionDto dto)
     {
         var expiredTransmissionAttachmentUrls = dto
             .Attachments
+            .Where(x => x.IsAuthorized)
             .Where(x => x.ExpiresAt < _clock.UtcNowOffset)
             .SelectMany(x => x.Urls);
 
@@ -143,6 +204,7 @@ internal sealed class SearchTransmissionQueryHandler : IRequestHandler<SearchTra
     private void ReplaceExpiredNavigationalActionUrls(TransmissionDto dto)
     {
         var expiredNavigationalActions = dto.NavigationalActions
+            .Where(x => x.IsAuthorized)
             .Where(x => x.ExpiresAt < _clock.UtcNowOffset);
 
         foreach (var action in expiredNavigationalActions)

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchTransmissions/TransmissionDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchTransmissions/TransmissionDto.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.Actors;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Common.Content;
 using Digdir.Domain.Dialogporten.Domain.Attachments;
@@ -22,6 +23,7 @@ public sealed class TransmissionDto
     /// <summary>
     /// The authorization attribute associated with the transmission.
     /// </summary>
+    [Obsolete("Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute.")]
     public string? AuthorizationAttribute { get; set; }
 
     /// <summary>
@@ -29,6 +31,14 @@ public sealed class TransmissionDto
     /// the attachments will not be available.
     /// </summary>
     public bool IsAuthorized { get; set; }
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific transmission, as determined by
+    /// its authorization context. Only present when the transmission has an authorization context and the user is
+    /// authorized. Should be used instead of the dialog token against URLs referred to by this transmission,
+    /// including front-channel embeds.
+    /// </summary>
+    public string? ContextToken { get; set; }
 
     /// <summary>
     /// The extended type URI for the transmission.
@@ -71,9 +81,33 @@ public sealed class TransmissionDto
     public List<AttachmentDto> Attachments { get; set; } = [];
 
     /// <summary>
+    /// Attachments on this transmission that exist but are withheld from the authenticated user, listed by
+    /// id and creation time only. An attachment is excluded rather than shown with masked URLs when its
+    /// authorization context sets unauthorizedPresentation to "excluded".
+    ///
+    /// Exclusions are reported per collection: the full set for a dialog is "excludedAttachments",
+    /// "excludedTransmissions", "excludedGuiActions" and "excludedApiActions" on the dialog itself, plus
+    /// "excludedAttachments" and "excludedNavigationalActions" on each transmission. Merge all six when
+    /// answering "what changed that I am not allowed to see?"; reading only one under-reports silently.
+    /// </summary>
+    public List<ExcludedElementDto>? ExcludedAttachments { get; set; }
+
+    /// <summary>
     /// The navigational actions associated with the transmission.
     /// </summary>
     public List<NavigationalActionDto> NavigationalActions { get; set; } = [];
+
+    /// <summary>
+    /// Navigational actions on this transmission that exist but are withheld from the authenticated user,
+    /// listed by id and creation time only. A navigational action is excluded rather than returned with
+    /// isAuthorized=false when its authorization context sets unauthorizedPresentation to "excluded".
+    ///
+    /// Exclusions are reported per collection: the full set for a dialog is "excludedAttachments",
+    /// "excludedTransmissions", "excludedGuiActions" and "excludedApiActions" on the dialog itself, plus
+    /// "excludedAttachments" and "excludedNavigationalActions" on each transmission. Merge all six when
+    /// answering "what changed that I am not allowed to see?"; reading only one under-reports silently.
+    /// </summary>
+    public List<ExcludedElementDto>? ExcludedNavigationalActions { get; set; }
 }
 
 public sealed class ContentDto : ITransmissionContentDto
@@ -121,6 +155,19 @@ public sealed class AttachmentDto
     /// The UTC timestamp when the attachment expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be
+    /// replaced with "urn:dialogporten:unauthorized".
+    /// </summary>
+    public bool IsAuthorized { get; set; } = true;
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific attachment, as determined by its
+    /// authorization context. Only present when the attachment has an authorization context and the user is
+    /// authorized. Should be used instead of the dialog token against this attachment's URLs.
+    /// </summary>
+    public string? ContextToken { get; set; }
 }
 
 public sealed class AttachmentUrlDto
@@ -177,4 +224,17 @@ public sealed class NavigationalActionDto
     /// The UTC timestamp when the navigational action expires and is no longer available.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be
+    /// replaced with "urn:dialogporten:unauthorized".
+    /// </summary>
+    public bool IsAuthorized { get; set; } = true;
+
+    /// <summary>
+    /// A token asserting the authenticated user's authorization for this specific navigational action, as determined
+    /// by its authorization context. Only present when the navigational action has an authorization context and the
+    /// user is authorized. Should be used instead of the dialog token against this action's URL.
+    /// </summary>
+    public string? ContextToken { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/MappingProfile.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/MappingProfile.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Get;
 using Digdir.Domain.Dialogporten.GraphQL.EndUser.Common;
 
@@ -12,6 +13,8 @@ public sealed class MappingProfile : Profile
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status));
 
         CreateMap<DialogEndUserContextDto, EndUserContext>();
+
+        CreateMap<ExcludedElementDto, ExcludedElement>();
 
         CreateMap<DialogAttachmentDto, Attachment>();
         CreateMap<DialogAttachmentUrlDto, AttachmentUrl>()

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/DialogById/ObjectTypes.cs
@@ -97,7 +97,7 @@ public sealed class Dialog
     [GraphQLDescription("The date and time when the dialog content was last updated. Example: 2022-12-31T23:59:59Z")]
     public DateTimeOffset ContentUpdatedAt { get; set; }
 
-    [GraphQLDescription("The dialog token. May be used (if supported) against external URLs referred to in this dialog's apiActions, transmissions or attachments. It should also be used for front-channel embeds.")]
+    [GraphQLDescription("The dialog token. May be used (if supported) against external URLs referred to in this dialog's apiActions, transmissions or attachments. It should also be used for front-channel embeds. Entities carrying an authorization context are the exception: they are issued their own, narrower 'contextToken' which must be used instead of this token, as the dialog token does not assert their grant.")]
     public string? DialogToken { get; set; }
 
     [GraphQLDescription("The aggregated status of the dialog.")]
@@ -131,11 +131,20 @@ public sealed class Dialog
     [GraphQLDescription("The attachments associated with the dialog (on an aggregate level).")]
     public List<Attachment> Attachments { get; set; } = [];
 
+    [GraphQLDescription("Dialog-level attachments that exist but are withheld from the authenticated user, listed by id and creation time only. An attachment is excluded rather than shown with masked URLs when its authorization context sets unauthorizedPresentation to 'excluded'. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently.")]
+    public List<ExcludedElement>? ExcludedAttachments { get; set; }
+
     [GraphQLDescription("The GUI actions associated with the dialog. Should be used in browser-based interactive frontends.")]
     public List<GuiAction> GuiActions { get; set; } = [];
 
+    [GraphQLDescription("GUI actions that exist but are withheld from the authenticated user, listed by id and creation time only. A GUI action is excluded rather than returned with isAuthorized=false when its authorization context sets unauthorizedPresentation to 'excluded'. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently.")]
+    public List<ExcludedElement>? ExcludedGuiActions { get; set; }
+
     [GraphQLDescription("The API actions associated with the dialog. Should be used in specialized, non-browser-based integrations.")]
     public List<ApiAction> ApiActions { get; set; } = [];
+
+    [GraphQLDescription("API actions that exist but are withheld from the authenticated user, listed by id and creation time only. An API action is excluded rather than returned with isAuthorized=false when its authorization context sets unauthorizedPresentation to 'excluded'. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently.")]
+    public List<ExcludedElement>? ExcludedApiActions { get; set; }
 
     [GraphQLDescription("An immutable list of activities associated with the dialog.")]
     public List<Activity> Activities { get; set; } = [];
@@ -159,6 +168,9 @@ public sealed class Dialog
     [GraphQLDescription("The immutable list of transmissions associated with the dialog.")]
     public List<Transmission> Transmissions { get; set; } = [];
 
+    [GraphQLDescription("Transmissions that exist but are withheld from the authenticated user, listed by id and creation time only. A transmission is excluded rather than returned with isAuthorized=false when its authorization context sets unauthorizedPresentation to 'excluded'; its children go with it. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently.")]
+    public List<ExcludedElement>? ExcludedTransmissions { get; set; }
+
     [GraphQLDescription("Metadata about the dialog owned by end-users.")]
     public EndUserContext EndUserContext { get; set; } = null!;
 }
@@ -172,10 +184,14 @@ public sealed class Transmission
     public DateTimeOffset CreatedAt { get; set; }
 
     [GraphQLDescription("Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service policy, which by default is the policy belonging to the service referred to by 'serviceResource' in the dialog. Can also be used to refer to other service policies. Example: mycustomresource, urn:altinn:subresource:mycustomresource, urn:altinn:task:Task_1, urn:altinn:resource:some-other-service-identifier")]
+    [GraphQLDeprecated("Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute.")]
     public string? AuthorizationAttribute { get; set; }
 
     [GraphQLDescription("Flag indicating if the authenticated user is authorized for this transmission. If not, embedded content and the attachments will not be available.")]
     public bool IsAuthorized { get; set; }
+
+    [GraphQLDescription("A token asserting the authenticated user's authorization for this specific transmission, as determined by its authorization context. Only present when the transmission has an authorization context and the user is authorized. Should be used instead of the dialog token against URLs referred to by this transmission, including front-channel embeds.")]
+    public string? ContextToken { get; set; }
 
     [GraphQLDescription("Arbitrary URI/URN describing a service-specific transmission type. Refer to the service-specific documentation provided by the service owner for details (if in use).")]
     public Uri? ExtendedType { get; set; }
@@ -201,8 +217,14 @@ public sealed class Transmission
     [GraphQLDescription("The transmission-level attachments.")]
     public List<Attachment> Attachments { get; set; } = [];
 
+    [GraphQLDescription("Attachments on this transmission that exist but are withheld from the authenticated user, listed by id and creation time only. An attachment is excluded rather than shown with masked URLs when its authorization context sets unauthorizedPresentation to 'excluded'. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently.")]
+    public List<ExcludedElement>? ExcludedAttachments { get; set; }
+
     [GraphQLDescription("The transmission-level navigational actions.")]
     public List<TransmissionNavigationalAction> NavigationalActions { get; set; } = [];
+
+    [GraphQLDescription("Navigational actions on this transmission that exist but are withheld from the authenticated user, listed by id and creation time only. A navigational action is excluded rather than returned with isAuthorized=false when its authorization context sets unauthorizedPresentation to 'excluded'. Exclusions are reported per collection: the full set for a dialog is 'excludedAttachments', 'excludedTransmissions', 'excludedGuiActions' and 'excludedApiActions' on the dialog, plus 'excludedAttachments' and 'excludedNavigationalActions' on each transmission. Merge all six when answering 'what changed that I am not allowed to see?'; reading only one under-reports silently.")]
+    public List<ExcludedElement>? ExcludedNavigationalActions { get; set; }
 }
 
 public enum TransmissionType
@@ -274,10 +296,14 @@ public sealed class ApiAction
     public string Action { get; set; } = null!;
 
     [GraphQLDescription("Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service policy, which by default is the policy belonging to the service referred to by 'serviceResource' in the dialog. Can also be used to refer to other service policies.")]
+    [GraphQLDeprecated("Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute.")]
     public string? AuthorizationAttribute { get; set; }
 
     [GraphQLDescription("True if the authenticated user is authorized for this action. If not, the action will not be available and all endpoints will be replaced with a fixed placeholder.")]
     public bool IsAuthorized { get; set; }
+
+    [GraphQLDescription("A token asserting the authenticated user's authorization for this specific action, as determined by its authorization context. Only present when the action has an authorization context and the user is authorized. Should be used instead of the dialog token against this action's endpoints.")]
+    public string? ContextToken { get; set; }
 
     [GraphQLDescription("The logical name of the operation the API action refers to.")]
     public string? Name { get; set; }
@@ -342,10 +368,14 @@ public sealed class GuiAction
     public Uri Url { get; set; } = null!;
 
     [GraphQLDescription("Contains an authorization resource attributeId, that can used in custom authorization rules in the XACML service policy, which by default is the policy belonging to the service referred to by 'serviceResource' in the dialog. Can also be used to refer to other service policies.")]
+    [GraphQLDeprecated("Use of 'authorizationContext' on the service owner API is preferred; this field only reflects the legacy authorization attribute.")]
     public string? AuthorizationAttribute { get; set; }
 
     [GraphQLDescription("Whether the user is authorized to perform the action.")]
     public bool IsAuthorized { get; set; }
+
+    [GraphQLDescription("A token asserting the authenticated user's authorization for this specific action, as determined by its authorization context. Only present when the action has an authorization context and the user is authorized. Should be used instead of the dialog token against this action's URL.")]
+    public string? ContextToken { get; set; }
 
     [GraphQLDescription("Indicates whether the action results in the dialog being deleted. Used by frontends to implement custom UX for delete actions.")]
     public bool IsDeleteDialogAction { get; set; }
@@ -386,6 +416,12 @@ public sealed class Attachment
 
     [GraphQLDescription("The UTC timestamp when the attachment expires and is no longer available.")]
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    [GraphQLDescription("Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be replaced with 'urn:dialogporten:unauthorized'.")]
+    public bool IsAuthorized { get; set; }
+
+    [GraphQLDescription("A token asserting the authenticated user's authorization for this specific attachment, as determined by its authorization context. Only present when the attachment has an authorization context and the user is authorized. Should be used instead of the dialog token against this attachment's URLs.")]
+    public string? ContextToken { get; set; }
 }
 
 public sealed class AttachmentUrl
@@ -413,6 +449,12 @@ public sealed class TransmissionNavigationalAction
 
     [GraphQLDescription("The UTC timestamp when the navigational action expires and is no longer available.")]
     public DateTimeOffset? ExpiresAt { get; set; }
+
+    [GraphQLDescription("Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be replaced with 'urn:dialogporten:unauthorized'.")]
+    public bool IsAuthorized { get; set; }
+
+    [GraphQLDescription("A token asserting the authenticated user's authorization for this specific navigational action, as determined by its authorization context. Only present when the navigational action has an authorization context and the user is authorized. Should be used instead of the dialog token against this action's URL.")]
+    public string? ContextToken { get; set; }
 }
 
 public enum AttachmentUrlConsumer
@@ -431,4 +473,13 @@ public enum DialogEventType
 {
     DialogUpdated = 1,
     DialogDeleted = 2
+}
+
+public sealed class ExcludedElement
+{
+    [GraphQLDescription("The identifier of the excluded element, matching the id it would have had in its own collection.")]
+    public Guid Id { get; set; }
+
+    [GraphQLDescription("The date and time when the excluded element was created. Lets a client order exclusions against the elements it can see, e.g. to tell where in a transmission thread something is missing.")]
+    public DateTimeOffset CreatedAt { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Swagger/OpenApiTypeNameOverrides.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Swagger/OpenApiTypeNameOverrides.cs
@@ -35,6 +35,7 @@ internal static class OpenApiTypeNameOverrides
         ["V1CommonServiceResourceMetadata_ServiceResourceMetadataServiceResource"] = "ServiceResource",
         ["V1EndUserCommon_AcceptedLanguage"] = "AcceptedLanguage",
         ["V1EndUserCommon_AcceptedLanguages"] = "AcceptedLanguages",
+        ["V1EndUserCommon_ExcludedElement"] = "ExcludedElement",
         ["V1MetadataLimitsQueriesGet_EndUserSearchLimits"] = "EndUserSearchLimits",
         ["V1MetadataLimitsQueriesGet_Limits"] = "Limits",
         ["V1MetadataLimitsQueriesGet_ServiceOwnerSearchLimits"] = "ServiceOwnerSearchLimits",

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogAuthorizationContextTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogAuthorizationContextTests.cs
@@ -1,0 +1,418 @@
+using System.Text.Json;
+using Digdir.Domain.Dialogporten.Application.Common;
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
+using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
+using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Get;
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.SearchTransmissions;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common.ApplicationFlow;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.Common.Extensions;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using static Digdir.Domain.Dialogporten.Application.Integration.Tests.Common.Common;
+using CreateContextDto = Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts.AuthorizationContextDto;
+using CreateChildContextDto = Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts.AuthorizationContextDto;
+using GetTransmissionDtoEU = Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.GetTransmission.TransmissionDto;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.EndUser.Dialogs.Queries.Get;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class GetDialogAuthorizationContextTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    private const string OtherParty = "urn:altinn:organization:identifier-no:991825827";
+    private const string ContextResource = "urn:altinn:resource:context-service";
+
+    private static readonly AuthorizationCheck ContextReadCheck =
+        new("read", AuthorizationResourceSpec.FromContext(ContextResource, null), [OtherParty]);
+
+    private static CreateContextDto ContextDto(AuthorizationContextUnauthorizedPresentation.Values ifUnauthorized, string? action = "read") =>
+        new()
+        {
+            ServiceResource = ContextResource,
+            Parties = [OtherParty],
+            Action = action,
+            UnauthorizedPresentation = ifUnauthorized
+        };
+
+    private static CreateChildContextDto ChildContextDto(AuthorizationContextUnauthorizedPresentation.Values ifUnauthorized) =>
+        new()
+        {
+            ServiceResource = ContextResource,
+            Parties = [OtherParty],
+            UnauthorizedPresentation = ifUnauthorized
+        };
+
+    private static void ConfigureMainReadOnlyAuthorization(IServiceCollection services) =>
+        services.ConfigureDialogDetailsAuthorizationResult(new DialogDetailsAuthorizationResult
+        {
+            AuthorizedChecks = [TestAuthorizedChecks.Authorized(Constants.ReadAction)]
+        });
+
+    private static void ConfigureMainReadAndContextAuthorization(IServiceCollection services) =>
+        services.ConfigureDialogDetailsAuthorizationResult(new DialogDetailsAuthorizationResult
+        {
+            AuthorizedChecks =
+            [
+                TestAuthorizedChecks.Authorized(Constants.ReadAction),
+                TestAuthorizedChecks.Authorized(ContextReadCheck)
+            ]
+        });
+
+    [Fact]
+    public Task Context_Entities_Should_Be_Authorized_With_Default_Authorization() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.Url = new Uri("https://localhost/gui");
+                    guiAction.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded);
+                });
+                x.AddAttachment(attachment => attachment.AuthorizationContext = ChildContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded));
+            })
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                var guiAction = x.GuiActions.Single();
+                guiAction.IsAuthorized.Should().BeTrue();
+                guiAction.Url.Should().Be(new Uri("https://localhost/gui"));
+                // The end user API coalesces the action from the context
+                guiAction.Action.Should().Be("read");
+
+                var attachment = x.Attachments.Single();
+                attachment.IsAuthorized.Should().BeTrue();
+                attachment.Urls.Should().AllSatisfy(url => url.Url.Should().NotBe(Constants.UnauthorizedUri));
+            });
+
+    [Fact]
+    public Task Context_GuiAction_And_ApiAction_Should_Surface_Read_As_Effective_Action_When_Context_Action_Is_Omitted() =>
+        // authorizationContext.action is documented as optional, defaulting to "read" - the mapper must
+        // surface that effective value rather than the literal (omitted) input, since both REST and GraphQL
+        // declare the action field as required.
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded, action: null);
+                });
+                x.AddApiAction(apiAction =>
+                {
+                    apiAction.Action = null;
+                    apiAction.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded, action: null);
+                });
+            })
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                x.GuiActions.Single().Action.Should().Be(Constants.ReadAction);
+                x.ApiActions.Single().Action.Should().Be(Constants.ReadAction);
+            });
+
+    [Fact]
+    public Task Unauthorized_Context_GuiAction_With_Disable_Should_Be_Masked() =>
+        FlowBuilder.For(Application, ConfigureMainReadOnlyAuthorization)
+            .CreateSimpleDialog((x, _) =>
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled);
+                }))
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                var guiAction = x.GuiActions.Single();
+                guiAction.IsAuthorized.Should().BeFalse();
+                guiAction.Url.Should().Be(Constants.UnauthorizedUri);
+
+                // Disabled is not exclusion: nothing left the list, so the property is absent entirely
+                x.ExcludedGuiActions.Should().BeNull();
+            });
+
+    [Fact]
+    public Task Unauthorized_Context_GuiAction_With_Excluded_Should_Leave_Its_List_For_The_Excluded_List() =>
+        FlowBuilder.For(Application, ConfigureMainReadOnlyAuthorization)
+            .CreateSimpleDialog((x, _) =>
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded);
+                }))
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                x.GuiActions.Should().BeEmpty();
+                var excluded = x.ExcludedGuiActions.Should().ContainSingle().Subject;
+                excluded.Id.Should().NotBeEmpty();
+                excluded.CreatedAt.Should().NotBe(default);
+            });
+
+    [Fact]
+    public Task Authorized_Context_GuiAction_Should_Keep_Url_When_Context_Check_Is_Granted() =>
+        FlowBuilder.For(Application, ConfigureMainReadAndContextAuthorization)
+            .CreateSimpleDialog((x, _) =>
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.Url = new Uri("https://localhost/gui");
+                    guiAction.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded);
+                }))
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                var guiAction = x.GuiActions.Single();
+                guiAction.IsAuthorized.Should().BeTrue();
+                guiAction.Url.Should().Be(new Uri("https://localhost/gui"));
+            });
+
+    [Fact]
+    public Task Unauthorized_Context_Dialog_Attachment_With_Disable_Should_Mask_Urls() =>
+        FlowBuilder.For(Application, ConfigureMainReadOnlyAuthorization)
+            .CreateSimpleDialog((x, _) =>
+                x.AddAttachment(attachment => attachment.AuthorizationContext = ChildContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled)))
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                var attachment = x.Attachments.Single();
+                attachment.IsAuthorized.Should().BeFalse();
+                attachment.Urls.Should().NotBeEmpty()
+                    .And.AllSatisfy(url => url.Url.Should().Be(Constants.UnauthorizedUri));
+            });
+
+    [Fact]
+    public Task Unauthorized_Context_Dialog_Attachment_With_Excluded_Should_Leave_Its_List_For_The_Excluded_List() =>
+        FlowBuilder.For(Application, ConfigureMainReadOnlyAuthorization)
+            .CreateSimpleDialog((x, _) =>
+                x.AddAttachment(attachment => attachment.AuthorizationContext = ChildContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded)))
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                x.Attachments.Should().BeEmpty();
+                x.ExcludedAttachments.Should().ContainSingle().Subject.Id.Should().NotBeEmpty();
+            });
+
+    [Fact]
+    public async Task Unauthorized_Context_Transmission_With_Excluded_Should_Leave_Its_List_In_GetDialog()
+    {
+        var transmissionId = NewUuidV7();
+
+        await FlowBuilder.For(Application, ConfigureMainReadOnlyAuthorization)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.Id = transmissionId;
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded, action: null);
+                    transmission.AddAttachment();
+                    transmission.AddNavigationalAction();
+                }))
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                // The transmission and everything under it is gone; only the stub says it existed
+                x.Transmissions.Should().BeEmpty();
+                var excluded = x.ExcludedTransmissions.Should().ContainSingle().Subject;
+                excluded.Id.Should().Be(transmissionId);
+                excluded.CreatedAt.Should().NotBe(default);
+            });
+    }
+
+    [Fact]
+    public async Task Unauthorized_Context_Transmission_With_Excluded_Should_Be_Forbidden_In_GetTransmission()
+    {
+        var transmissionId = NewUuidV7();
+
+        await FlowBuilder.For(Application, ConfigureMainReadOnlyAuthorization)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.Id = transmissionId;
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded, action: null);
+                    transmission.AddAttachment();
+                }))
+            .GetEndUserTransmission(transmissionId)
+            // 403, not 404: the dialog's own excludedTransmissions already says this transmission exists
+            .ExecuteAndAssert<Forbidden>();
+    }
+
+    [Fact]
+    public Task Unauthorized_Context_Transmission_With_Excluded_Should_Be_Dropped_From_Search() =>
+        FlowBuilder.For(Application, ConfigureMainReadOnlyAuthorization)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded, action: null);
+                    transmission.AddAttachment();
+                }))
+            .SendCommand((_, ctx) => new SearchTransmissionQuery
+            {
+                DialogId = ctx.GetDialogId(),
+            })
+            // A bare JSON array has nowhere to report exclusions; the dialog GET is the authoritative timeline
+            .ExecuteAndAssert<List<TransmissionDto>>(x => x.Should().BeEmpty());
+
+    [Fact]
+    public async Task Child_Context_Grant_Should_Not_Widen_Access_When_Parent_Transmission_Is_Denied()
+    {
+        // The transmission is unauthorized (legacy attribute not granted), while the attachment's own
+        // context check IS granted. Parent-first narrowing must still mask the attachment.
+        var transmissionId = NewUuidV7();
+
+        await FlowBuilder.For(Application, ConfigureMainReadAndContextAuthorization)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.Id = transmissionId;
+                    transmission.AuthorizationAttribute = "urn:altinn:resource:restricted";
+                    transmission.AddAttachment(attachment =>
+                        attachment.AuthorizationContext = ChildContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled));
+                }))
+            .GetEndUserTransmission(transmissionId)
+            .ExecuteAndAssert<GetTransmissionDtoEU>(x =>
+            {
+                x.IsAuthorized.Should().BeFalse();
+                x.Attachments.Should().NotBeEmpty();
+                x.Attachments.Should().AllSatisfy(a =>
+                {
+                    a.IsAuthorized.Should().BeFalse();
+                    a.Urls.Should().AllSatisfy(url => url.Url.Should().Be(Constants.UnauthorizedUri));
+                });
+            });
+    }
+
+    [Fact]
+    public Task Unauthorized_Child_Context_Within_Authorized_Transmission_Should_Only_Affect_The_Child() =>
+        FlowBuilder.For(Application, ConfigureMainReadOnlyAuthorization)
+            .CreateSimpleDialog((x, _) =>
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AddAttachment(attachment =>
+                        attachment.AuthorizationContext = ChildContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled));
+                    transmission.AddNavigationalAction(navigationalAction =>
+                        navigationalAction.AuthorizationContext = ChildContextDto(AuthorizationContextUnauthorizedPresentation.Values.Excluded));
+                }))
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                var transmission = x.Transmissions.Single();
+                transmission.IsAuthorized.Should().BeTrue();
+
+                var attachment = transmission.Attachments.Single();
+                attachment.IsAuthorized.Should().BeFalse();
+                attachment.Urls.Should().AllSatisfy(url => url.Url.Should().Be(Constants.UnauthorizedUri));
+
+                // The excluded navigational action leaves the list, and is reported beside it
+                transmission.NavigationalActions.Should().BeEmpty();
+                transmission.ExcludedNavigationalActions.Should().ContainSingle()
+                    .Subject.Id.Should().NotBeEmpty();
+
+                // ... which is per collection: the attachment above was disabled, not excluded
+                transmission.ExcludedAttachments.Should().BeNull();
+            });
+
+    [Fact]
+    public Task Authorized_Context_Entities_Should_Get_Context_Tokens() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled);
+                });
+                // Legacy gui action without a context must not get a context token
+                x.AddGuiAction(guiAction => guiAction.Priority = DialogGuiActionPriority.Values.Secondary);
+                x.AddAttachment(attachment =>
+                    attachment.AuthorizationContext = ChildContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled));
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled, action: null);
+                    transmission.AddAttachment(attachment =>
+                        attachment.AuthorizationContext = ChildContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled));
+                    transmission.AddNavigationalAction(navigationalAction =>
+                        navigationalAction.AuthorizationContext = ChildContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled));
+                });
+            })
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                // The dialog token itself is typed and carries no context grants
+                GetTokenHeader(x.DialogToken!).GetProperty("typ").GetString().Should().Be(DialogTokenTypes.DialogToken);
+
+                var contextGuiAction = x.GuiActions.Single(g => g.Action == "read");
+                contextGuiAction.IsAuthorized.Should().BeTrue();
+                contextGuiAction.ContextToken.Should().NotBeNullOrEmpty();
+
+                var legacyGuiAction = x.GuiActions.Single(g => g.Action != "read");
+                legacyGuiAction.IsAuthorized.Should().BeTrue();
+                legacyGuiAction.ContextToken.Should().BeNull();
+
+                x.Attachments.Single().ContextToken.Should().NotBeNullOrEmpty();
+
+                var transmission = x.Transmissions.Single();
+                transmission.ContextToken.Should().NotBeNullOrEmpty();
+                // The "dp-excluded" rollback sentinel is persisted on the transmission but never echoed
+                transmission.AuthorizationAttribute.Should().BeNull();
+                transmission.Attachments.Single().ContextToken.Should().NotBeNullOrEmpty();
+                transmission.NavigationalActions.Single().ContextToken.Should().NotBeNullOrEmpty();
+
+                // The context token asserts exactly the entity, the grant and the permitted parties
+                GetTokenHeader(contextGuiAction.ContextToken!).GetProperty("typ").GetString()
+                    .Should().Be(DialogTokenTypes.DialogContextToken);
+
+                var payload = GetTokenPayload(contextGuiAction.ContextToken!);
+                payload.GetProperty(DialogTokenClaimTypes.EntityId).GetGuid().Should().Be(contextGuiAction.Id);
+                payload.GetProperty(DialogTokenClaimTypes.EntityType).GetString()
+                    .Should().Be(DialogContextTokenEntityTypes.GuiAction);
+                payload.GetProperty(DialogTokenClaimTypes.Actions).GetString().Should().Be("read");
+                payload.GetProperty(DialogTokenClaimTypes.EffectiveResource).GetString().Should().Be(ContextResource);
+                payload.GetProperty(DialogTokenClaimTypes.PermittedParties).EnumerateArray()
+                    .Select(p => p.GetString()).Should().BeEquivalentTo([OtherParty]);
+                payload.GetProperty(DialogTokenClaimTypes.DialogId).GetGuid().Should().Be(x.Id);
+            });
+
+    [Fact]
+    public Task Unauthorized_Context_Entities_Should_Not_Get_Context_Tokens() =>
+        FlowBuilder.For(Application, ConfigureMainReadOnlyAuthorization)
+            .CreateSimpleDialog((x, _) =>
+            {
+                x.AddGuiAction(guiAction =>
+                {
+                    guiAction.Action = null;
+                    guiAction.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled);
+                });
+                x.AddTransmission(transmission =>
+                {
+                    transmission.AuthorizationAttribute = null;
+                    transmission.AuthorizationContext = ContextDto(AuthorizationContextUnauthorizedPresentation.Values.Disabled, action: null);
+                });
+            })
+            .GetEndUserDialog()
+            .ExecuteAndAssert<DialogDto>(x =>
+            {
+                var guiAction = x.GuiActions.Single();
+                guiAction.IsAuthorized.Should().BeFalse();
+                guiAction.ContextToken.Should().BeNull();
+
+                var transmission = x.Transmissions.Single();
+                transmission.IsAuthorized.Should().BeFalse();
+                transmission.ContextToken.Should().BeNull();
+            });
+
+    private static JsonElement GetTokenHeader(string token) => DecodeTokenPart(token, 0);
+
+    private static JsonElement GetTokenPayload(string token) => DecodeTokenPart(token, 1);
+
+    private static JsonElement DecodeTokenPart(string token, int index) =>
+        JsonSerializer.Deserialize<JsonElement>(Base64Url.Decode(token.Split('.')[index]));
+}

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogTests.cs
@@ -433,7 +433,7 @@ public class GetDialogTests(DialogApplication application) : ApplicationCollecti
                 x.Transmissions.Should().AllSatisfy(x =>
                 {
                     x.IsAuthorized.Should().BeTrue();
-                    x.Content.ContentReference.Should().NotBeNull();
+                    x.Content!.ContentReference.Should().NotBeNull();
                     x.Content.ContentReference.Value.Should().NotBeEmpty();
                     x.Content.ContentReference.Value.Should().AllSatisfy(v =>
                     {
@@ -467,7 +467,7 @@ public class GetDialogTests(DialogApplication application) : ApplicationCollecti
             {
                 var transmission = x.Transmissions.Single();
                 transmission.IsAuthorized.Should().BeFalse();
-                transmission.Content.ContentReference.Should().NotBeNull();
+                transmission.Content!.ContentReference.Should().NotBeNull();
                 transmission.Content.ContentReference!.Value.Should().NotBeEmpty()
                     .And.AllSatisfy(localization =>
                         localization.Value.Should().Be(Constants.UnauthorizedUri.ToString()));

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Transmissions/Queries/Get/GetTransmissionsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Transmissions/Queries/Get/GetTransmissionsTests.cs
@@ -101,7 +101,7 @@ public class GetTransmissionsTests(DialogApplication application) : ApplicationC
             .ExecuteAndAssert<TransmissionDto>(x =>
             {
                 x.IsAuthorized.Should().BeFalse();
-                x.Content.ContentReference.Should().NotBeNull();
+                x.Content!.ContentReference.Should().NotBeNull();
                 x.Content.ContentReference!.Value.Should().NotBeEmpty()
                     .And.AllSatisfy(localization =>
                         localization.Value.Should().Be(Constants.UnauthorizedUri.ToString()));

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Transmissions/Queries/Search/SearchTransmissionsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/Transmissions/Queries/Search/SearchTransmissionsTests.cs
@@ -74,7 +74,7 @@ public class SearchTransmissionsTests(DialogApplication application) : Applicati
             {
                 var transmission = x.Single();
                 transmission.IsAuthorized.Should().BeFalse();
-                transmission.Content.ContentReference.Should().NotBeNull();
+                transmission.Content!.ContentReference.Should().NotBeNull();
                 transmission.Content.ContentReference!.Value.Should().NotBeEmpty()
                     .And.AllSatisfy(localization =>
                         localization.Value.Should().Be(Constants.UnauthorizedUri.ToString()));

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/PropertyNameComparisonTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.Unit.Tests/ObjectTypes/PropertyNameComparisonTests.cs
@@ -1,3 +1,4 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Get;
 using Digdir.Domain.Dialogporten.Domain.Attachments;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Actions;
@@ -10,6 +11,7 @@ using Digdir.Domain.Dialogporten.GraphQL.EndUser.SearchDialogs;
 using Activity = Digdir.Domain.Dialogporten.GraphQL.EndUser.Common.Activity;
 using ActorType = Digdir.Domain.Dialogporten.Domain.Actors.ActorType;
 using Attachment = Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogById.Attachment;
+using ExcludedElement = Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogById.ExcludedElement;
 using AttachmentUrl = Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogById.AttachmentUrl;
 using DialogDto = Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Get.DialogDto;
 using DialogStatus = Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.DialogStatus;
@@ -70,6 +72,7 @@ public class PropertyNameComparisonTests
             Add(typeof(DialogTransmissionAttachmentDto), typeof(Attachment), null);
             Add(typeof(DialogTransmissionAttachmentUrlDto), typeof(AttachmentUrl), null);
             Add(typeof(DialogTransmissionNavigationalActionDto), typeof(TransmissionNavigationalAction), null);
+            Add(typeof(ExcludedElementDto), typeof(ExcludedElement), null);
 
             // ====== Enums =======
             Add(typeof(DialogStatus.Values), typeof(GraphQL.EndUser.Common.DialogStatus), null);


### PR DESCRIPTION
**Hand-written DTOs/mappers/decoration + tests; regenerated: `openapi.v1.enduser.verified.json`, `swagger.verified.json`, `schema.verified.graphql`.** Layer 9/13 of the `authorizationContext` stack (#3978).

Surfaces the feature to end users, REST and GraphQL together (a unit test enforces property parity between the end-user REST DTOs and the GraphQL object types, so they cannot be split):

- `authorization-context` authorization and `contextToken` on every carrier entity in get-dialog, get-transmission, search-transmissions and the GraphQL `dialogById`; dialog attachments, transmission attachments and navigational actions gain an `isAuthorized` flag of their own, since they can now be denied individually;
- per-entity authorization decoration: `unauthorizedPresentation: Disabled` keeps the entity visible but masks URLs and embedded content references; **`Excluded` removes it from its collection entirely** (see below);
- **parent-first narrowing**: a child whose parent is denied is denied too, and is issued no context token, regardless of what its own context would grant;
- tokens are issued only for entities that both carry a context and are authorized; authorized entities without a context continue to rely on the dialog token; unauthorized context-carrying entities receive no usable token. The standalone transmission endpoints issue them too (shared via `DialogContextTokenExtensions.GetContextTokenOrNull`), so a consumer fetching a transmission directly is never told it is authorized while being given no token to act on it;
- the existing action field surfaces the effective authorizationContext action (the field is optional on the write side and defaults to `read`), because both REST and GraphQL declare the action field as required;
- the `dialogToken` description is corrected — it told consumers to use the dialog token against "apiActions, transmissions or attachments", the exact inverse of the guidance for context-carrying entities.

## Exclusion, not in-place redaction

An unauthorized entity whose context asks for exclusion **leaves the collection it belongs to** and is recorded in a sibling list as id and creation time only (`ExcludedElement`): `excludedTransmissions`, `excludedGuiActions`, `excludedApiActions` and `excludedAttachments` on the dialog, plus `excludedAttachments` and `excludedNavigationalActions` on each transmission. The lists are nullable and absent when empty, like every other array in this contract, so a dialog that uses none of this is unchanged on the wire. A consumer answering "what am I not allowed to see?" must merge all six — reading one under-reports silently, and the field descriptions say so.

Removing rather than blanking in place:

- keeps `isAuthorized: false` meaning exactly one thing — present but not usable;
- keeps every collection a shape the write API would accept. Blanking emitted empty `guiAction.title`, `attachment.urls` and `apiAction.endpoints`, which the create validators reject, so a consumer that had internalised the documented write contract would break on them;
- leaks strictly less: a blanked GUI action still shipped its `action`, `priority`, `httpMethod` and `isDeleteDialogAction`.

`sender` and `content` therefore stay **non-nullable** on transmissions — nothing is blanked any more.

`GET /dialogs/{id}/transmissions/{transmissionId}` answers **403** for an excluded transmission rather than 404, because the dialog's own `excludedTransmissions` already publishes that it exists. `GET /dialogs/{id}/transmissions` drops them instead: it returns a bare JSON array with nowhere to report exclusions, and the dialog GET is the authoritative timeline.

**Review focus:** the decoration path in the get-dialog mappers (mask/exclude/token per carrier), the shared `AuthorizationExclusion.PartitionExcluded` helper, and `GetDialogAuthorizationContextTests`, which walks every surface.

Part of #3978.
