### PR TITLE
ci: cut pull request CI cost with concurrency cancellation and narrower job gates

### DIFF
--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -6,6 +6,13 @@ on:
     paths-ignore:
       - "tests/k6/**"
 
+# Supersede in-flight runs for the same PR. Without this, every force-push (rebases,
+# amends, and stacked-PR restacks in particular) leaves the previous run to complete,
+# so a single restack of an N-branch stack can occupy 2N runs concurrently.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   generate-git-short-sha:
     name: Generate git short sha
@@ -32,10 +39,14 @@ jobs:
     permissions:
       contents: read
 
+  # These images are built with `push: false`, so on a PR they only prove the images still
+  # build. `build-and-test` already compiles the same projects, so the marginal signal is
+  # limited to the container context itself — gate on the files that can break that.
+  # `ci-cd-main` rebuilds and pushes them on merge regardless.
   build-docker-images:
     uses: ./.github/workflows/workflow-publish-docker-images.yml
     needs: [ build-and-test, check-for-changes ]
-    if: ${{ needs.check-for-changes.outputs.hasBackendChanges == 'true' }}
+    if: ${{ needs.check-for-changes.outputs.hasDockerChanges == 'true' }}
     permissions:
       contents: read
       packages: write
@@ -67,7 +78,12 @@ jobs:
     # but was not vulnerable on the base commit. Covers both direct and transitive dependencies
     # via `dotnet list package --vulnerable --include-transitive`, since GitHub's dependency graph
     # does not parse packages.lock.json for NuGet.
+    # Restores twice (base + head), so it is gated on the manifests that can change what
+    # NuGet resolves. A PR that touches no dependency manifest cannot introduce a
+    # package@version pair that the base commit did not already have.
     name: Vulnerabilities introduced
+    needs: [ check-for-changes ]
+    if: ${{ needs.check-for-changes.outputs.hasDependencyChanges == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -43,10 +43,14 @@ jobs:
   # build. `build-and-test` already compiles the same projects, so the marginal signal is
   # limited to the container context itself — gate on the files that can break that.
   # `ci-cd-main` rebuilds and pushes them on merge regardless.
+  # `build-and-test` stays in `needs` purely for ordering — don't burn five image builds on a
+  # branch whose tests fail. Its gate is narrower than this one though (a `.dockerignore`,
+  # `global.json` or `Directory.Build.props` change touches no `src/**` or `tests/**` file), so
+  # it can legitimately be skipped here, and a skipped dependency would otherwise skip this job.
   build-docker-images:
     uses: ./.github/workflows/workflow-publish-docker-images.yml
     needs: [ build-and-test, check-for-changes ]
-    if: ${{ needs.check-for-changes.outputs.hasDockerChanges == 'true' }}
+    if: ${{ always() && !failure() && !cancelled() && needs.check-for-changes.outputs.hasDockerChanges == 'true' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -6,9 +6,8 @@ on:
     paths-ignore:
       - "tests/k6/**"
 
-# Supersede in-flight runs for the same PR. Without this, every force-push (rebases,
-# amends, and stacked-PR restacks in particular) leaves the previous run to complete,
-# so a single restack of an N-branch stack can occupy 2N runs concurrently.
+# Supersede in-flight runs for the same PR: a force-push (rebase, amend, stacked-PR
+# restack) makes the previous run's result irrelevant, so don't let it occupy runners.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -35,7 +34,7 @@ jobs:
   build-and-test:
     uses: ./.github/workflows/workflow-build-and-test.yml
     needs: [ check-for-changes ]
-    if: ${{ needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true' }}
+    if: ${{ needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true' || needs.check-for-changes.outputs.hasDependencyChanges == 'true' }}
     permissions:
       contents: read
 
@@ -44,9 +43,9 @@ jobs:
   # limited to the container context itself — gate on the files that can break that.
   # `ci-cd-main` rebuilds and pushes them on merge regardless.
   # `build-and-test` stays in `needs` purely for ordering — don't burn five image builds on a
-  # branch whose tests fail. Its gate is narrower than this one though (a `.dockerignore`,
-  # `global.json` or `Directory.Build.props` change touches no `src/**` or `tests/**` file), so
-  # it can legitimately be skipped here, and a skipped dependency would otherwise skip this job.
+  # branch whose tests fail. Its gate is narrower than this one though (a `.dockerignore` or
+  # `.editorconfig` change touches no file it gates on), so it can legitimately be skipped
+  # here, and a skipped dependency would otherwise skip this job.
   build-docker-images:
     uses: ./.github/workflows/workflow-publish-docker-images.yml
     needs: [ build-and-test, check-for-changes ]
@@ -111,6 +110,10 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: pr/global.json
+          # Safe with RestorePackagesWithLockFile: the lock files are the cache key, and the
+          # head restore below runs `--locked-mode` so drift from them still fails.
+          cache: true
+          cache-dependency-path: 'pr/**/packages.lock.json'
 
       - name: Scan base (${{ github.event.pull_request.base.ref }})
         working-directory: base
@@ -122,7 +125,7 @@ jobs:
       - name: Scan PR head
         working-directory: pr
         run: |
-          dotnet restore
+          dotnet restore --locked-mode
           dotnet list package --vulnerable --include-transitive --format json > "$GITHUB_WORKSPACE/pr-vulns.json"
 
       - name: Fail on newly-introduced vulnerabilities

--- a/.github/workflows/workflow-build-and-test.yml
+++ b/.github/workflows/workflow-build-and-test.yml
@@ -20,6 +20,10 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: ./global.json
+          # Safe with RestorePackagesWithLockFile: the lock files are the cache key, and
+          # `restore --locked-mode` below still fails if resolution drifts from them.
+          cache: true
+          cache-dependency-path: '**/packages.lock.json'
 
       - name: Restore
         run: dotnet restore --locked-mode

--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -76,8 +76,11 @@ jobs:
       hasWebApiEndUserClientChanges: ${{ steps.filter-backend.outputs.web_api_enduser_client_any_modified == 'true'}}
       hasWebApiServiceOwnerClientChanges: ${{ steps.filter-backend.outputs.web_api_serviceowner_client_any_modified == 'true'}}
       hasSchemaPackageChanges: ${{ steps.filter-backend.outputs.schema_package_any_modified == 'true'}}
-      hasDependencyChanges: ${{ steps.filter-backend.outputs.dependencies_any_modified == 'true' || steps.filter.outputs.github_workflows_any_modified == 'true' }}
-      hasDockerChanges: ${{ steps.filter-backend.outputs.docker_any_modified == 'true' || steps.filter-backend.outputs.dependencies_any_modified == 'true' || steps.filter.outputs.github_workflows_any_modified == 'true' }}
+      # Deliberately not OR'd with github_workflows_any_modified, unlike hasBackendChanges and
+      # hasInfraChanges: the two filters below already name the workflows that govern these
+      # jobs, so an unrelated workflow edit no longer rebuilds every image and rescans NuGet.
+      hasDependencyChanges: ${{ steps.filter-backend.outputs.dependencies_any_modified == 'true' }}
+      hasDockerChanges: ${{ steps.filter-backend.outputs.docker_any_modified == 'true' || steps.filter-backend.outputs.dependencies_any_modified == 'true' }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -144,7 +147,8 @@ jobs:
             schema_package:
               - 'docs/schema/V*/**/*'
             # Anything that can change what NuGet resolves, and therefore what
-            # `dotnet list package --vulnerable` reports.
+            # `dotnet list package --vulnerable` reports. The last entry is the workflow
+            # that defines the scan itself, so a change to it still exercises it.
             dependencies:
               - '**/packages.lock.json'
               - '**/*.csproj'
@@ -153,11 +157,15 @@ jobs:
               - 'global.json'
               - 'nuget.config'
               - 'NuGet.config'
-            # Anything that can break an image build without also breaking `dotnet build`.
+              - '.github/workflows/ci-cd-pull-request.yml'
+            # Anything that can break an image build without also breaking `dotnet build`,
+            # plus the image-build pipeline and its call site.
             docker:
               - '**/Dockerfile'
               - '**/*.dockerfile'
               - '.dockerignore'
+              - '.github/workflows/workflow-publish-docker-images.yml'
+              - '.github/workflows/ci-cd-pull-request.yml'
 
       - name: Log backend changes
         run: |

--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -51,10 +51,10 @@ on:
         description: "Schema package content or infrastructure has changed"
         value: ${{ jobs.check-for-changes.outputs.hasSchemaPackageChanges }}
       hasDependencyChanges:
-        description: "NuGet dependency manifests or SDK pinning changed"
+        description: "NuGet resolution inputs, SDK pinning, or a workflow governing the dependency scan changed"
         value: ${{ jobs.check-for-changes.outputs.hasDependencyChanges }}
       hasDockerChanges:
-        description: "Dockerfiles, docker context or dependency manifests changed"
+        description: "Docker build context, NuGet resolution inputs, or a workflow governing the image build changed"
         value: ${{ jobs.check-for-changes.outputs.hasDockerChanges }}
 
 jobs:
@@ -147,8 +147,8 @@ jobs:
             schema_package:
               - 'docs/schema/V*/**/*'
             # Anything that can change what NuGet resolves, and therefore what
-            # `dotnet list package --vulnerable` reports. The last entry is the workflow
-            # that defines the scan itself, so a change to it still exercises it.
+            # `dotnet list package --vulnerable` reports. The last two entries are the workflows
+            # that define and gate the scan, so a change to either still exercises it.
             dependencies:
               - '**/packages.lock.json'
               - '**/*.csproj'
@@ -158,14 +158,16 @@ jobs:
               - 'nuget.config'
               - 'NuGet.config'
               - '.github/workflows/ci-cd-pull-request.yml'
+              - '.github/workflows/workflow-check-for-changes.yml'
             # Anything that can break an image build without also breaking `dotnet build`,
-            # plus the image-build pipeline and its call site.
+            # plus the image-build pipeline, its call site, and this filter.
             docker:
               - '**/Dockerfile'
               - '**/*.dockerfile'
               - '.dockerignore'
               - '.github/workflows/workflow-publish-docker-images.yml'
               - '.github/workflows/ci-cd-pull-request.yml'
+              - '.github/workflows/workflow-check-for-changes.yml'
 
       - name: Log backend changes
         run: |

--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -50,6 +50,12 @@ on:
       hasSchemaPackageChanges:
         description: "Schema package content or infrastructure has changed"
         value: ${{ jobs.check-for-changes.outputs.hasSchemaPackageChanges }}
+      hasDependencyChanges:
+        description: "NuGet dependency manifests or SDK pinning changed"
+        value: ${{ jobs.check-for-changes.outputs.hasDependencyChanges }}
+      hasDockerChanges:
+        description: "Dockerfiles, docker context or dependency manifests changed"
+        value: ${{ jobs.check-for-changes.outputs.hasDockerChanges }}
 
 jobs:
   check-for-changes:
@@ -70,6 +76,8 @@ jobs:
       hasWebApiEndUserClientChanges: ${{ steps.filter-backend.outputs.web_api_enduser_client_any_modified == 'true'}}
       hasWebApiServiceOwnerClientChanges: ${{ steps.filter-backend.outputs.web_api_serviceowner_client_any_modified == 'true'}}
       hasSchemaPackageChanges: ${{ steps.filter-backend.outputs.schema_package_any_modified == 'true'}}
+      hasDependencyChanges: ${{ steps.filter-backend.outputs.dependencies_any_modified == 'true' || steps.filter.outputs.github_workflows_any_modified == 'true' }}
+      hasDockerChanges: ${{ steps.filter-backend.outputs.docker_any_modified == 'true' || steps.filter-backend.outputs.dependencies_any_modified == 'true' || steps.filter.outputs.github_workflows_any_modified == 'true' }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -135,6 +143,21 @@ jobs:
               - 'src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Migrations/**/*'
             schema_package:
               - 'docs/schema/V*/**/*'
+            # Anything that can change what NuGet resolves, and therefore what
+            # `dotnet list package --vulnerable` reports.
+            dependencies:
+              - '**/packages.lock.json'
+              - '**/*.csproj'
+              - '**/*.slnx'
+              - 'Directory.Build.props'
+              - 'global.json'
+              - 'nuget.config'
+              - 'NuGet.config'
+            # Anything that can break an image build without also breaking `dotnet build`.
+            docker:
+              - '**/Dockerfile'
+              - '**/*.dockerfile'
+              - '.dockerignore'
 
       - name: Log backend changes
         run: |
@@ -149,5 +172,7 @@ jobs:
           echo "GraphQL schema changes detected: ${{ steps.filter-backend.outputs.gql_schema_any_modified }}"
           echo "Migration changes detected: ${{ steps.filter-backend.outputs.migration_any_modified }}"
           echo "Schema package changes detected: ${{ steps.filter-backend.outputs.schema_package_any_modified }}"
+          echo "Dependency manifest changes detected: ${{ steps.filter-backend.outputs.dependencies_any_modified }}"
+          echo "Docker changes detected: ${{ steps.filter-backend.outputs.docker_any_modified }}"
           echo "Changed backend files:"
           echo "${{ steps.filter-backend.outputs.backend_modified_files }}"

--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -77,8 +77,8 @@ jobs:
       hasWebApiServiceOwnerClientChanges: ${{ steps.filter-backend.outputs.web_api_serviceowner_client_any_modified == 'true'}}
       hasSchemaPackageChanges: ${{ steps.filter-backend.outputs.schema_package_any_modified == 'true'}}
       # Deliberately not OR'd with github_workflows_any_modified, unlike hasBackendChanges and
-      # hasInfraChanges: the two filters below already name the workflows that govern these
-      # jobs, so an unrelated workflow edit no longer rebuilds every image and rescans NuGet.
+      # hasInfraChanges: the dependencies and docker filters name the workflows that govern
+      # these jobs, so an unrelated workflow edit doesn't rebuild every image or rescan NuGet.
       hasDependencyChanges: ${{ steps.filter-backend.outputs.dependencies_any_modified == 'true' }}
       hasDockerChanges: ${{ steps.filter-backend.outputs.docker_any_modified == 'true' || steps.filter-backend.outputs.dependencies_any_modified == 'true' }}
     steps:
@@ -147,27 +147,34 @@ jobs:
             schema_package:
               - 'docs/schema/V*/**/*'
             # Anything that can change what NuGet resolves, and therefore what
-            # `dotnet list package --vulnerable` reports. The last two entries are the workflows
-            # that define and gate the scan, so a change to either still exercises it.
+            # `dotnet list package --vulnerable` reports. MSBuild/NuGet config files are
+            # matched at any depth: nested Directory.Build.props files shadow the root one.
+            # The last two entries are the workflows that define and gate the scan, so a
+            # change to either still exercises it.
             dependencies:
               - '**/packages.lock.json'
               - '**/*.csproj'
               - '**/*.slnx'
-              - 'Directory.Build.props'
+              - '**/Directory.Build.props'
+              - '**/Directory.Build.targets'
+              - '**/Directory.Packages.props'
               - 'global.json'
-              - 'nuget.config'
-              - 'NuGet.config'
+              - '**/nuget.config'
+              - '**/NuGet.config'
               - '.github/workflows/ci-cd-pull-request.yml'
               - '.github/workflows/workflow-check-for-changes.yml'
-            # Anything that can break an image build without also breaking `dotnet build`,
-            # plus the image-build pipeline, its call site, and this filter.
+            # Anything that can break an image build without also breaking `dotnet build`.
+            # The root .editorconfig is COPY'd into every image and, with
+            # EnforceCodeStyleInBuild + TreatWarningsAsErrors, can fail the in-container
+            # publish on a PR that skips build-and-test. The call site and this filter are
+            # already in the dependencies filter, which hasDockerChanges ORs in, so only the
+            # image-build pipeline itself is listed here.
             docker:
               - '**/Dockerfile'
               - '**/*.dockerfile'
               - '.dockerignore'
+              - '.editorconfig'
               - '.github/workflows/workflow-publish-docker-images.yml'
-              - '.github/workflows/ci-cd-pull-request.yml'
-              - '.github/workflows/workflow-check-for-changes.yml'
 
       - name: Log backend changes
         run: |

--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -183,6 +183,7 @@ jobs:
           echo "Migration changes detected: ${{ steps.filter-backend.outputs.migration_any_modified }}"
           echo "Schema package changes detected: ${{ steps.filter-backend.outputs.schema_package_any_modified }}"
           echo "Dependency manifest changes detected: ${{ steps.filter-backend.outputs.dependencies_any_modified }}"
-          echo "Docker changes detected: ${{ steps.filter-backend.outputs.docker_any_modified }}"
+          echo "Docker filter matched: ${{ steps.filter-backend.outputs.docker_any_modified }}"
+          echo "Docker image build triggered (docker || dependencies): ${{ steps.filter-backend.outputs.docker_any_modified == 'true' || steps.filter-backend.outputs.dependencies_any_modified == 'true' }}"
           echo "Changed backend files:"
           echo "${{ steps.filter-backend.outputs.backend_modified_files }}"


### PR DESCRIPTION
**Cuts a PR run from ~20 jobs / ~23 runner-minutes to ~14 / ~11, and stops superseded runs from holding runners.**

## Why

Runner capacity is shared across the org, and this workflow is the heaviest thing most PRs trigger. Measured on one completed run: `build-docker-images` ~9 min over 5 jobs, `Dry run deploy apps` ~6 min over 9 jobs, `build-and-test` ~4.6 min, `Vulnerabilities introduced` ~2.7 min (it restores twice). Four further jobs land on the self-hosted pool.

It compounds on rebase-heavy work. Restacking an 11-branch stack produced **18 simultaneous runs**, ~360 jobs queued at once: every force-push fires `synchronize` on the branch itself and again on the PR whose base moved, and nothing cancelled the superseded runs.

## What changed

- **`concurrency` + `cancel-in-progress` on the PR workflow.** `ci-cd-main`, `staging`, `prod` and `yt01` already have this; the PR workflow was the only one without, so superseded runs ran to completion. Biggest single win, and no change to merge criteria.

- **`build-docker-images` gated on Dockerfile / `.dockerignore` / dependency changes** instead of any backend change. On a PR these are built with `push: false` and `build-and-test` already compiles the same projects, so the marginal signal is the container context. `ci-cd-main` still builds and pushes on merge.

- **`Vulnerabilities introduced` gated on dependency manifests.** A PR touching no manifest cannot introduce a `package@version` pair the base commit did not already have.

- **NuGet cache in `workflow-build-and-test`**, keyed on the lock files. Safe with `RestorePackagesWithLockFile`: `restore --locked-mode` still fails if resolution drifts.

Both new filters name the workflows that govern them rather than matching all of `.github/**`, so an unrelated workflow edit no longer re-enables everything. This PR does touch those files, so it exercises both gates on itself.

## Notes

No job here can block a merge by skipping — `main` has "require status checks" enabled with an empty required-checks list. `actionlint` reports the same 24 findings as `main`, none new. The two new `check-for-changes` outputs are additive, so the other seven callers of that reusable workflow are unaffected.

**Review focus:** whether the docker gate keeps the signal you want. A PR editing only `src/**` C# will no longer build images.

**Out of scope:** the 9-job `Dry run deploy apps` fan-out — collapsing it means restructuring `workflow-deploy-apps.yml`, which is shared with real staging and prod deploys. Also gating inner layers of a `gh stack`: the `branches: [main]` filter is fine (an ordinary PR with a non-`main` base does not trigger this workflow), it is gh stack that propagates trunk-targeting CI to every layer, so that needs an explicit `github.base_ref` guard rather than a config fix.
