### PR TITLE
feat: enforce the JOSE typ header in the SDK dialog token validator

### DIFF
--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/DialogTokenTypes.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/DialogTokenTypes.cs
@@ -1,0 +1,22 @@
+namespace Altinn.ApiClients.Dialogporten;
+
+/// <summary>
+/// The JOSE "typ" header values of the tokens Dialogporten issues.
+/// </summary>
+public static class DialogTokenTypes
+{
+    /// <summary>
+    /// The dialog token, issued per dialog and asserting the actions authorized for the dialog party.
+    /// </summary>
+    /// <remarks>
+    /// Dialogporten deliberately keeps the generic "JWT" type on the dialog token; explicit typing per
+    /// RFC 8725 is applied to the token types introduced after it.
+    /// </remarks>
+    public const string DialogToken = "JWT";
+
+    /// <summary>
+    /// The dialog context token, issued per authorization-context-carrying entity and asserting a single
+    /// PDP-verified grant (action, effective resource) along with the parties it was permitted for.
+    /// </summary>
+    public const string DialogContextToken = "dialogcontexttoken+jwt";
+}

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/IDialogTokenValidator.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/IDialogTokenValidator.cs
@@ -44,6 +44,25 @@ public class DialogTokenValidationParameters
     public bool ValidateLifetime { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to validate the token's JOSE "typ" header against
+    /// <see cref="ValidTokenTypes"/>.
+    /// </summary>
+    public bool ValidateTokenType { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the token types accepted by the validation. A token whose "typ" header is missing, or holds
+    /// a type not listed here, is rejected.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="DialogTokenTypes.DialogToken"/> only. Dialogporten signs every token type with the
+    /// same keys, so a caller expecting a dialog token must not accept, say, a
+    /// <see cref="DialogTokenTypes.DialogContextToken"/> handed to it in place of one: the two assert different
+    /// things about what the holder was permitted. Set this to the type the receiving endpoint expects.
+    /// Comparison is ordinal; the types Dialogporten issues are listed in <see cref="DialogTokenTypes"/>.
+    /// </remarks>
+    public IReadOnlyCollection<string> ValidTokenTypes { get; set; } = [DialogTokenTypes.DialogToken];
+
+    /// <summary>
     /// Gets or sets the clock skew to apply when validating the token's lifetime.
     /// </summary>
     public TimeSpan ClockSkew { get; set; } = TimeSpan.FromSeconds(10);

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/IDialogTokenValidator.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/IDialogTokenValidator.cs
@@ -59,6 +59,9 @@ public class DialogTokenValidationParameters
     /// <see cref="DialogTokenTypes.DialogContextToken"/> handed to it in place of one: the two assert different
     /// things about what the holder was permitted. Set this to the type the receiving endpoint expects.
     /// Comparison is ordinal; the types Dialogporten issues are listed in <see cref="DialogTokenTypes"/>.
+    /// Selecting <see cref="DialogTokenTypes.DialogContextToken"/> here only confirms the token is a context
+    /// token; it does not validate the context-specific claims (entity id, entity type, effective resource) -
+    /// the receiver must still check those separately against the entity being accessed.
     /// </remarks>
     public IReadOnlyCollection<string> ValidTokenTypes { get; set; } = [DialogTokenTypes.DialogToken];
 

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/Services/DialogTokenValidator.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/Services/DialogTokenValidator.cs
@@ -75,9 +75,15 @@ internal sealed class DialogTokenValidator : IDialogTokenValidator
     {
         const string typPropertyName = "typ";
         var reader = new Utf8JsonReader(header);
+
+        // Require a root JSON object, and only match "typ" at depth 1 — otherwise a header carrying an
+        // unrelated nested object with its own "typ" property (e.g. {"kid":"x","nested":{"typ":"JWT"}})
+        // would satisfy validation without a genuine top-level "typ".
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject) return false;
+
         while (reader.Read())
         {
-            if (!IsPropertyName(reader, typPropertyName)) continue;
+            if (reader.CurrentDepth != 1 || !IsPropertyName(reader, typPropertyName)) continue;
             if (!reader.Read() || reader.TokenType != JsonTokenType.String) return false;
 
             foreach (var validTokenType in validTokenTypes)

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/Services/DialogTokenValidator.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/Services/DialogTokenValidator.cs
@@ -43,6 +43,11 @@ internal sealed class DialogTokenValidator : IDialogTokenValidator
             validationResult.AddError(tokenPropertyName, "Invalid signature");
         }
 
+        if (options.ValidateTokenType && !VerifyTokenType(decodedTokenParts.Header, options.ValidTokenTypes))
+        {
+            validationResult.AddError(tokenPropertyName, "Invalid typ");
+        }
+
         if (options.ValidateLifetime && !claimsPrincipal.VerifyNotValidBefore(_clock, options.ClockSkew))
         {
             validationResult.AddError(tokenPropertyName, "Invalid nbf");
@@ -64,6 +69,29 @@ internal sealed class DialogTokenValidator : IDialogTokenValidator
         }
 
         return validationResult;
+    }
+
+    private static bool VerifyTokenType(ReadOnlySpan<byte> header, IReadOnlyCollection<string> validTokenTypes)
+    {
+        const string typPropertyName = "typ";
+        var reader = new Utf8JsonReader(header);
+        while (reader.Read())
+        {
+            if (!IsPropertyName(reader, typPropertyName)) continue;
+            if (!reader.Read() || reader.TokenType != JsonTokenType.String) return false;
+
+            foreach (var validTokenType in validTokenTypes)
+            {
+                // ValueTextEquals compares the unescaped value, so a header writing the '+' of a structured
+                // type as the JSON escape u002B still matches.
+                if (reader.ValueTextEquals(validTokenType)) return true;
+            }
+
+            return false;
+        }
+
+        // A token without a "typ" header is not one of ours.
+        return false;
     }
 
     private static bool TryDecodeToken(

--- a/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/DialogTokenValidatorTests.cs
+++ b/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/DialogTokenValidatorTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using Altinn.ApiClients.Dialogporten;
 using Altinn.ApiClients.Dialogporten.Common;
@@ -16,6 +17,10 @@ public class DialogTokenValidatorTests
     private static readonly DateTimeOffset ValidTimeStamp = DateTimeOffset.Parse("2025-02-14T09:00:00Z", CultureInfo.InvariantCulture);
     private const string DialogToken =
         "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsImtpZCI6ImRwLXN0YWdpbmctMjQwMzIyLW81eW1uIn0.eyJqdGkiOiIzOGNmZGNiOS0zODhiLTQ3YjgtYTFiZi05ZjE1YjI4MTk4OTQiLCJjIjoidXJuOmFsdGlubjpwZXJzb246aWRlbnRpZmllci1ubzoxNDg4NjQ5ODIyNiIsImwiOjMsInAiOiJ1cm46YWx0aW5uOnBlcnNvbjppZGVudGlmaWVyLW5vOjE0ODg2NDk4MjI2IiwicyI6InVybjphbHRpbm46cmVzb3VyY2U6ZGFnbC1jb3JyZXNwb25kZW5jZSIsImkiOiIwMTk0ZmU4Mi05MjgwLTc3YTUtYTdjZC01ZmYwZTZhNmZhMDciLCJhIjoicmVhZCIsImlzcyI6Imh0dHBzOi8vcGxhdGZvcm0udHQwMi5hbHRpbm4ubm8vZGlhbG9ncG9ydGVuL2FwaS92MSIsImlhdCI6MTczOTUyMzM2NywibmJmIjoxNzM5NTIzMzY3LCJleHAiOjE3Mzk1MjM5Njd9.O_f-RJhRPT7B76S7aOGw6jfxKDki3uJQLLC8nVlcNVJWFIOQUsy6gU4bG1ZdqoMBZPvb2K2X4I5fGpHW9dQMAA";
+    private static readonly JsonSerializerOptions RelaxedHeaderOptions =
+        new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+    private static readonly JsonSerializerOptions EscapingHeaderOptions =
+        new() { Encoder = JavaScriptEncoder.Default };
     private static readonly PublicKeyPair[] ValidPublicKeyPairs =
     [
         new("dp-staging-240322-o5ymn", ToPublicKey("zs9hR9oqgf53th2lTdrBq3C1TZ9UlR-HVJOiUpWV63o")),
@@ -299,6 +304,142 @@ public class DialogTokenValidatorTests
         Assert.False(result.IsValid);
         Assert.True(result.Errors.ContainsKey("token"));
         Assert.Contains("Invalid actions", result.Errors["token"]);
+    }
+
+    [Fact]
+    public void ShouldReturnError_GivenContextTokenType()
+    {
+        // Arrange
+        var (token, keyPair) = CreateSignedToken(DialogTokenTypes.DialogContextToken);
+        var sut = GetSut(ValidTimeStamp, keyPair);
+
+        // Act
+        var result = sut.Validate(token);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.True(result.Errors.ContainsKey("token"));
+        Assert.Contains("Invalid typ", result.Errors["token"]);
+        Assert.DoesNotContain("Invalid signature", result.Errors["token"]);
+    }
+
+    [Fact]
+    public void ShouldReturnIsValid_GivenContextTokenTypeWhenAccepted()
+    {
+        // Arrange
+        var (token, keyPair) = CreateSignedToken(DialogTokenTypes.DialogContextToken);
+        var sut = GetSut(ValidTimeStamp, keyPair);
+
+        // Act
+        var result = sut.Validate(token, options: new DialogTokenValidationParameters
+        {
+            ClockSkew = TimeSpan.Zero,
+            ValidTokenTypes = [DialogTokenTypes.DialogContextToken]
+        });
+
+        // Assert
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ShouldReturnError_GivenMissingTokenType()
+    {
+        // Arrange
+        var (token, keyPair) = CreateSignedToken(tokenType: null);
+        var sut = GetSut(ValidTimeStamp, keyPair);
+
+        // Act
+        var result = sut.Validate(token);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.True(result.Errors.ContainsKey("token"));
+        Assert.Contains("Invalid typ", result.Errors["token"]);
+    }
+
+    [Fact]
+    public void ShouldReturnIsValid_GivenContextTokenTypeWhenTypeValidationIsDisabled()
+    {
+        // Arrange
+        var (token, keyPair) = CreateSignedToken(DialogTokenTypes.DialogContextToken);
+        var sut = GetSut(ValidTimeStamp, keyPair);
+
+        // Act
+        var result = sut.Validate(token, options: new DialogTokenValidationParameters
+        {
+            ClockSkew = TimeSpan.Zero,
+            ValidateTokenType = false
+        });
+
+        // Assert
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ShouldReturnIsValid_GivenTokenTypeEscapedInHeader()
+    {
+        // A JSON header may escape the '+' of a structured type as u002B. That is the same type.
+        // Arrange
+        var (token, keyPair) = CreateSignedToken(DialogTokenTypes.DialogContextToken, escapeHeader: true);
+        var sut = GetSut(ValidTimeStamp, keyPair);
+        Assert.Contains(@"dialogcontexttoken\u002Bjwt",
+            Encoding.UTF8.GetString(Base64Url.DecodeFromChars(token.Split('.')[0])),
+            StringComparison.Ordinal);
+
+        // Act
+        var result = sut.Validate(token, options: new DialogTokenValidationParameters
+        {
+            ClockSkew = TimeSpan.Zero,
+            ValidTokenTypes = [DialogTokenTypes.DialogContextToken]
+        });
+
+        // Assert
+        Assert.True(result.IsValid);
+    }
+
+    /// <summary>
+    /// Mints a token signed with a throwaway key, so the type assertions are made against a token that is
+    /// valid in every other respect. Tampering with the header of <see cref="DialogToken"/> would invalidate
+    /// its signature, which cannot be re-created without Dialogporten's private key.
+    /// </summary>
+    private static (string Token, PublicKeyPair KeyPair) CreateSignedToken(string? tokenType, bool escapeHeader = false)
+    {
+        const string kid = "dp-testing-generated-key";
+        using var key = Key.Create(SignatureAlgorithm.Ed25519, new KeyCreationParameters
+        {
+            ExportPolicy = KeyExportPolicies.AllowPlaintextExport
+        });
+
+        var header = tokenType is null
+            ? new Dictionary<string, object> { ["alg"] = "EdDSA", ["kid"] = kid }
+            : new Dictionary<string, object> { ["alg"] = "EdDSA", ["typ"] = tokenType, ["kid"] = kid };
+
+        var claims = new Dictionary<string, object>
+        {
+            ["jti"] = "38cfdcb9-388b-47b8-a1bf-9f15b2819894",
+            ["c"] = "urn:altinn:person:identifier-no:14886498226",
+            ["l"] = 3,
+            ["p"] = "urn:altinn:person:identifier-no:14886498226",
+            ["s"] = "urn:altinn:resource:dagl-correspondence",
+            ["i"] = "0194fe82-9280-77a5-a7cd-5ff0e6a6fa07",
+            ["a"] = "read",
+            ["iss"] = "https://platform.tt02.altinn.no/dialogporten/api/v1",
+            ["iat"] = ValidTimeStamp.ToUnixTimeSeconds(),
+            ["nbf"] = ValidTimeStamp.ToUnixTimeSeconds(),
+            ["exp"] = ValidTimeStamp.AddMinutes(10).ToUnixTimeSeconds()
+        };
+
+        // Dialogporten writes the header with the relaxed encoder, leaving a structured type's '+' literal;
+        // escapeHeader mints the equivalent header the default encoder would produce.
+        var headerOptions = escapeHeader ? EscapingHeaderOptions : RelaxedHeaderOptions;
+
+        var signedPart = string.Join('.',
+            Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header, headerOptions)),
+            Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(claims)));
+        var signature = SignatureAlgorithm.Ed25519.Sign(key, Encoding.UTF8.GetBytes(signedPart));
+
+        var publicKeyPair = new PublicKeyPair(kid, key.PublicKey);
+        return ($"{signedPart}.{Base64Url.EncodeToString(signature)}", publicKeyPair);
     }
 
     private static DialogTokenValidator GetSut(

--- a/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/DialogTokenValidatorTests.cs
+++ b/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/DialogTokenValidatorTests.cs
@@ -21,6 +21,7 @@ public class DialogTokenValidatorTests
         new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
     private static readonly JsonSerializerOptions EscapingHeaderOptions =
         new() { Encoder = JavaScriptEncoder.Default };
+    private static readonly string[] NonObjectHeader = ["not", "an", "object"];
     private static readonly PublicKeyPair[] ValidPublicKeyPairs =
     [
         new("dp-staging-240322-o5ymn", ToPublicKey("zs9hR9oqgf53th2lTdrBq3C1TZ9UlR-HVJOiUpWV63o")),
@@ -342,6 +343,50 @@ public class DialogTokenValidatorTests
     }
 
     [Fact]
+    public void ShouldReturnError_GivenTokenTypeOnlyInNestedProperty()
+    {
+        // A header carrying a "typ" only inside a nested object must not satisfy top-level typ validation.
+        // Arrange
+        const string kid = "dp-testing-generated-key";
+        var header = JsonSerializer.SerializeToUtf8Bytes(new Dictionary<string, object>
+        {
+            ["alg"] = "EdDSA",
+            ["kid"] = kid,
+            ["nested"] = new Dictionary<string, object> { ["typ"] = DialogTokenTypes.DialogToken }
+        });
+        var (token, keyPair) = CreateSignedTokenWithHeaderBytes(kid, header);
+        var sut = GetSut(ValidTimeStamp, keyPair);
+
+        // Act
+        var result = sut.Validate(token);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.True(result.Errors.ContainsKey("token"));
+        Assert.Contains("Invalid typ", result.Errors["token"]);
+        Assert.DoesNotContain("Invalid signature", result.Errors["token"]);
+    }
+
+    [Fact]
+    public void ShouldReturnError_GivenNonObjectHeader()
+    {
+        // A header whose root is not a JSON object can never carry a valid top-level "typ".
+        // Arrange
+        const string kid = "dp-testing-generated-key";
+        var header = JsonSerializer.SerializeToUtf8Bytes(NonObjectHeader);
+        var (token, keyPair) = CreateSignedTokenWithHeaderBytes(kid, header);
+        var sut = GetSut(ValidTimeStamp, keyPair);
+
+        // Act
+        var result = sut.Validate(token);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.True(result.Errors.ContainsKey("token"));
+        Assert.Contains("Invalid typ", result.Errors["token"]);
+    }
+
+    [Fact]
     public void ShouldReturnError_GivenMissingTokenType()
     {
         // Arrange
@@ -405,14 +450,28 @@ public class DialogTokenValidatorTests
     private static (string Token, PublicKeyPair KeyPair) CreateSignedToken(string? tokenType, bool escapeHeader = false)
     {
         const string kid = "dp-testing-generated-key";
+        var header = tokenType is null
+            ? new Dictionary<string, object> { ["alg"] = "EdDSA", ["kid"] = kid }
+            : new Dictionary<string, object> { ["alg"] = "EdDSA", ["typ"] = tokenType, ["kid"] = kid };
+
+        // Dialogporten writes the header with the relaxed encoder, leaving a structured type's '+' literal;
+        // escapeHeader mints the equivalent header the default encoder would produce.
+        var headerOptions = escapeHeader ? EscapingHeaderOptions : RelaxedHeaderOptions;
+        return CreateSignedTokenWithHeaderBytes(kid, JsonSerializer.SerializeToUtf8Bytes(header, headerOptions));
+    }
+
+    /// <summary>
+    /// Mints a token whose header is exactly the given raw JSON bytes, for exercising header shapes
+    /// (nested properties, non-object roots) that can't be expressed via a flat header dictionary.
+    /// The "kid" property, if present anywhere in <paramref name="headerBytes"/>, is not otherwise
+    /// inspected here — the caller passes the matching <paramref name="kid"/> for key lookup.
+    /// </summary>
+    private static (string Token, PublicKeyPair KeyPair) CreateSignedTokenWithHeaderBytes(string kid, byte[] headerBytes)
+    {
         using var key = Key.Create(SignatureAlgorithm.Ed25519, new KeyCreationParameters
         {
             ExportPolicy = KeyExportPolicies.AllowPlaintextExport
         });
-
-        var header = tokenType is null
-            ? new Dictionary<string, object> { ["alg"] = "EdDSA", ["kid"] = kid }
-            : new Dictionary<string, object> { ["alg"] = "EdDSA", ["typ"] = tokenType, ["kid"] = kid };
 
         var claims = new Dictionary<string, object>
         {
@@ -429,12 +488,8 @@ public class DialogTokenValidatorTests
             ["exp"] = ValidTimeStamp.AddMinutes(10).ToUnixTimeSeconds()
         };
 
-        // Dialogporten writes the header with the relaxed encoder, leaving a structured type's '+' literal;
-        // escapeHeader mints the equivalent header the default encoder would produce.
-        var headerOptions = escapeHeader ? EscapingHeaderOptions : RelaxedHeaderOptions;
-
         var signedPart = string.Join('.',
-            Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header, headerOptions)),
+            Base64Url.EncodeToString(headerBytes),
             Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(claims)));
         var signature = SignatureAlgorithm.Ed25519.Sign(key, Encoding.UTF8.GetBytes(signedPart));
 


### PR DESCRIPTION
**Hand-written.** Layer 12/13 of the `authorizationContext` stack (#3978).

## What

`DialogTokenValidator` validated format, signature, lifetime, dialog id and actions — but never the token type. A `dialogcontexttoken+jwt` handed to a caller expecting a dialog token therefore validated cleanly, and `VerifyActions(["sign"])` would answer from the context token's `a` claim.

That is a real substitution: the two tokens share the signing key, the issuer and most of their claims, but assert different things. The context token's `a` is a single action against the entity's *effective* resource (`r`), which a dialog-token receiver reads as an action authorized on the dialog's own resource.

## The change

- `DialogTokenValidationParameters` gains `ValidateTokenType` (default `true`) and `ValidTokenTypes` (default: the dialog token alone). A token whose `typ` is missing, or not in the list, fails with `Invalid typ`.
- `DialogTokenTypes` is added to the SDK, mirroring the types Dialogporten issues: `DialogToken` (`"JWT"`, see #4269 for why it stays generic) and `DialogContextToken` (`"dialogcontexttoken+jwt"`).
- Matching is done on the *unescaped* header value (`Utf8JsonReader.ValueTextEquals`), so a header that writes the `+` of a structured type as `\u002B` still matches. Layer 8 now emits it literally, but a receiver should not depend on that.

## Behaviour change for SDK consumers

A caller that validates context tokens must opt in:

```csharp
validator.Validate(token, options: new DialogTokenValidationParameters
{
    ValidTokenTypes = [DialogTokenTypes.DialogContextToken]
});
```

`ValidateTokenType = false` restores the previous unchecked behaviour. Note that accepting the context token type validates the *type* only — the validator still checks dialog id and actions against the dialog token's claim shape, and says nothing about the context token's own `e`/`t`/`pp` claims; a receiver acting on those must read them itself. Callers that only ever receive dialog tokens — including the three `WebApiSample` projects — need no change.

Closes the open reviewer note from #3978 ("the SDK's `DialogTokenValidator` does not validate the `typ` header").

## Tests

Seven cases in `DialogTokenValidatorTests`, all against tokens signed with a throwaway Ed25519 key so the type assertions are made on tokens that are valid in every other respect: context token rejected by default (and *only* on `typ` — the signature stays valid), accepted when listed, accepted with type validation off, missing `typ` rejected, nested-only `typ` rejected, non-object header rejected, and an escaped `+` header accepted.

Part of #3978.
