### PR TITLE
ci: close change-filter gaps and cache the vulnerability scan

### DIFF
--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -6,9 +6,8 @@ on:
     paths-ignore:
       - "tests/k6/**"
 
-# Supersede in-flight runs for the same PR. Without this, every force-push (rebases,
-# amends, and stacked-PR restacks in particular) leaves the previous run to complete,
-# so a single restack of an N-branch stack can occupy 2N runs concurrently.
+# Supersede in-flight runs for the same PR: a force-push (rebase, amend, stacked-PR
+# restack) makes the previous run's result irrelevant, so don't let it occupy runners.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -35,7 +34,7 @@ jobs:
   build-and-test:
     uses: ./.github/workflows/workflow-build-and-test.yml
     needs: [ check-for-changes ]
-    if: ${{ needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true' }}
+    if: ${{ needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasTestChanges == 'true' || needs.check-for-changes.outputs.hasDependencyChanges == 'true' }}
     permissions:
       contents: read
 
@@ -44,9 +43,9 @@ jobs:
   # limited to the container context itself — gate on the files that can break that.
   # `ci-cd-main` rebuilds and pushes them on merge regardless.
   # `build-and-test` stays in `needs` purely for ordering — don't burn five image builds on a
-  # branch whose tests fail. Its gate is narrower than this one though (a `.dockerignore`,
-  # `global.json` or `Directory.Build.props` change touches no `src/**` or `tests/**` file), so
-  # it can legitimately be skipped here, and a skipped dependency would otherwise skip this job.
+  # branch whose tests fail. Its gate is narrower than this one though (a `.dockerignore` or
+  # `.editorconfig` change touches no file it gates on), so it can legitimately be skipped
+  # here, and a skipped dependency would otherwise skip this job.
   build-docker-images:
     uses: ./.github/workflows/workflow-publish-docker-images.yml
     needs: [ build-and-test, check-for-changes ]
@@ -111,6 +110,10 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: pr/global.json
+          # Safe with RestorePackagesWithLockFile: the lock files are the cache key, and the
+          # head restore below runs `--locked-mode` so drift from them still fails.
+          cache: true
+          cache-dependency-path: 'pr/**/packages.lock.json'
 
       - name: Scan base (${{ github.event.pull_request.base.ref }})
         working-directory: base
@@ -122,7 +125,7 @@ jobs:
       - name: Scan PR head
         working-directory: pr
         run: |
-          dotnet restore
+          dotnet restore --locked-mode
           dotnet list package --vulnerable --include-transitive --format json > "$GITHUB_WORKSPACE/pr-vulns.json"
 
       - name: Fail on newly-introduced vulnerabilities

--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -77,8 +77,8 @@ jobs:
       hasWebApiServiceOwnerClientChanges: ${{ steps.filter-backend.outputs.web_api_serviceowner_client_any_modified == 'true'}}
       hasSchemaPackageChanges: ${{ steps.filter-backend.outputs.schema_package_any_modified == 'true'}}
       # Deliberately not OR'd with github_workflows_any_modified, unlike hasBackendChanges and
-      # hasInfraChanges: the two filters below already name the workflows that govern these
-      # jobs, so an unrelated workflow edit no longer rebuilds every image and rescans NuGet.
+      # hasInfraChanges: the dependencies and docker filters name the workflows that govern
+      # these jobs, so an unrelated workflow edit doesn't rebuild every image or rescan NuGet.
       hasDependencyChanges: ${{ steps.filter-backend.outputs.dependencies_any_modified == 'true' }}
       hasDockerChanges: ${{ steps.filter-backend.outputs.docker_any_modified == 'true' || steps.filter-backend.outputs.dependencies_any_modified == 'true' }}
     steps:
@@ -147,27 +147,34 @@ jobs:
             schema_package:
               - 'docs/schema/V*/**/*'
             # Anything that can change what NuGet resolves, and therefore what
-            # `dotnet list package --vulnerable` reports. The last two entries are the workflows
-            # that define and gate the scan, so a change to either still exercises it.
+            # `dotnet list package --vulnerable` reports. MSBuild/NuGet config files are
+            # matched at any depth: nested Directory.Build.props files shadow the root one.
+            # The last two entries are the workflows that define and gate the scan, so a
+            # change to either still exercises it.
             dependencies:
               - '**/packages.lock.json'
               - '**/*.csproj'
               - '**/*.slnx'
-              - 'Directory.Build.props'
+              - '**/Directory.Build.props'
+              - '**/Directory.Build.targets'
+              - '**/Directory.Packages.props'
               - 'global.json'
-              - 'nuget.config'
-              - 'NuGet.config'
+              - '**/nuget.config'
+              - '**/NuGet.config'
               - '.github/workflows/ci-cd-pull-request.yml'
               - '.github/workflows/workflow-check-for-changes.yml'
-            # Anything that can break an image build without also breaking `dotnet build`,
-            # plus the image-build pipeline, its call site, and this filter.
+            # Anything that can break an image build without also breaking `dotnet build`.
+            # The root .editorconfig is COPY'd into every image and, with
+            # EnforceCodeStyleInBuild + TreatWarningsAsErrors, can fail the in-container
+            # publish on a PR that skips build-and-test. The call site and this filter are
+            # already in the dependencies filter, which hasDockerChanges ORs in, so only the
+            # image-build pipeline itself is listed here.
             docker:
               - '**/Dockerfile'
               - '**/*.dockerfile'
               - '.dockerignore'
+              - '.editorconfig'
               - '.github/workflows/workflow-publish-docker-images.yml'
-              - '.github/workflows/ci-cd-pull-request.yml'
-              - '.github/workflows/workflow-check-for-changes.yml'
 
       - name: Log backend changes
         run: |


### PR DESCRIPTION
Follow-up to the change-detection gating in #4284, as a PR into the branch so you
can review before it lands. Four filter-gap fixes plus the restore-cache treatment
for the vulnerability scan.

1. **Dependencies filter: match config files at any depth.** `Directory.Build.props`
   was root-anchored, but `tests/` and `src/WebApiClient/` have shadowing copies, so
   editing them changed NuGet resolution without triggering the scan. Also globbed
   `nuget.config` and added `Directory.Build.targets`/`Directory.Packages.props` for
   the day one is introduced.

2. **Docker filter: add root `.editorconfig`.** All five Dockerfiles COPY it before
   publish, and `EnforceCodeStyleInBuild` + `TreatWarningsAsErrors` are on, so an
   `.editorconfig`-only PR currently matches no filter and can break first on main.

3. **Gate build-and-test on `hasDependencyChanges`.** A `global.json`-only PR built
   five images and ran the scan but never ran `dotnet test`. The comment on
   build-docker-images acknowledged the asymmetry; this closes it. The
   `always() && !failure() && !cancelled()` guard is still needed for
   `.dockerignore`/`.editorconfig`-only changes.

4. **Docker filter: drop the two workflow entries duplicated from the dependencies
   filter**, which `hasDockerChanges` already ORs in. No behavior change.

5. **Vulnerability scan: cache + lock.** The job restores the solution twice but
   didn't get the cache block #4284 gave build-and-test. Same cache config, plus
   `--locked-mode` on the head restore so lock-file drift fails loudly. Base stays
   unlocked (main's already-CI-proven state).

Watch on first relevant run: `**/Directory.Build.props` matching the root file
relies on the changed-files action's micromatch semantics; the "Dependency manifest
changes detected" log line will confirm.
