### PR TITLE
fix(ci): restrict dispatch ref inputs to named refs in this repository

### DIFF
--- a/.github/workflows/dispatch-build-hotfix-prod.yml
+++ b/.github/workflows/dispatch-build-hotfix-prod.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Hotfix branch or sha (branched from the current prod release tag)"
+        description: "Hotfix branch, hotfix/<name> (branched from the current prod release tag)"
         required: true
         type: string
 
@@ -46,9 +46,16 @@ jobs:
           INPUT_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
-          # Allow only operator hotfix branches or an explicit full commit SHA.
-          if [[ ! "$INPUT_REF" =~ ^hotfix/[A-Za-z0-9._/-]+$ && ! "$INPUT_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            echo "::error::Invalid ref. Allowed formats: hotfix/<name> or 40-char commit SHA."
+          # Allow only operator hotfix branches that exist in this repository. Creating a
+          # branch requires write access, whereas a raw SHA can reference fork PR commits,
+          # which are fetchable from this repository without any write access.
+          if [[ ! "$INPUT_REF" =~ ^hotfix/[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid ref. Allowed format: hotfix/<name>."
+            exit 1
+          fi
+          if ! git ls-remote --exit-code --heads "https://github.com/${GITHUB_REPOSITORY}" \
+              "refs/heads/${INPUT_REF}" >/dev/null; then
+            echo "::error::Branch '${INPUT_REF}' does not exist in ${GITHUB_REPOSITORY}."
             exit 1
           fi
 

--- a/.github/workflows/dispatch-build-hotfix-prod.yml
+++ b/.github/workflows/dispatch-build-hotfix-prod.yml
@@ -49,13 +49,20 @@ jobs:
           # Allow only operator hotfix branches that exist in this repository. Creating a
           # branch requires write access, whereas a raw SHA can reference fork PR commits,
           # which are fetchable from this repository without any write access.
-          if [[ ! "$INPUT_REF" =~ ^hotfix/[A-Za-z0-9._/-]+$ ]]; then
+          # check-ref-format rejects names the regex allows but git does not (e.g. '..').
+          if [[ ! "$INPUT_REF" =~ ^hotfix/[A-Za-z0-9._/-]+$ ]] \
+              || ! git check-ref-format "refs/heads/${INPUT_REF}"; then
             echo "::error::Invalid ref. Allowed format: hotfix/<name>."
             exit 1
           fi
-          if ! git ls-remote --exit-code --heads "https://github.com/${GITHUB_REPOSITORY}" \
-              "refs/heads/${INPUT_REF}" >/dev/null; then
+          status=0
+          git ls-remote --exit-code --heads "https://github.com/${GITHUB_REPOSITORY}" \
+            "refs/heads/${INPUT_REF}" >/dev/null || status=$?
+          if [[ "$status" -eq 2 ]]; then
             echo "::error::Branch '${INPUT_REF}' does not exist in ${GITHUB_REPOSITORY}."
+            exit 1
+          elif [[ "$status" -ne 0 ]]; then
+            echo "::error::Could not query refs in ${GITHUB_REPOSITORY} (git ls-remote exit ${status})."
             exit 1
           fi
 

--- a/.github/workflows/dispatch-deploy-branch-yt01.yml
+++ b/.github/workflows/dispatch-deploy-branch-yt01.yml
@@ -47,9 +47,19 @@ jobs:
           # Only named branches/tags in this repository are deployable. Creating a named ref
           # requires write access, whereas a raw SHA can reference fork PR commits, which are
           # fetchable from this repository without any write access.
-          if ! git ls-remote --exit-code "https://github.com/${GITHUB_REPOSITORY}" \
-              "refs/heads/${INPUT_REF}" "refs/tags/${INPUT_REF}" >/dev/null; then
+          # check-ref-format rejects glob characters, which ls-remote would treat as patterns.
+          if ! git check-ref-format "refs/heads/${INPUT_REF}"; then
+            echo "::error::'${INPUT_REF}' is not a valid ref name."
+            exit 1
+          fi
+          status=0
+          git ls-remote --exit-code "https://github.com/${GITHUB_REPOSITORY}" \
+            "refs/heads/${INPUT_REF}" "refs/tags/${INPUT_REF}" >/dev/null || status=$?
+          if [[ "$status" -eq 2 ]]; then
             echo "::error::Ref '${INPUT_REF}' is not a branch or tag in ${GITHUB_REPOSITORY}."
+            exit 1
+          elif [[ "$status" -ne 0 ]]; then
+            echo "::error::Could not query refs in ${GITHUB_REPOSITORY} (git ls-remote exit ${status})."
             exit 1
           fi
 

--- a/.github/workflows/dispatch-deploy-branch-yt01.yml
+++ b/.github/workflows/dispatch-deploy-branch-yt01.yml
@@ -1,4 +1,4 @@
-# Deploys an arbitrary (typically unmerged) branch/tag/sha to YT01 for early performance testing.
+# Deploys an arbitrary (typically unmerged) branch/tag to YT01 for early performance testing.
 #
 # This is an *ephemeral* deploy: it builds and pushes images from the given ref and updates the YT01
 # container apps, but it deliberately does NOT update the dialogporten-manifests GitOps repo. The next
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Branch, tag or sha to build and deploy (e.g. my-feature-branch)"
+        description: "Branch or tag to build and deploy (e.g. my-feature-branch)"
         required: true
         type: string
 
@@ -38,6 +38,21 @@ jobs:
     outputs:
       imageTag: ${{ steps.resolve.outputs.imageTag }}
     steps:
+      - name: Validate dispatched ref
+        env:
+          # Via env (not interpolated into the script) so a crafted ref can't inject shell commands.
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          # Only named branches/tags in this repository are deployable. Creating a named ref
+          # requires write access, whereas a raw SHA can reference fork PR commits, which are
+          # fetchable from this repository without any write access.
+          if ! git ls-remote --exit-code "https://github.com/${GITHUB_REPOSITORY}" \
+              "refs/heads/${INPUT_REF}" "refs/tags/${INPUT_REF}" >/dev/null; then
+            echo "::error::Ref '${INPUT_REF}' is not a branch or tag in ${GITHUB_REPOSITORY}."
+            exit 1
+          fi
+
       - name: "Checkout ref"
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -150,8 +150,9 @@ This workflow facilitates the deployment of infrastructure to the specified envi
 
 The normal flow promotes a release tag through `main → test → [yt01 + staging] → prod`. Two dispatch
 workflows support deploying *outside* that chain. Both are run **from `main`** and take an explicit
-`ref` input (a branch or tag that exists in this repo; raw SHAs are not accepted) that is what
-actually gets built and deployed — GitHub only lists a
+`ref` input that is what actually gets built and deployed. The YT01 deploy accepts an existing
+branch or tag; the hotfix build accepts only an existing `hotfix/<name>` branch. Raw SHAs are not
+accepted. GitHub only lists a
 workflow in the "Run workflow" picker if the file exists on the chosen branch, so a hotfix branch cut
 from an older tag would not show a newly added workflow. Running from `main` and passing the target as
 `ref` avoids that.

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -150,7 +150,8 @@ This workflow facilitates the deployment of infrastructure to the specified envi
 
 The normal flow promotes a release tag through `main → test → [yt01 + staging] → prod`. Two dispatch
 workflows support deploying *outside* that chain. Both are run **from `main`** and take an explicit
-`ref` input (branch/tag/sha) that is what actually gets built and deployed — GitHub only lists a
+`ref` input (a branch or tag that exists in this repo; raw SHAs are not accepted) that is what
+actually gets built and deployed — GitHub only lists a
 workflow in the "Run workflow" picker if the file exists on the chosen branch, so a hotfix branch cut
 from an older tag would not show a newly added workflow. Running from `main` and passing the target as
 `ref` avoids that.
@@ -167,7 +168,7 @@ handled by their own dispatch workflows (`dispatch-apps.yml`, `dispatch-infrastr
 
 1. YT01 is scale-to-zero. Bring the environment up first via the `Scale yt01 (manual)` workflow
    (`dispatch-scale-yt01-manual.yml`, action `on`).
-2. Run **Dispatch Deploy Branch to YT01** from `main` with **ref** = the branch/tag/sha to deploy.
+2. Run **Dispatch Deploy Branch to YT01** from `main` with **ref** = the branch/tag to deploy.
 
 Images are tagged `<version>-<shortsha>` (from `version.txt` + the ref's short sha), same as the main
 build convention.


### PR DESCRIPTION
## What

`dispatch-deploy-branch-yt01.yml` and `dispatch-build-hotfix-prod.yml` now validate the `ref` input before checkout: it must be an existing branch or tag on this repository (an existing `hotfix/<name>` branch for the hotfix workflow). Raw commit SHAs are no longer accepted. The input is passed via `env` so a crafted ref cannot inject shell commands. `docs/CI-CD.md` updated to match.

## Why

Addresses code scanning alerts [255](https://github.com/Altinn/dialogporten/security/code-scanning/255) and [256](https://github.com/Altinn/dialogporten/security/code-scanning/256) (`actions/untrusted-checkout`, medium). The dispatched ref is built and deployed by jobs holding real privileges. Restricting the input to named refs on this repository guarantees the dispatched code was pushed by someone with write access, which is the trust boundary `workflow_dispatch` already assumes.

## Operational impact

None for the documented flows, which already dispatch pushed branches. A bare SHA can no longer be dispatched; push a branch pointing at it instead.

## Note on the alerts

CodeQL does not model the `ls-remote` guard, so alerts 255/256 stay open after merge and should be dismissed manually ("won't fix") with a comment referencing this PR.
