### PR TITLE
chore: flag the authorizationContext feature as experimental

### DIFF
--- a/docs/schema/V1/openapi.v1.enduser.verified.json
+++ b/docs/schema/V1/openapi.v1.enduser.verified.json
@@ -355,36 +355,40 @@
             ]
           },
           "excludedApiActions": {
-            "description": "API actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. An API action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nAPI actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. An API action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedAttachments": {
-            "description": "Dialog-level attachments that exist but are withheld from the authenticated user, listed by id and\ncreation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDialog-level attachments that exist but are withheld from the authenticated user, listed by id and\ncreation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedGuiActions": {
-            "description": "GUI actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. A GUI action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nGUI actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. A GUI action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedTransmissions": {
-            "description": "Transmissions that exist but are withheld from the authenticated user, listed by id and creation\ntime only. A transmission is excluded rather than returned with isAuthorized=false when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022; its children go with it.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nTransmissions that exist but are withheld from the authenticated user, listed by id and creation\ntime only. A transmission is excluded rather than returned with isAuthorized=false when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022; its children go with it.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The expiration date for the dialog. This is the last date when the dialog is available for the end user.\n            \nAfter this date is passed, the dialog will be considered expired and no longer available for the end user in any\nAPI. If not supplied, the dialog will be considered to never expire. This field can be changed by the service\nowner after the dialog has been created.",
@@ -768,9 +772,10 @@
             "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
           },
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s endpoints.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s endpoints.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -860,9 +865,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -884,8 +890,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1032,9 +1039,10 @@
             "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
           },
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s URL.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s URL.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -1451,9 +1459,10 @@
             ]
           },
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
@@ -1461,20 +1470,22 @@
             "type": "string"
           },
           "excludedAttachments": {
-            "description": "Transmission-level attachments that exist but are withheld from the authenticated user, listed by id\nand creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nTransmission-level attachments that exist but are withheld from the authenticated user, listed by id\nand creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedNavigationalActions": {
-            "description": "Navigational actions that exist but are withheld from the authenticated user, listed by id and\ncreation time only. A navigational action is excluded rather than returned with isAuthorized=false\nwhen its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nNavigational actions that exist but are withheld from the authenticated user, listed by id and\ncreation time only. A navigational action is excluded rather than returned with isAuthorized=false\nwhen its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "extendedType": {
             "description": "Arbitrary URI/URN describing a service-specific transmission type.\n            \nRefer to the service-specific documentation provided by the service owner for details (if in use).",
@@ -1537,9 +1548,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -1561,8 +1573,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1585,9 +1598,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -1609,8 +1623,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1782,9 +1797,10 @@
             ]
           },
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
@@ -1798,20 +1814,22 @@
             "type": "string"
           },
           "excludedAttachments": {
-            "description": "Attachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nAttachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedNavigationalActions": {
-            "description": "Navigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nNavigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "extendedType": {
             "description": "The extended type URI for the transmission.",
@@ -1870,9 +1888,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -1881,8 +1900,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -1905,9 +1925,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -1916,8 +1937,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -1940,9 +1962,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -1964,8 +1987,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -2074,9 +2098,10 @@
             ]
           },
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
@@ -2090,20 +2115,22 @@
             "type": "string"
           },
           "excludedAttachments": {
-            "description": "Attachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nAttachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedNavigationalActions": {
-            "description": "Navigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nNavigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "extendedType": {
             "description": "The extended type URI for the transmission.",
@@ -2162,9 +2189,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -2173,8 +2201,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -2273,7 +2302,7 @@
       },
       "ExcludedElement": {
         "additionalProperties": false,
-        "description": "A stub standing in for an element the authenticated user is not authorized for, and whose authorization\ncontext asks for it to be excluded rather than disabled. The element is removed from the collection it\nbelongs to and recorded here instead, so that a client can tell \u0022this existed and you cannot see it\u0022\napart from \u0022this does not exist\u0022 without being shown anything about it.",
+        "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA stub standing in for an element the authenticated user is not authorized for, and whose authorization\ncontext asks for it to be excluded rather than disabled. The element is removed from the collection it\nbelongs to and recorded here instead, so that a client can tell \u0022this existed and you cannot see it\u0022\napart from \u0022this does not exist\u0022 without being shown anything about it.",
         "properties": {
           "createdAt": {
             "description": "The UTC timestamp when the excluded element was created. Lets a client order exclusions against the\nelements it can see, e.g. to tell where in a transmission thread something is missing.",
@@ -2286,7 +2315,8 @@
             "type": "string"
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-experimental": true
       },
       "GetDialogActivityRequest": {
         "additionalProperties": false,

--- a/docs/schema/V1/openapi.v1.serviceowner.verified.json
+++ b/docs/schema/V1/openapi.v1.serviceowner.verified.json
@@ -79,6 +79,7 @@
       },
       "AuthorizationContext": {
         "additionalProperties": false,
+        "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.",
         "properties": {
           "action": {
             "description": "The XACML action to evaluate. Null when not overridden; the effective action is then \u0022read\u0022.",
@@ -120,10 +121,12 @@
             ]
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-experimental": true
       },
       "AuthorizationContextDetails": {
         "additionalProperties": false,
+        "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.",
         "properties": {
           "action": {
             "description": "The XACML action to evaluate. Null when not overridden; the effective action is then \u0022read\u0022.",
@@ -165,10 +168,12 @@
             ]
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-experimental": true
       },
       "AuthorizationContextInput": {
         "additionalProperties": false,
+        "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.",
         "properties": {
           "action": {
             "description": "The XACML action to evaluate. Optional; defaults to \u0022read\u0022 if not supplied.",
@@ -210,7 +215,8 @@
             ]
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-experimental": true
       },
       "AuthorizationContextUnauthorizedPresentation": {
         "description": "",
@@ -680,13 +686,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -775,13 +782,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -948,13 +956,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -1063,13 +1072,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -1145,13 +1155,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -1252,13 +1263,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -1295,13 +1307,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -1402,13 +1415,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -1452,13 +1466,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -2018,13 +2033,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nNull when no authorization context is set, including when the action uses legacy\nauthorization fields.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nNull when no authorization context is set, including when the action uses legacy\nauthorization fields.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -2114,13 +2130,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -2312,13 +2329,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nNull when no authorization context is set, including when the action uses legacy\nauthorization fields.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nNull when no authorization context is set, including when the action uses legacy\nauthorization fields.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -2863,13 +2881,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses legacy\nauthorization fields.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses legacy\nauthorization fields.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -2951,13 +2970,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -3004,13 +3024,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextDetails"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -3193,13 +3214,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses the legacy\n\u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses the legacy\n\u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextDetails"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The content of the transmission.",
@@ -3272,13 +3294,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -3312,13 +3335,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextDetails"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -3347,13 +3371,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/DialogTransmissionSearchAuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -3424,6 +3449,7 @@
       },
       "DialogTransmissionSearchAuthorizationContext": {
         "additionalProperties": false,
+        "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.",
         "properties": {
           "action": {
             "description": "The XACML action to evaluate. Null when not overridden; the effective action is then \u0022read\u0022.",
@@ -3465,7 +3491,8 @@
             ]
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-experimental": true
       },
       "DialogTransmissionSearchContent": {
         "additionalProperties": false,
@@ -3518,13 +3545,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses the legacy\n\u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses the legacy\n\u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/DialogTransmissionSearchAuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The content of the transmission.",
@@ -3597,13 +3625,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/DialogTransmissionSearchAuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -4431,13 +4460,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -4526,13 +4556,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -4700,13 +4731,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -4791,13 +4823,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -4873,13 +4906,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -4980,13 +5014,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -5014,13 +5049,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -5128,13 +5164,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -5178,13 +5215,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/AuthorizationContextInput"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The transmission unstructured text content.",

--- a/docs/schema/V1/swagger.verified.json
+++ b/docs/schema/V1/swagger.verified.json
@@ -481,6 +481,7 @@
       },
       "V1CommonAuthorizationContexts_AuthorizationContext": {
         "additionalProperties": false,
+        "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.",
         "properties": {
           "action": {
             "description": "The XACML action to evaluate. Optional; defaults to \u0022read\u0022 if not supplied.",
@@ -522,7 +523,8 @@
             ]
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-experimental": true
       },
       "V1CommonContent_ContentValue": {
         "additionalProperties": false,
@@ -887,7 +889,7 @@
       },
       "V1EndUserCommon_ExcludedElement": {
         "additionalProperties": false,
-        "description": "A stub standing in for an element the authenticated user is not authorized for, and whose authorization\ncontext asks for it to be excluded rather than disabled. The element is removed from the collection it\nbelongs to and recorded here instead, so that a client can tell \u0022this existed and you cannot see it\u0022\napart from \u0022this does not exist\u0022 without being shown anything about it.",
+        "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA stub standing in for an element the authenticated user is not authorized for, and whose authorization\ncontext asks for it to be excluded rather than disabled. The element is removed from the collection it\nbelongs to and recorded here instead, so that a client can tell \u0022this existed and you cannot see it\u0022\napart from \u0022this does not exist\u0022 without being shown anything about it.",
         "properties": {
           "createdAt": {
             "description": "The UTC timestamp when the excluded element was created. Lets a client order exclusions against the\nelements it can see, e.g. to tell where in a transmission thread something is missing.",
@@ -900,7 +902,8 @@
             "type": "string"
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-experimental": true
       },
       "V1EndUserCommonActors_Actor": {
         "additionalProperties": false,
@@ -1069,36 +1072,40 @@
             ]
           },
           "excludedApiActions": {
-            "description": "API actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. An API action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nAPI actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. An API action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedAttachments": {
-            "description": "Dialog-level attachments that exist but are withheld from the authenticated user, listed by id and\ncreation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDialog-level attachments that exist but are withheld from the authenticated user, listed by id and\ncreation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedGuiActions": {
-            "description": "GUI actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. A GUI action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nGUI actions that exist but are withheld from the authenticated user, listed by id and creation time\nonly. A GUI action is excluded rather than returned with isAuthorized=false when its authorization\ncontext sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedTransmissions": {
-            "description": "Transmissions that exist but are withheld from the authenticated user, listed by id and creation\ntime only. A transmission is excluded rather than returned with isAuthorized=false when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022; its children go with it.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nTransmissions that exist but are withheld from the authenticated user, listed by id and creation\ntime only. A transmission is excluded rather than returned with isAuthorized=false when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022; its children go with it.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The expiration date for the dialog. This is the last date when the dialog is available for the end user.\n            \nAfter this date is passed, the dialog will be considered expired and no longer available for the end user in any\nAPI. If not supplied, the dialog will be considered to never expire. This field can be changed by the service\nowner after the dialog has been created.",
@@ -1315,9 +1322,10 @@
             "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
           },
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s endpoints.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s endpoints.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -1407,9 +1415,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -1431,8 +1440,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1518,9 +1528,10 @@
             "x-deprecatedMessage": "Use of \u0027authorizationContext\u0027 on the service owner API is preferred; this field only reflects the legacy authorization attribute."
           },
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s URL.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific action, as determined by its\nauthorization context. Only present when the action has an authorization context and the user is authorized.\nShould be used instead of the dialog token against this action\u0027s URL.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -1651,9 +1662,10 @@
             ]
           },
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
@@ -1661,20 +1673,22 @@
             "type": "string"
           },
           "excludedAttachments": {
-            "description": "Transmission-level attachments that exist but are withheld from the authenticated user, listed by id\nand creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nTransmission-level attachments that exist but are withheld from the authenticated user, listed by id\nand creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedNavigationalActions": {
-            "description": "Navigational actions that exist but are withheld from the authenticated user, listed by id and\ncreation time only. A navigational action is excluded rather than returned with isAuthorized=false\nwhen its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nNavigational actions that exist but are withheld from the authenticated user, listed by id and\ncreation time only. A navigational action is excluded rather than returned with isAuthorized=false\nwhen its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "extendedType": {
             "description": "Arbitrary URI/URN describing a service-specific transmission type.\n            \nRefer to the service-specific documentation provided by the service owner for details (if in use).",
@@ -1737,9 +1751,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -1761,8 +1776,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -1848,9 +1864,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -1859,8 +1876,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -1958,9 +1976,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -1982,8 +2001,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -2069,9 +2089,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -2080,8 +2101,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -2127,9 +2149,10 @@
             ]
           },
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
@@ -2143,20 +2166,22 @@
             "type": "string"
           },
           "excludedAttachments": {
-            "description": "Attachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nAttachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedNavigationalActions": {
-            "description": "Navigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nNavigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "extendedType": {
             "description": "The extended type URI for the transmission.",
@@ -2631,9 +2656,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific attachment, as determined by its\nauthorization context. Only present when the attachment has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against this attachment\u0027s URLs.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -2655,8 +2681,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this attachment. If not, the URLs will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "name": {
             "description": "The logical name of the attachment.",
@@ -2742,9 +2769,10 @@
         "additionalProperties": false,
         "properties": {
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific navigational action, as determined\nby its authorization context. Only present when the navigational action has an authorization context and the\nuser is authorized. Should be used instead of the dialog token against this action\u0027s URL.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -2753,8 +2781,9 @@
             "type": "string"
           },
           "isAuthorized": {
-            "description": "Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
-            "type": "boolean"
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nIndicates whether the authenticated user is authorized for this navigational action. If not, the URL will be\nreplaced with \u0022urn:dialogporten:unauthorized\u0022.",
+            "type": "boolean",
+            "x-experimental": true
           },
           "title": {
             "description": "The title of the navigational action.",
@@ -2800,9 +2829,10 @@
             ]
           },
           "contextToken": {
-            "description": "A token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nA token asserting the authenticated user\u0027s authorization for this specific transmission, as determined by\nits authorization context. Only present when the transmission has an authorization context and the user is\nauthorized. Should be used instead of the dialog token against URLs referred to by this transmission,\nincluding front-channel embeds.",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-experimental": true
           },
           "createdAt": {
             "description": "The date and time when the transmission was created.",
@@ -2816,20 +2846,22 @@
             "type": "string"
           },
           "excludedAttachments": {
-            "description": "Attachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nAttachments on this transmission that exist but are withheld from the authenticated user, listed by\nid and creation time only. An attachment is excluded rather than shown with masked URLs when its\nauthorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "excludedNavigationalActions": {
-            "description": "Navigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nNavigational actions on this transmission that exist but are withheld from the authenticated user,\nlisted by id and creation time only. A navigational action is excluded rather than returned with\nisAuthorized=false when its authorization context sets unauthorizedPresentation to \u0022excluded\u0022.\n            \nExclusions are reported per collection: the full set for a dialog is \u0022excludedAttachments\u0022,\n\u0022excludedTransmissions\u0022, \u0022excludedGuiActions\u0022 and \u0022excludedApiActions\u0022 on the dialog itself, plus\n\u0022excludedAttachments\u0022 and \u0022excludedNavigationalActions\u0022 on each transmission. Merge all six when\nanswering \u0022what changed that I am not allowed to see?\u0022; reading only one under-reports silently.",
             "items": {
               "$ref": "#/components/schemas/V1EndUserCommon_ExcludedElement"
             },
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "x-experimental": true
           },
           "extendedType": {
             "description": "The extended type URI for the transmission.",
@@ -3265,13 +3297,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -3360,13 +3393,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -3733,13 +3767,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -3834,13 +3869,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -3916,13 +3952,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -4023,13 +4060,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -4112,13 +4150,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -4219,13 +4258,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -4269,13 +4309,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -4422,13 +4463,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -4517,13 +4559,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -4815,13 +4858,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nCannot be combined with \u0022authorizationAttribute\u0022 or \u0022action\u0022; the XACML action is given by\n\u0022authorizationContext.action\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -4906,13 +4950,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -4988,13 +5033,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -5095,13 +5141,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -5129,13 +5176,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -5243,13 +5291,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition; this\ncontext can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -5293,13 +5342,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nCannot be combined with \u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1CommonAuthorizationContexts_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -5370,6 +5420,7 @@
       },
       "V1ServiceOwnerDialogsQueriesGet_AuthorizationContext": {
         "additionalProperties": false,
+        "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.",
         "properties": {
           "action": {
             "description": "The XACML action to evaluate. Null when not overridden; the effective action is then \u0022read\u0022.",
@@ -5411,7 +5462,8 @@
             ]
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-experimental": true
       },
       "V1ServiceOwnerDialogsQueriesGet_Content": {
         "additionalProperties": false,
@@ -5804,13 +5856,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nNull when no authorization context is set, including when the action uses legacy\nauthorization fields.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nNull when no authorization context is set, including when the action uses legacy\nauthorization fields.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesGet_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "endpoints": {
             "description": "The endpoints associated with the action.",
@@ -5900,13 +5953,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesGet_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -6018,13 +6072,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this action.\nNull when no authorization context is set, including when the action uses legacy\nauthorization fields.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this action.\nNull when no authorization context is set, including when the action uses legacy\nauthorization fields.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesGet_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "httpMethod": {
             "description": "The HTTP method that the frontend should use when redirecting the user.",
@@ -6163,13 +6218,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses legacy\nauthorization fields.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses legacy\nauthorization fields.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesGet_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The transmission unstructured text content.",
@@ -6251,13 +6307,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesGet_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -6367,13 +6424,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent is always required in addition; this context\ncan only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesGet_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -6476,13 +6534,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesGetTransmission_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -6553,6 +6612,7 @@
       },
       "V1ServiceOwnerDialogsQueriesGetTransmission_AuthorizationContext": {
         "additionalProperties": false,
+        "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.",
         "properties": {
           "action": {
             "description": "The XACML action to evaluate. Null when not overridden; the effective action is then \u0022read\u0022.",
@@ -6594,7 +6654,8 @@
             ]
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-experimental": true
       },
       "V1ServiceOwnerDialogsQueriesGetTransmission_Content": {
         "additionalProperties": false,
@@ -6632,13 +6693,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesGetTransmission_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -6682,13 +6744,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses the legacy\n\u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses the legacy\n\u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesGetTransmission_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The content of the transmission.",
@@ -7242,13 +7305,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this attachment.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesSearchTransmissions_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "displayName": {
             "description": "The display name of the attachment that should be used in GUIs.",
@@ -7319,6 +7383,7 @@
       },
       "V1ServiceOwnerDialogsQueriesSearchTransmissions_AuthorizationContext": {
         "additionalProperties": false,
+        "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.",
         "properties": {
           "action": {
             "description": "The XACML action to evaluate. Null when not overridden; the effective action is then \u0022read\u0022.",
@@ -7360,7 +7425,8 @@
             ]
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-experimental": true
       },
       "V1ServiceOwnerDialogsQueriesSearchTransmissions_Content": {
         "additionalProperties": false,
@@ -7398,13 +7464,14 @@
         "additionalProperties": false,
         "properties": {
           "authorizationContext": {
-            "description": "Describes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes additional authorization inputs used when evaluating end user access to this navigational action.\nThe XACML action defaults to \u0022read\u0022. Access to the parent transmission is always required in addition;\nthis context can only further restrict access, never widen it.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesSearchTransmissions_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "expiresAt": {
             "description": "The UTC timestamp when the navigational action expires and is no longer available.",
@@ -7448,13 +7515,14 @@
             "x-deprecatedMessage": "Use \u0027AuthorizationContext\u0027 instead."
           },
           "authorizationContext": {
-            "description": "Describes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses the legacy\n\u0022authorizationAttribute\u0022.",
+            "description": "**Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.\n\nDescribes the authorization inputs used when evaluating end user access to this transmission.\nNull when no authorization context is set, including when the transmission uses the legacy\n\u0022authorizationAttribute\u0022.",
             "nullable": true,
             "oneOf": [
               {
                 "$ref": "#/components/schemas/V1ServiceOwnerDialogsQueriesSearchTransmissions_AuthorizationContext"
               }
-            ]
+            ],
+            "x-experimental": true
           },
           "content": {
             "description": "The content of the transmission.",

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/AuthorizationContexts/AuthorizationContextDto.cs
@@ -2,6 +2,7 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.AuthorizationContexts;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common.AuthorizationContexts;
 
+[ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
 public sealed class AuthorizationContextDto
 {
     /// <summary>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/ExperimentalFeatureAttribute.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/ExperimentalFeatureAttribute.cs
@@ -1,12 +1,13 @@
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common;
 
 /// <summary>
-/// Marks an API contract type as belonging to an experimental feature that is subject to breaking
-/// changes without a major version bump. The service owner OpenAPI document flags the schema for a
-/// marked type - and every property referencing it - with an experimental notice; see
-/// ExperimentalFeatureSchemaProcessor in the WebApi project.
+/// Marks an API contract type or property as belonging to an experimental feature that is subject to
+/// breaking changes without a major version bump. Every OpenAPI document flags the schema for a marked
+/// type - and every property referencing it - with an experimental notice; a marked property is flagged
+/// directly, which is how members with no contract type of their own (a token string, a boolean flag)
+/// are covered. See ExperimentalFeatureSchemaProcessor in the WebApi project.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Property)]
 public sealed class ExperimentalFeatureAttribute(string documentationUrl) : Attribute
 {
     /// <summary>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/ExperimentalFeatureAttribute.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/Common/ExperimentalFeatureAttribute.cs
@@ -1,0 +1,24 @@
+namespace Digdir.Domain.Dialogporten.Application.Features.V1.Common;
+
+/// <summary>
+/// Marks an API contract type as belonging to an experimental feature that is subject to breaking
+/// changes without a major version bump. The service owner OpenAPI document flags the schema for a
+/// marked type - and every property referencing it - with an experimental notice; see
+/// ExperimentalFeatureSchemaProcessor in the WebApi project.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum)]
+public sealed class ExperimentalFeatureAttribute(string documentationUrl) : Attribute
+{
+    /// <summary>
+    /// URL to the issue or documentation tracking the feature, included in the experimental notice.
+    /// </summary>
+    public string DocumentationUrl { get; } = documentationUrl;
+}
+
+/// <summary>
+/// Documentation references for the currently experimental features.
+/// </summary>
+public static class ExperimentalFeatures
+{
+    public const string AuthorizationContext = "https://github.com/Altinn/dialogporten/issues/3978";
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Common/ExcludedElementDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Common/ExcludedElementDto.cs
@@ -1,3 +1,5 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
+
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 
 /// <summary>
@@ -6,6 +8,7 @@ namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 /// belongs to and recorded here instead, so that a client can tell "this existed and you cannot see it"
 /// apart from "this does not exist" without being shown anything about it.
 /// </summary>
+[ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
 public sealed class ExcludedElementDto
 {
     /// <summary>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/DialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/DialogDto.cs
@@ -1,4 +1,5 @@
-﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
+﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.Actors;
@@ -335,6 +336,7 @@ public sealed class DialogTransmissionDto
     /// authorized. Should be used instead of the dialog token against URLs referred to by this transmission,
     /// including front-channel embeds.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 
     /// <summary>
@@ -573,6 +575,7 @@ public sealed class DialogApiActionDto
     /// authorization context. Only present when the action has an authorization context and the user is authorized.
     /// Should be used instead of the dialog token against this action's endpoints.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 
     /// <summary>
@@ -695,6 +698,7 @@ public sealed class DialogGuiActionDto
     /// authorization context. Only present when the action has an authorization context and the user is authorized.
     /// Should be used instead of the dialog token against this action's URL.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 
     /// <summary>
@@ -758,6 +762,7 @@ public sealed class DialogAttachmentDto
     /// Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be
     /// replaced with "urn:dialogporten:unauthorized".
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public bool IsAuthorized { get; set; } = true;
 
     /// <summary>
@@ -765,6 +770,7 @@ public sealed class DialogAttachmentDto
     /// authorization context. Only present when the attachment has an authorization context and the user is
     /// authorized. Should be used instead of the dialog token against this attachment's URLs.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 }
 
@@ -830,6 +836,7 @@ public sealed class DialogTransmissionAttachmentDto
     /// Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be
     /// replaced with "urn:dialogporten:unauthorized".
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public bool IsAuthorized { get; set; } = true;
 
     /// <summary>
@@ -837,6 +844,7 @@ public sealed class DialogTransmissionAttachmentDto
     /// authorization context. Only present when the attachment has an authorization context and the user is
     /// authorized. Should be used instead of the dialog token against this attachment's URLs.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 }
 
@@ -899,6 +907,7 @@ public sealed class DialogTransmissionNavigationalActionDto
     /// Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be
     /// replaced with "urn:dialogporten:unauthorized".
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public bool IsAuthorized { get; set; } = true;
 
     /// <summary>
@@ -906,5 +915,6 @@ public sealed class DialogTransmissionNavigationalActionDto
     /// by its authorization context. Only present when the navigational action has an authorization context and the
     /// user is authorized. Should be used instead of the dialog token against this action's URL.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetTransmission/TransmissionDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetTransmission/TransmissionDto.cs
@@ -1,3 +1,4 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
@@ -38,6 +39,7 @@ public sealed class TransmissionDto
     /// authorized. Should be used instead of the dialog token against URLs referred to by this transmission,
     /// including front-channel embeds.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 
     /// <summary>
@@ -160,6 +162,7 @@ public sealed class AttachmentDto
     /// Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be
     /// replaced with "urn:dialogporten:unauthorized".
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public bool IsAuthorized { get; set; } = true;
 
     /// <summary>
@@ -167,6 +170,7 @@ public sealed class AttachmentDto
     /// authorization context. Only present when the attachment has an authorization context and the user is
     /// authorized. Should be used instead of the dialog token against this attachment's URLs.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 }
 
@@ -229,6 +233,7 @@ public sealed class NavigationalActionDto
     /// Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be
     /// replaced with "urn:dialogporten:unauthorized".
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public bool IsAuthorized { get; set; } = true;
 
     /// <summary>
@@ -236,5 +241,6 @@ public sealed class NavigationalActionDto
     /// by its authorization context. Only present when the navigational action has an authorization context and the
     /// user is authorized. Should be used instead of the dialog token against this action's URL.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchTransmissions/TransmissionDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchTransmissions/TransmissionDto.cs
@@ -1,3 +1,4 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
@@ -38,6 +39,7 @@ public sealed class TransmissionDto
     /// authorized. Should be used instead of the dialog token against URLs referred to by this transmission,
     /// including front-channel embeds.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 
     /// <summary>
@@ -160,6 +162,7 @@ public sealed class AttachmentDto
     /// Indicates whether the authenticated user is authorized for this attachment. If not, the URLs will be
     /// replaced with "urn:dialogporten:unauthorized".
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public bool IsAuthorized { get; set; } = true;
 
     /// <summary>
@@ -167,6 +170,7 @@ public sealed class AttachmentDto
     /// authorization context. Only present when the attachment has an authorization context and the user is
     /// authorized. Should be used instead of the dialog token against this attachment's URLs.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 }
 
@@ -229,6 +233,7 @@ public sealed class NavigationalActionDto
     /// Indicates whether the authenticated user is authorized for this navigational action. If not, the URL will be
     /// replaced with "urn:dialogporten:unauthorized".
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public bool IsAuthorized { get; set; } = true;
 
     /// <summary>
@@ -236,5 +241,6 @@ public sealed class NavigationalActionDto
     /// by its authorization context. Only present when the navigational action has an authorization context and the
     /// user is authorized. Should be used instead of the dialog token against this action's URL.
     /// </summary>
+    [ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
     public string? ContextToken { get; set; }
 }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/DialogDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/Get/DialogDto.cs
@@ -1,4 +1,5 @@
-﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
+﻿using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Dialogs.Common.Content;
@@ -895,6 +896,7 @@ public sealed class DialogTransmissionNavigationalActionDto
     public bool? IsAuthorized { get; set; }
 }
 
+[ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
 public sealed class AuthorizationContextDto
 {
     /// <summary>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/GetTransmission/TransmissionDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/GetTransmission/TransmissionDto.cs
@@ -1,3 +1,4 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
@@ -194,6 +195,7 @@ public sealed class NavigationalActionDto
     public AuthorizationContextDto? AuthorizationContext { get; set; }
 }
 
+[ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
 public sealed class AuthorizationContextDto
 {
     /// <summary>

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/SearchTransmissions/TransmissionDto.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/ServiceOwner/Dialogs/Queries/SearchTransmissions/TransmissionDto.cs
@@ -1,3 +1,4 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Content;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.ServiceOwner.Common.Actors;
@@ -193,6 +194,7 @@ public sealed class NavigationalActionDto
     public AuthorizationContextDto? AuthorizationContext { get; set; }
 }
 
+[ExperimentalFeature(ExperimentalFeatures.AuthorizationContext)]
 public sealed class AuthorizationContextDto
 {
     /// <summary>

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Swagger/ExperimentalFeatureSchemaProcessor.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Swagger/ExperimentalFeatureSchemaProcessor.cs
@@ -98,7 +98,9 @@ internal sealed class ExperimentalFeatureSchemaProcessor : ISchemaProcessor
     private static void MarkExperimental(JsonSchema schema, string notice)
     {
         // A property can be reached twice - marked directly and again through the flagged schema it
-        // references - and the notice must not be prepended twice.
+        // references - and the notice must not be prepended twice. Note this keys on the presence of the
+        // extension, not on which notice: once a second experimental feature exists, a property belonging
+        // to both would carry only the notice that landed first.
         if (schema.ExtensionData?.ContainsKey(ExtensionName) == true)
         {
             return;

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Swagger/ExperimentalFeatureSchemaProcessor.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Swagger/ExperimentalFeatureSchemaProcessor.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
+using NJsonSchema;
+using NJsonSchema.Generation;
+using NSwag;
+
+namespace Digdir.Domain.Dialogporten.WebApi.Common.Swagger;
+
+/// <summary>
+/// Flags schemas generated from types marked with <see cref="ExperimentalFeatureAttribute"/>:
+/// the schema description gets a standardized experimental notice and an "x-experimental" vendor
+/// extension. <see cref="AddPropertyNotices"/> then propagates the notice to every property
+/// referencing a flagged schema, so contract types only need the attribute in one place.
+/// </summary>
+internal sealed class ExperimentalFeatureSchemaProcessor : ISchemaProcessor
+{
+    private const string ExtensionName = "x-experimental";
+    private readonly ConcurrentDictionary<JsonSchema, string> _noticesBySchema = new(ReferenceEqualityComparer.Instance);
+
+    public void Process(SchemaProcessorContext context)
+    {
+        var attribute = context.ContextualType.Type.GetCustomAttribute<ExperimentalFeatureAttribute>();
+        if (attribute is null)
+        {
+            return;
+        }
+
+        var notice =
+            "**Experimental:** This is part of an experimental feature that may change or be removed " +
+            $"without a major version bump. See {attribute.DocumentationUrl} for details.";
+
+        MarkExperimental(context.Schema, notice);
+        _noticesBySchema[context.Schema] = notice;
+    }
+
+    /// <summary>
+    /// Document post-process step: prepends the experimental notice to every property whose type
+    /// (or array item type) resolves to a schema flagged by <see cref="Process"/>.
+    /// </summary>
+    public void AddPropertyNotices(OpenApiDocument document)
+    {
+        var properties = document.Components.Schemas.Values
+            .SelectMany(schema => schema.ActualProperties.Values);
+
+        foreach (var property in properties)
+        {
+            // A bare $ref property cannot carry its own description or extensions. Properties
+            // wrapping their reference in oneOf/allOf (HasReference is also true for those) can.
+            if (property.Reference is not null)
+            {
+                continue;
+            }
+
+            if (TryGetNotice(property, out var notice) ||
+                (property.Item is not null && TryGetNotice(property.Item, out notice)))
+            {
+                MarkExperimental(property, notice);
+            }
+        }
+    }
+
+    // ActualTypeSchema resolves a oneOf/allOf wrapper to the reference-holding item, which still
+    // needs ActualSchema to land on the flagged component schema.
+    private bool TryGetNotice(JsonSchema schema, out string notice) =>
+        _noticesBySchema.TryGetValue(schema.ActualTypeSchema, out notice!) ||
+        _noticesBySchema.TryGetValue(schema.ActualTypeSchema.ActualSchema, out notice!);
+
+    private static void MarkExperimental(JsonSchema schema, string notice)
+    {
+        schema.Description = string.IsNullOrEmpty(schema.Description)
+            ? notice
+            : $"{notice}\n\n{schema.Description}";
+        schema.ExtensionData ??= new Dictionary<string, object?>();
+        schema.ExtensionData[ExtensionName] = true;
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.WebApi/Common/Swagger/ExperimentalFeatureSchemaProcessor.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Common/Swagger/ExperimentalFeatureSchemaProcessor.cs
@@ -20,19 +20,48 @@ internal sealed class ExperimentalFeatureSchemaProcessor : ISchemaProcessor
 
     public void Process(SchemaProcessorContext context)
     {
-        var attribute = context.ContextualType.Type.GetCustomAttribute<ExperimentalFeatureAttribute>();
-        if (attribute is null)
+        var type = context.ContextualType.Type;
+
+        if (type.GetCustomAttribute<ExperimentalFeatureAttribute>() is { } typeAttribute)
         {
-            return;
+            var notice = BuildNotice(typeAttribute);
+            MarkExperimental(context.Schema, notice);
+            _noticesBySchema[context.Schema] = notice;
         }
 
-        var notice =
-            "**Experimental:** This is part of an experimental feature that may change or be removed " +
-            $"without a major version bump. See {attribute.DocumentationUrl} for details.";
-
-        MarkExperimental(context.Schema, notice);
-        _noticesBySchema[context.Schema] = notice;
+        MarkExperimentalProperties(type, context.Schema);
     }
+
+    /// <summary>
+    /// Flags the schema properties generated from marked CLR properties. Needed for members that carry no
+    /// contract type of their own - a token string, a boolean flag - which <see cref="AddPropertyNotices"/>
+    /// cannot reach, as it works off the schema a property references.
+    /// </summary>
+    private static void MarkExperimentalProperties(Type type, JsonSchema schema)
+    {
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (property.GetCustomAttribute<ExperimentalFeatureAttribute>() is not { } attribute)
+            {
+                continue;
+            }
+
+            // The schema property is keyed by its serialized name; the contract uses camel casing
+            // throughout, so a case-insensitive lookup is enough to pair the two.
+            var schemaProperty = schema.ActualProperties
+                .FirstOrDefault(x => string.Equals(x.Key, property.Name, StringComparison.OrdinalIgnoreCase))
+                .Value;
+
+            if (schemaProperty is not null)
+            {
+                MarkExperimental(schemaProperty, BuildNotice(attribute));
+            }
+        }
+    }
+
+    private static string BuildNotice(ExperimentalFeatureAttribute attribute) =>
+        "**Experimental:** This is part of an experimental feature that may change or be removed " +
+        $"without a major version bump. See {attribute.DocumentationUrl} for details.";
 
     /// <summary>
     /// Document post-process step: prepends the experimental notice to every property whose type
@@ -68,6 +97,13 @@ internal sealed class ExperimentalFeatureSchemaProcessor : ISchemaProcessor
 
     private static void MarkExperimental(JsonSchema schema, string notice)
     {
+        // A property can be reached twice - marked directly and again through the flagged schema it
+        // references - and the notice must not be prepended twice.
+        if (schema.ExtensionData?.ContainsKey(ExtensionName) == true)
+        {
+            return;
+        }
+
         schema.Description = string.IsNullOrEmpty(schema.Description)
             ? notice
             : $"{notice}\n\n{schema.Description}";

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -357,10 +357,10 @@ static void ConfigureOpenApiV1Document(
     string? audience = null
 )
 {
-    // Experimental-feature notices are only surfaced in the service owner document.
-    var experimentalProcessor = audience == "serviceowner"
-        ? new ExperimentalFeatureSchemaProcessor()
-        : null;
+    // Every document surfaces experimental-feature notices: a feature can reach the contract on either
+    // side of the API (authorizationContext on the service owner side, contextToken and the excluded*
+    // collections on the end user side), and the combined legacy document carries both.
+    var experimentalProcessor = new ExperimentalFeatureSchemaProcessor();
 
     options.MaxEndpointVersion = 1;
     options.ShortSchemaNames = true;
@@ -379,7 +379,7 @@ static void ConfigureOpenApiV1Document(
             document.RemoveRequiredPropertiesFromSchemas();
             postProcess.Invoke(document);
             document.ChangeEndUserContextPartyExample();
-            experimentalProcessor?.AddPropertyNotices(document);
+            experimentalProcessor.AddPropertyNotices(document);
         };
         s.Title = title;
         s.Description = Constants.SwaggerSummary.GlobalDescription;
@@ -392,10 +392,7 @@ static void ConfigureOpenApiV1Document(
 
         s.SchemaSettings.SchemaNameGenerator = new ShortNameGenerator(documentName);
 
-        if (experimentalProcessor is not null)
-        {
-            s.SchemaSettings.SchemaProcessors.Add(experimentalProcessor);
-        }
+        s.SchemaSettings.SchemaProcessors.Add(experimentalProcessor);
 
         if (audience is not null)
         {

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -357,6 +357,11 @@ static void ConfigureOpenApiV1Document(
     string? audience = null
 )
 {
+    // Experimental-feature notices are only surfaced in the service owner document.
+    var experimentalProcessor = audience == "serviceowner"
+        ? new ExperimentalFeatureSchemaProcessor()
+        : null;
+
     options.MaxEndpointVersion = 1;
     options.ShortSchemaNames = true;
     options.RemoveEmptyRequestSchema = true;
@@ -374,6 +379,7 @@ static void ConfigureOpenApiV1Document(
             document.RemoveRequiredPropertiesFromSchemas();
             postProcess.Invoke(document);
             document.ChangeEndUserContextPartyExample();
+            experimentalProcessor?.AddPropertyNotices(document);
         };
         s.Title = title;
         s.Description = Constants.SwaggerSummary.GlobalDescription;
@@ -385,6 +391,11 @@ static void ConfigureOpenApiV1Document(
         s.EnsureJsonPatchConsumes();
 
         s.SchemaSettings.SchemaNameGenerator = new ShortNameGenerator(documentName);
+
+        if (experimentalProcessor is not null)
+        {
+            s.SchemaSettings.SchemaProcessors.Add(experimentalProcessor);
+        }
 
         if (audience is not null)
         {

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/DialogTokenTypes.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.Common/DialogTokenTypes.cs
@@ -18,5 +18,6 @@ public static class DialogTokenTypes
     /// The dialog context token, issued per authorization-context-carrying entity and asserting a single
     /// PDP-verified grant (action, effective resource) along with the parties it was permitted for.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public const string DialogContextToken = "dialogcontexttoken+jwt";
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Common/ExcludedElement.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Common/ExcludedElement.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
@@ -8,6 +9,7 @@ namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
 /// <br/>belongs to and recorded here instead, so that a client can tell "this existed and you cannot see it"
 /// <br/>apart from "this does not exist" without being shown anything about it.
 /// </summary>
+[Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
 public class ExcludedElement
 {
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/Dialog.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/Dialog.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Enums;
@@ -195,6 +196,7 @@ public class Dialog
     /// <br/>"excludedAttachments" and "excludedNavigationalActions" on each transmission.
     /// </summary>
     [JsonPropertyName("excludedAttachments")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public ICollection<ExcludedElement> ExcludedAttachments { get; set; } = [];
 
     /// <summary>
@@ -213,6 +215,7 @@ public class Dialog
     /// <br/>"excludedAttachments" and "excludedNavigationalActions" on each transmission.
     /// </summary>
     [JsonPropertyName("excludedTransmissions")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public ICollection<ExcludedElement> ExcludedTransmissions { get; set; } = [];
 
     /// <summary>
@@ -231,6 +234,7 @@ public class Dialog
     /// <br/>"excludedAttachments" and "excludedNavigationalActions" on each transmission.
     /// </summary>
     [JsonPropertyName("excludedGuiActions")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public ICollection<ExcludedElement> ExcludedGuiActions { get; set; } = [];
 
     /// <summary>
@@ -249,6 +253,7 @@ public class Dialog
     /// <br/>"excludedAttachments" and "excludedNavigationalActions" on each transmission.
     /// </summary>
     [JsonPropertyName("excludedApiActions")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public ICollection<ExcludedElement> ExcludedApiActions { get; set; } = [];
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogApiAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogApiAction.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Get;
@@ -40,6 +41,7 @@ public class DialogApiAction
     /// <br/>Should be used instead of the dialog token against this action's endpoints.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Get;
 
@@ -48,5 +49,6 @@ public class DialogAttachment
     /// <br/>authorized. Should be used instead of the dialog token against this attachment's URLs.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogAttachment.cs
@@ -41,6 +41,7 @@ public class DialogAttachment
     /// <br/>replaced with "urn:dialogporten:unauthorized".
     /// </summary>
     [JsonPropertyName("isAuthorized")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public bool IsAuthorized { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogGuiAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogGuiAction.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Get;
 
@@ -47,6 +48,7 @@ public class DialogGuiAction
     /// <br/>Should be used instead of the dialog token against this action's URL.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmission.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmission.cs
@@ -107,6 +107,7 @@ public class DialogTransmission
     /// <br/>"excludedAttachments" and "excludedNavigationalActions" on each transmission.
     /// </summary>
     [JsonPropertyName("excludedAttachments")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public ICollection<ExcludedElement> ExcludedAttachments { get; set; } = [];
 
     /// <summary>
@@ -125,5 +126,6 @@ public class DialogTransmission
     /// <br/>"excludedAttachments" and "excludedNavigationalActions" on each transmission.
     /// </summary>
     [JsonPropertyName("excludedNavigationalActions")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public ICollection<ExcludedElement> ExcludedNavigationalActions { get; set; } = [];
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmission.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmission.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Get;
 
@@ -42,6 +43,7 @@ public class DialogTransmission
     /// <br/>including front-channel embeds.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionAttachment.cs
@@ -41,6 +41,7 @@ public class DialogTransmissionAttachment
     /// <br/>replaced with "urn:dialogporten:unauthorized".
     /// </summary>
     [JsonPropertyName("isAuthorized")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public bool IsAuthorized { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Get;
 
@@ -48,5 +49,6 @@ public class DialogTransmissionAttachment
     /// <br/>authorized. Should be used instead of the dialog token against this attachment's URLs.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionAttachmentDetails.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionAttachmentDetails.cs
@@ -41,6 +41,7 @@ public class DialogTransmissionAttachmentDetails
     /// <br/>replaced with "urn:dialogporten:unauthorized".
     /// </summary>
     [JsonPropertyName("isAuthorized")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public bool IsAuthorized { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionAttachmentDetails.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionAttachmentDetails.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Get;
 
@@ -48,5 +49,6 @@ public class DialogTransmissionAttachmentDetails
     /// <br/>authorized. Should be used instead of the dialog token against this attachment's URLs.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionDetails.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionDetails.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Get;
 
@@ -39,6 +40,7 @@ public class DialogTransmissionDetails
     /// <br/>including front-channel embeds.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionDetails.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionDetails.cs
@@ -102,6 +102,7 @@ public class DialogTransmissionDetails
     /// <br/>"excludedAttachments" and "excludedNavigationalActions" on each transmission.
     /// </summary>
     [JsonPropertyName("excludedAttachments")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public ICollection<ExcludedElement> ExcludedAttachments { get; set; } = [];
 
     /// <summary>
@@ -120,5 +121,6 @@ public class DialogTransmissionDetails
     /// <br/>"excludedAttachments" and "excludedNavigationalActions" on each transmission.
     /// </summary>
     [JsonPropertyName("excludedNavigationalActions")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public ICollection<ExcludedElement> ExcludedNavigationalActions { get; set; } = [];
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionNavigationalAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionNavigationalAction.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Get;
 
@@ -37,5 +38,6 @@ public class DialogTransmissionNavigationalAction
     /// <br/>user is authorized. Should be used instead of the dialog token against this action's URL.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionNavigationalAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionNavigationalAction.cs
@@ -30,6 +30,7 @@ public class DialogTransmissionNavigationalAction
     /// <br/>replaced with "urn:dialogporten:unauthorized".
     /// </summary>
     [JsonPropertyName("isAuthorized")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public bool IsAuthorized { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionNavigationalActionDetails.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionNavigationalActionDetails.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Get;
 
@@ -37,5 +38,6 @@ public class DialogTransmissionNavigationalActionDetails
     /// <br/>user is authorized. Should be used instead of the dialog token against this action's URL.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionNavigationalActionDetails.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Get/DialogTransmissionNavigationalActionDetails.cs
@@ -30,6 +30,7 @@ public class DialogTransmissionNavigationalActionDetails
     /// <br/>replaced with "urn:dialogporten:unauthorized".
     /// </summary>
     [JsonPropertyName("isAuthorized")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public bool IsAuthorized { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Mapping/TransmissionMappingExtensions.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Mapping/TransmissionMappingExtensions.cs
@@ -4,6 +4,7 @@ using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Search;
 // The end user contracts mark authorizationAttribute [Obsolete] in favour of the service owner API's
 // authorizationContext, but this layer has to keep carrying it for as long as the server returns it.
 #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable DPEXP001 // authorizationContext/contextToken are experimental
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Mapping;
 
@@ -148,4 +149,5 @@ public static class TransmissionMappingExtensions
     };
 }
 
+#pragma warning restore DPEXP001
 #pragma warning restore CS0618

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Search;
 
@@ -48,5 +49,6 @@ public class DialogTransmissionSearchAttachment
     /// <br/>authorized. Should be used instead of the dialog token against this attachment's URLs.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchAttachment.cs
@@ -41,6 +41,7 @@ public class DialogTransmissionSearchAttachment
     /// <br/>replaced with "urn:dialogporten:unauthorized".
     /// </summary>
     [JsonPropertyName("isAuthorized")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public bool IsAuthorized { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchItem.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchItem.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Search;
 
@@ -39,6 +40,7 @@ public class DialogTransmissionSearchItem
     /// <br/>including front-channel embeds.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchItem.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchItem.cs
@@ -102,6 +102,7 @@ public class DialogTransmissionSearchItem
     /// <br/>"excludedAttachments" and "excludedNavigationalActions" on each transmission.
     /// </summary>
     [JsonPropertyName("excludedAttachments")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public ICollection<ExcludedElement> ExcludedAttachments { get; set; } = [];
 
     /// <summary>
@@ -120,5 +121,6 @@ public class DialogTransmissionSearchItem
     /// <br/>"excludedAttachments" and "excludedNavigationalActions" on each transmission.
     /// </summary>
     [JsonPropertyName("excludedNavigationalActions")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public ICollection<ExcludedElement> ExcludedNavigationalActions { get; set; } = [];
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchNavigationalAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchNavigationalAction.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.EndUser.Features.V1.Search;
 
@@ -37,5 +38,6 @@ public class DialogTransmissionSearchNavigationalAction
     /// <br/>user is authorized. Should be used instead of the dialog token against this action's URL.
     /// </summary>
     [JsonPropertyName("contextToken")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public string? ContextToken { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchNavigationalAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.EndUser/Features/V1/Search/DialogTransmissionSearchNavigationalAction.cs
@@ -30,6 +30,7 @@ public class DialogTransmissionSearchNavigationalAction
     /// <br/>replaced with "urn:dialogporten:unauthorized".
     /// </summary>
     [JsonPropertyName("isAuthorized")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public bool IsAuthorized { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogApiAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogApiAction.cs
@@ -1,4 +1,5 @@
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Create;
@@ -35,6 +36,7 @@ public class CreateDialogApiAction
     /// <br/>"authorizationContext.action".
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Create;
 
@@ -41,5 +42,6 @@ public class CreateDialogAttachment
     /// <br/>can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogGuiAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogGuiAction.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Create;
 
@@ -42,6 +43,7 @@ public class CreateDialogGuiAction
     /// <br/>"authorizationContext.action".
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogTransmission.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogTransmission.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Create;
 
@@ -40,6 +41,7 @@ public class CreateDialogTransmission
     /// <br/>Cannot be combined with "authorizationAttribute".
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogTransmissionAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogTransmissionAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Create;
 
@@ -41,5 +42,6 @@ public class CreateDialogTransmissionAttachment
     /// <br/>can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogTransmissionNavigationalAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateDialogTransmissionNavigationalAction.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Create;
 
@@ -29,5 +30,6 @@ public class CreateDialogTransmissionNavigationalAction
     /// <br/>context can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateTransmissionAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateTransmissionAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Create;
 
@@ -41,5 +42,6 @@ public class CreateTransmissionAttachment
     /// <br/>this context can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateTransmissionNavigationalAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateTransmissionNavigationalAction.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Create;
 
@@ -29,5 +30,6 @@ public class CreateTransmissionNavigationalAction
     /// <br/>context can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateTransmissionRequest.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Create/CreateTransmissionRequest.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Create;
 
@@ -41,6 +42,7 @@ public class CreateTransmissionRequest
     /// <br/>Cannot be combined with "authorizationAttribute".
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogApiAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogApiAction.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
@@ -36,6 +37,7 @@ public class DialogApiAction
     /// <br/>Null when the action uses legacy authorization fields.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContext? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
 
@@ -41,6 +42,7 @@ public class DialogAttachment
     /// <br/>can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContext? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogGuiAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogGuiAction.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
 
@@ -43,6 +44,7 @@ public class DialogGuiAction
     /// <br/>Null when the action uses legacy authorization fields.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContext? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmission.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmission.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
 
@@ -39,6 +40,7 @@ public class DialogTransmission
     /// <br/>Null when the transmission uses legacy authorization fields.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContext? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmissionAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmissionAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
 
@@ -41,6 +42,7 @@ public class DialogTransmissionAttachment
     /// <br/>can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContext? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmissionAttachmentDetails.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmissionAttachmentDetails.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
 
@@ -41,5 +42,6 @@ public class DialogTransmissionAttachmentDetails
     /// <br/>this context can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextDetails? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmissionDetails.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmissionDetails.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
 
@@ -36,6 +37,7 @@ public class DialogTransmissionDetails
     /// <br/>Null when the transmission uses the legacy "authorizationAttribute".
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextDetails? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmissionNavigationalAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmissionNavigationalAction.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
 
@@ -29,6 +30,7 @@ public class DialogTransmissionNavigationalAction
     /// <br/>can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContext? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmissionNavigationalActionDetails.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Get/DialogTransmissionNavigationalActionDetails.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
 
@@ -29,5 +30,6 @@ public class DialogTransmissionNavigationalActionDetails
     /// <br/>this context can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextDetails? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Mapping/ActionMappingExtensions.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Mapping/ActionMappingExtensions.cs
@@ -6,6 +6,7 @@ using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 // authorizationContext, but a mapping layer has to keep round-tripping them for as long as the server
 // still returns and accepts them.
 #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable DPEXP001 // authorizationContext/contextToken are experimental
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Mapping;
 
@@ -252,4 +253,5 @@ internal static class ActionMappingExtensions
     };
 }
 
+#pragma warning restore DPEXP001
 #pragma warning restore CS0618

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Mapping/AttachmentMappingExtensions.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Mapping/AttachmentMappingExtensions.cs
@@ -2,6 +2,10 @@ using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Create;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 
+// The authorizationContext members these maps carry are flagged experimental for consumers; the SDK's
+// own mapping layer is part of the feature, so it opts in rather than warning about itself.
+#pragma warning disable DPEXP001
+
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Mapping;
 
 /// <summary>
@@ -121,3 +125,5 @@ internal static class AttachmentMappingExtensions
         ConsumerType = source.ConsumerType,
     };
 }
+
+#pragma warning restore DPEXP001

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Mapping/AuthorizationContextMappingExtensions.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Mapping/AuthorizationContextMappingExtensions.cs
@@ -1,6 +1,10 @@
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Get;
 
+// The authorizationContext members these maps carry are flagged experimental for consumers; the SDK's
+// own mapping layer is part of the feature, so it opts in rather than warning about itself.
+#pragma warning disable DPEXP001
+
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Mapping;
 
 /// <summary>
@@ -32,3 +36,5 @@ internal static class AuthorizationContextMappingExtensions
         UnauthorizedPresentation = source.UnauthorizedPresentation,
     };
 }
+
+#pragma warning restore DPEXP001

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Mapping/TransmissionMappingExtensions.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Mapping/TransmissionMappingExtensions.cs
@@ -6,6 +6,7 @@ using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 // authorizationContext, but a mapping layer has to keep round-tripping them for as long as the server
 // still returns and accepts them.
 #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable DPEXP001 // authorizationContext/contextToken are experimental
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Mapping;
 
@@ -329,4 +330,5 @@ internal static class TransmissionMappingExtensions
     };
 }
 
+#pragma warning restore DPEXP001
 #pragma warning restore CS0618

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Search/DialogTransmissionSearchAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Search/DialogTransmissionSearchAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Search;
 
@@ -41,5 +42,6 @@ public class DialogTransmissionSearchAttachment
     /// <br/>this context can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public DialogTransmissionSearchAuthorizationContext? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Search/DialogTransmissionSearchItem.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Search/DialogTransmissionSearchItem.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Search;
 
@@ -36,6 +37,7 @@ public class DialogTransmissionSearchItem
     /// <br/>Null when the transmission uses the legacy "authorizationAttribute".
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public DialogTransmissionSearchAuthorizationContext? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Search/DialogTransmissionSearchNavigationalAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Search/DialogTransmissionSearchNavigationalAction.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Search;
 
@@ -29,5 +30,6 @@ public class DialogTransmissionSearchNavigationalAction
     /// <br/>this context can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public DialogTransmissionSearchAuthorizationContext? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogApiAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogApiAction.cs
@@ -1,4 +1,5 @@
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
@@ -35,6 +36,7 @@ public class UpdateDialogApiAction
     /// <br/>"authorizationContext.action".
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 
@@ -41,5 +42,6 @@ public class UpdateDialogAttachment
     /// <br/>can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogGuiAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogGuiAction.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 
@@ -42,6 +43,7 @@ public class UpdateDialogGuiAction
     /// <br/>"authorizationContext.action".
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogTransmission.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogTransmission.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 
@@ -41,6 +42,7 @@ public class UpdateDialogTransmission
     /// <br/>Cannot be combined with "authorizationAttribute".
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogTransmissionAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogTransmissionAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 
@@ -41,5 +42,6 @@ public class UpdateDialogTransmissionAttachment
     /// <br/>can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogTransmissionNavigationalAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateDialogTransmissionNavigationalAction.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 
@@ -29,5 +30,6 @@ public class UpdateDialogTransmissionNavigationalAction
     /// <br/>context can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateTransmissionAttachment.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateTransmissionAttachment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 
@@ -41,5 +42,6 @@ public class UpdateTransmissionAttachment
     /// <br/>this context can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateTransmissionNavigationalAction.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateTransmissionNavigationalAction.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 
@@ -29,5 +30,6 @@ public class UpdateTransmissionNavigationalAction
     /// <br/>context can only further restrict access, never widen it.
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 }

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateTransmissionRequest.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient.ServiceOwner/Features/V1/Update/UpdateTransmissionRequest.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Common;
 using Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Enums;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.ApiClients.Dialogporten.ServiceOwner.Features.V1.Update;
 
@@ -33,6 +34,7 @@ public class UpdateTransmissionRequest
     /// <br/>Cannot be combined with "authorizationAttribute".
     /// </summary>
     [JsonPropertyName("authorizationContext")]
+    [Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
     public AuthorizationContextInput? AuthorizationContext { get; set; }
 
     /// <summary>

--- a/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient/Features/V1/RefitterInterface.cs
+++ b/src/WebApiClient/Digdir.Library.Dialogporten.WebApiClient/Features/V1/RefitterInterface.cs
@@ -1965,6 +1965,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>Null when the transmission uses the legacy "authorizationAttribute".
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesSearchTransmissions_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -2156,6 +2157,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>this context can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesSearchTransmissions_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -2232,6 +2234,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>this context can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesSearchTransmissions_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -2960,6 +2963,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>Null when the transmission uses the legacy "authorizationAttribute".
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesGetTransmission_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -3089,6 +3093,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>this context can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesGetTransmission_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -3153,6 +3158,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>this context can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesGetTransmission_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -3625,6 +3631,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesGet_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -3705,6 +3712,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>Null when the transmission uses legacy authorization fields.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesGet_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -3836,6 +3844,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesGet_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -3908,6 +3917,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesGet_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -4010,6 +4020,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>Null when the action uses legacy authorization fields.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesGet_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -4139,6 +4150,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>Null when the action uses legacy authorization fields.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1ServiceOwnerDialogsQueriesGet_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -4397,6 +4409,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>Cannot be combined with "authorizationAttribute".
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -4519,6 +4532,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>this context can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -4582,6 +4596,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>context can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -4889,6 +4904,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -4963,6 +4979,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>Cannot be combined with "authorizationAttribute".
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -5082,6 +5099,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -5139,6 +5157,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>context can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -5183,6 +5202,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>"authorizationContext.action".
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -5256,6 +5276,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>"authorizationContext.action".
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -5428,6 +5449,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>Cannot be combined with "authorizationAttribute".
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -5547,6 +5569,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>this context can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -5604,6 +5627,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>context can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -5966,6 +5990,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -6039,6 +6064,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>Cannot be combined with "authorizationAttribute".
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -6158,6 +6184,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -6215,6 +6242,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>context can only further restrict access, never widen it.
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
     }
@@ -6259,6 +6287,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>"authorizationContext.action".
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>
@@ -6332,6 +6361,7 @@ namespace Altinn.ApiClients.Dialogporten.Features.V1
         /// <br/>"authorizationContext.action".
         /// </summary>
         [JsonPropertyName("authorizationContext")]
+        [System.Diagnostics.CodeAnalysis.Experimental("DPEXP001", UrlFormat = "https://github.com/Altinn/dialogporten/issues/3978")]
         public V1CommonAuthorizationContexts_AuthorizationContext AuthorizationContext { get; set; }
 
         /// <summary>

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests.csproj
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!-- Tests exercise the experimental authorizationContext SDK surface on purpose. -->
+        <NoWarn>$(NoWarn);DPEXP001</NoWarn>
         <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests.csproj
+++ b/tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests/Digdir.Domain.Dialogporten.WebAPI.E2E.Tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!-- Tests exercise the experimental authorizationContext SDK surface on purpose. -->
+        <NoWarn>$(NoWarn);DPEXP001</NoWarn>
         <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests.csproj
+++ b/tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests/Digdir.Library.Dialogporten.WebApiClient.Unit.Tests.csproj
@@ -9,6 +9,8 @@
         <!-- The NET8_0-conditional code paths are fixed at compile time, so the net8.0 test
              assembly may run on a newer runtime on machines without the .NET 8 runtime installed. -->
         <RollForward Condition="'$(TargetFramework)' == 'net8.0'">Major</RollForward>
+        <!-- Tests exercise the experimental authorizationContext SDK surface on purpose. -->
+        <NoWarn>$(NoWarn);DPEXP001</NoWarn>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>


### PR DESCRIPTION
Layer 13/13 — the top of the `authorizationContext` stack (#3978).

## What

The `authorizationContext` feature is experimental: the contract may still change in breaking ways without a major version bump. Nothing in the API surface said so. This layer introduces a small, reusable regime for signalling exactly that to consumers, and applies it to authorization contexts across **all three OpenAPI documents** and the SDK contracts.

## The regime

- **`ExperimentalFeatureAttribute`** (Application) marks an API contract type — or a single property — as part of an experimental feature, carrying a documentation URL. The URLs live in a single `ExperimentalFeatures` registry, so the next experimental feature adds one constant and a handful of attributes — no new swagger code.
- **`ExperimentalFeatureSchemaProcessor`** (WebApi) does the rest in two phases. During schema generation it prepends a standardized notice to each flagged schema's description and stamps the schema with an `x-experimental: true` vendor extension. In the document post-process it propagates the notice to every *property* whose type (or array item type) resolves to a flagged schema, and flags directly-marked properties — which is how members with no contract type of their own (a token string, a boolean flag) get covered.
- Five flagged types (`AuthorizationContextDto`, the three service-owner context types, and the end-user `ExcludedElementDto`) plus 19 flagged end-user properties fan out to **34 markers in `openapi.v1.serviceowner`, 30 in `openapi.v1.enduser` and 64 in the combined `swagger` document** — all `authorizationContext`, `contextToken`, `excluded*` and per-entity `isAuthorized` properties across create/update/get/search, without per-property annotations on the service-owner side.

The processor is registered for **every** v1 document, because a feature can reach the contract on either side of the API: `authorizationContext` on the service-owner side, `contextToken`, the six `excluded*` collections and the new per-attachment/per-navigational-action `isAuthorized` on the end-user side, and the combined legacy document carries both.

The rendered notice:

> **Experimental:** This is part of an experimental feature that may change or be removed without a major version bump. See https://github.com/Altinn/dialogporten/issues/3978 for details.

Two NJsonSchema/processor subtleties worth recording:

- `JsonSchema.HasReference` is `true` for `oneOf`-wrapped references too, so the "skip bare `$ref` properties" guard must test `Reference is not null` — bare `$ref` properties cannot carry a description, but the `oneOf` wrappers NSwag emits for nullable reference properties can.
- the double-marking guard keys on the presence of `x-experimental`, not on *which* notice, so a property belonging to two experimental features would carry only the notice that landed first. Harmless while there is one feature.

## Scope note: GraphQL is still unmarked

The end-user REST contract is now marked, so the remaining gap is GraphQL: `Transmission.contextToken`, the `excluded*` collections and the per-entity `isAuthorized` fields appear in `schema.verified.graphql` with no experimental marking, because HotChocolate has no equivalent mechanism wired up here. A GraphQL consumer like Arbeidsflate gets no schema-level signal that these fields may change or disappear.

## SDK

The hand-maintained contracts get .NET's real `[Experimental("DPEXP001")]` (with the issue URL as `UrlFormat`) on every `authorizationContext`/`contextToken`/`excluded*` member — 30 in the ServiceOwner package, 30 in the EndUser package, 30 in the legacy combined package — plus the `DialogTokenTypes.DialogContextToken` constant. NuGet consumers touching the feature get an error-by-default compiler diagnostic and must consciously suppress `DPEXP001` to opt in; everything else compiles as before. The three in-repo test projects that exercise the feature suppress it via a commented `<NoWarn>`.

## npm consumers do get these markers

`docs/schema/V1/.npmignore` excludes `openapi.v1.enduser.verified.json` and `openapi.v1.serviceowner.verified.json` pending #3794, so the published schema package carries only the combined `swagger.verified.json` and the GraphQL schema. Since the processor now runs for the combined document too, the experimental notices **do** reach npm consumers of that spec — unlike the earlier service-owner-only revision of this layer, which produced no change in any file the package actually ships.

## Verification

Full Release build clean. WebApi unit (including the re-verified OpenAPI snapshots for all three documents), WebApiClient unit, Application unit, Infrastructure unit, Architecture, GraphQL unit and the full Application integration suite all green at this tip; E2E run against AT23 green.

Part of #3978.
