### PR TITLE
fix: give FusionCache factories their own scope and a deadline

### DIFF
--- a/src/Digdir.Domain.Dialogporten.GraphQL/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/Program.cs
@@ -4,6 +4,7 @@ using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.OptionExtensions;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.GraphQL;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Digdir.Domain.Dialogporten.GraphQL.Common;
 using Digdir.Domain.Dialogporten.GraphQL.Common.Authentication;
 using Digdir.Domain.Dialogporten.GraphQL.Common.Authorization;
@@ -117,7 +118,8 @@ static void BuildAndRun(string[] args)
         .AddDialogportenTelemetry(builder.Configuration, builder.Environment,
             additionalMetrics: x => x
                 .AddAspNetCoreInstrumentation()
-                .AddNpgsqlInstrumentation(),
+                .AddNpgsqlInstrumentation()
+                .AddMeter(FusionCacheFactoryTelemetry.MeterName),
             additionalTracing: x => x
                 .AddSource("Dialogporten.GraphQL")
                 .AddFusionCacheInstrumentation()

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AltinnAuthorizationClient.cs
@@ -13,6 +13,7 @@ using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Parties;
 using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
 using Digdir.Domain.Dialogporten.Domain.SubjectResources;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Digdir.Domain.Dialogporten.Infrastructure.Common.Exceptions;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -38,7 +39,7 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
     private readonly IServiceResourceMinimumAuthenticationLevelResolver _serviceResourceMinimumAuthenticationLevelResolver;
     private readonly IPartyResourceReferenceRepository _partyResourceReferenceRepository;
     private readonly ILogger _logger;
-    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly FusionCacheFactoryRunner _factoryRunner;
     private readonly IOptionsMonitor<ApplicationSettings> _applicationSettings;
     private readonly IPartyNameRegistry _partyNameRegistry;
 
@@ -56,7 +57,7 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
         IServiceResourceMinimumAuthenticationLevelResolver serviceResourceMinimumAuthenticationLevelResolver,
         IPartyResourceReferenceRepository partyResourceReferenceRepository,
         ILogger<AltinnAuthorizationClient> logger,
-        IServiceScopeFactory serviceScopeFactory,
+        FusionCacheFactoryRunner factoryRunner,
         IOptionsMonitor<ApplicationSettings> applicationSettings,
         IPartyNameRegistry partyNameRegistry
     )
@@ -68,7 +69,7 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
         ArgumentNullException.ThrowIfNull(serviceResourceMinimumAuthenticationLevelResolver);
         ArgumentNullException.ThrowIfNull(partyResourceReferenceRepository);
         ArgumentNullException.ThrowIfNull(logger);
-        ArgumentNullException.ThrowIfNull(serviceScopeFactory);
+        ArgumentNullException.ThrowIfNull(factoryRunner);
         ArgumentNullException.ThrowIfNull(applicationSettings);
         ArgumentNullException.ThrowIfNull(partyNameRegistry);
 
@@ -90,7 +91,7 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
         _serviceResourceMinimumAuthenticationLevelResolver = serviceResourceMinimumAuthenticationLevelResolver;
         _partyResourceReferenceRepository = partyResourceReferenceRepository;
         _logger = logger;
-        _serviceScopeFactory = serviceScopeFactory;
+        _factoryRunner = factoryRunner;
         _applicationSettings = applicationSettings;
         _partyNameRegistry = partyNameRegistry;
     }
@@ -363,12 +364,12 @@ internal sealed partial class AltinnAuthorizationClient : IAltinnAuthorization
     }
 
     private async Task<List<SubjectResource>> GetAllSubjectResources(CancellationToken cancellationToken) =>
-        await _subjectResourcesCache.GetOrSetAsync(nameof(SubjectResource), async ct =>
-            {
-                using var scope = _serviceScopeFactory.CreateScope();
-                var dbContext = scope.ServiceProvider.GetRequiredService<DialogDbContext>();
-                return await dbContext.SubjectResources.AsNoTracking().ToListAsync(cancellationToken: ct);
-            },
+        await _subjectResourcesCache.GetOrSetAsync(nameof(SubjectResource),
+            token => _factoryRunner.RunInScope(
+                FusionCacheFactoryPolicy.SubjectResources,
+                static async (services, ct) => await services.GetRequiredService<DialogDbContext>()
+                    .SubjectResources.AsNoTracking().ToListAsync(cancellationToken: ct),
+                token),
             token: cancellationToken);
 
     private static List<AuthorizedPartyFilter> CreatePartyFilters(List<string> constraintParties)

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedServiceResourcesProvider.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedServiceResourcesProvider.cs
@@ -3,6 +3,8 @@ using Digdir.Domain.Dialogporten.Application.Common;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -19,33 +21,25 @@ internal sealed class AuthorizedServiceResourcesProvider : IAuthorizedServiceRes
 
     private static readonly StringComparer Comparer = StringComparer.OrdinalIgnoreCase;
 
-    private readonly IAltinnAuthorization _altinnAuthorization;
     private readonly IUser _user;
-    private readonly IUserParties _userParties;
-    private readonly IOptionsSnapshot<ApplicationSettings> _applicationSettings;
     private readonly IFusionCache _cache;
+    private readonly FusionCacheFactoryRunner _factoryRunner;
 
     public AuthorizedServiceResourcesProvider(
-        IAltinnAuthorization altinnAuthorization,
         IUser user,
-        IUserParties userParties,
-        IOptionsSnapshot<ApplicationSettings> applicationSettings,
-        IFusionCacheProvider cacheProvider)
+        IFusionCacheProvider cacheProvider,
+        FusionCacheFactoryRunner factoryRunner)
     {
-        ArgumentNullException.ThrowIfNull(altinnAuthorization);
         ArgumentNullException.ThrowIfNull(user);
-        ArgumentNullException.ThrowIfNull(userParties);
-        ArgumentNullException.ThrowIfNull(applicationSettings);
         ArgumentNullException.ThrowIfNull(cacheProvider);
+        ArgumentNullException.ThrowIfNull(factoryRunner);
 
         var cache = cacheProvider.GetCache(CacheName);
         ArgumentNullException.ThrowIfNull(cache);
 
-        _altinnAuthorization = altinnAuthorization;
         _user = user;
-        _userParties = userParties;
-        _applicationSettings = applicationSettings;
         _cache = cache;
+        _factoryRunner = factoryRunner;
     }
 
     public async Task<AuthorizedServiceResources> GetAuthorizedServiceResources(
@@ -65,19 +59,26 @@ internal sealed class AuthorizedServiceResourcesProvider : IAuthorizedServiceRes
         // request it is the tiny "return the full catalogue" signal (the expensive per-party pruning is skipped).
         return await _cache.GetOrSetAsync<AuthorizedServiceResources>(
             GetCacheKey(partyIdentifier.FullId, normalizedFilter),
-            async ct =>
-            {
-                // The factory may run detached from the request (eager refresh / soft-timeout background
-                // completion), where HttpContext — and thus IUser.GetPrincipal() — is no longer available. The
-                // downstream resolution (IUserParties / IAltinnAuthorization) needs the principal, so flow the
-                // request-thread principal into the factory's execution context.
-                using var _ = AmbientUserPrincipal.Use(principal);
-                return await ResolveAuthorizedServiceResources(normalizedFilter, ct);
-            },
+            token => _factoryRunner.RunInScope(
+                FusionCacheFactoryPolicy.AuthorizedServiceResources,
+                async (services, ct) =>
+                {
+                    // The factory runs detached from the request (eager refresh / soft-timeout background
+                    // completion), where HttpContext — and thus IUser.GetPrincipal() — is no longer available.
+                    // The runner's fresh scope gives the resolution live dependencies; the ambient principal
+                    // gives its IUser the request-thread principal. Established BEFORE resolving scoped
+                    // services and disposed only after the resolution has been awaited.
+                    using var _ = AmbientUserPrincipal.Use(principal);
+                    return await ResolveAuthorizedServiceResources(services, normalizedFilter, ct);
+                },
+                token),
             token: cancellationToken);
     }
 
-    private async Task<AuthorizedServiceResources> ResolveAuthorizedServiceResources(
+    // Static and resolving its own dependencies: the factory can run detached from the request (see
+    // FusionCacheFactoryRunner), so it must not capture request-scoped services from this instance.
+    private static async Task<AuthorizedServiceResources> ResolveAuthorizedServiceResources(
+        IServiceProvider services,
         string[]? normalizedFilter,
         CancellationToken cancellationToken)
     {
@@ -85,7 +86,7 @@ internal sealed class AuthorizedServiceResourcesProvider : IAuthorizedServiceRes
         // limit, return the full referenced catalogue and skip the expensive per-party resolution entirely. The
         // count uses the lightweight authorized-parties lookup (no resource/subject resolution, no pruning), so
         // we never do the heavy GetAuthorizedResourcesForSearch work just to discover the caller is over the limit.
-        var limits = _applicationSettings.Value.Limits;
+        var limits = services.GetRequiredService<IOptionsSnapshot<ApplicationSettings>>().Value.Limits;
         var maxPartiesBeforeFullCatalogue = limits.AuthorizedServiceResources.MaxAuthorizedPartiesBeforeFullCatalogue;
 
         // The fallback must trip no later than the per-party caching threshold: above that threshold the per-party
@@ -101,7 +102,7 @@ internal sealed class AuthorizedServiceResourcesProvider : IAuthorizedServiceRes
 
         if (normalizedFilter is null && maxPartiesBeforeFullCatalogue > 0)
         {
-            var userParties = await _userParties.GetUserParties(cancellationToken);
+            var userParties = await services.GetRequiredService<IUserParties>().GetUserParties(cancellationToken);
             if (userParties.FlattenedCount() > maxPartiesBeforeFullCatalogue)
             {
                 return new AuthorizedServiceResources(IncludeFullCatalogue: true, ResourceUrns: []);
@@ -117,7 +118,7 @@ internal sealed class AuthorizedServiceResourcesProvider : IAuthorizedServiceRes
         // DialogIds are not needed for this endpoint, so skip resolving them. Pruning happens once inside the
         // search call (ForceReferencedCatalogueSubsetPruning), so the provider does not prune again.
         var constraintParties = normalizedFilter is null ? [] : normalizedFilter.ToList();
-        var result = await _altinnAuthorization.GetAuthorizedResourcesForSearch(
+        var result = await services.GetRequiredService<IAltinnAuthorization>().GetAuthorizedResourcesForSearch(
             constraintParties, [], includeDialogIds: false,
             minResourcesPruningThreshold: ForceReferencedCatalogueSubsetPruning, cancellationToken: cancellationToken);
 

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedServiceResourcesProvider.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Altinn/Authorization/AuthorizedServiceResourcesProvider.cs
@@ -21,6 +21,9 @@ internal sealed class AuthorizedServiceResourcesProvider : IAuthorizedServiceRes
 
     private static readonly StringComparer Comparer = StringComparer.OrdinalIgnoreCase;
 
+    // The one deliberately request-scoped constructor dependency: the principal is resolved from it on the
+    // request thread before any cache access (see GetAuthorizedServiceResources), so it never crosses into
+    // the detached factory. Everything the factory needs comes from the runner's scope instead.
     private readonly IUser _user;
     private readonly IFusionCache _cache;
     private readonly FusionCacheFactoryRunner _factoryRunner;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryPolicy.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryPolicy.cs
@@ -1,0 +1,115 @@
+using Digdir.Domain.Dialogporten.Domain.SubjectResources;
+using Digdir.Domain.Dialogporten.Infrastructure.Altinn.Authorization;
+using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories;
+using Digdir.Domain.Dialogporten.Infrastructure.ServiceResourceMetadata;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
+
+/// <summary>
+/// Execution policy for a cache factory run through <see cref="FusionCacheFactoryRunner"/>. The same policy
+/// instance supplies the cache registration's FactoryHardTimeout so the waiter-facing budget and the factory's
+/// work ceiling cannot drift apart:
+/// FactoryHardTimeout (waiters released / cold misses fail) &lt; CancellationAfter (cooperative cancellation)
+/// &lt; AbandonAfter (the wall-clock ceiling: the runner stops awaiting the factory so FusionCache releases the
+/// per-key lock). The ordering is pinned by a unit test over <see cref="All"/>.
+/// </summary>
+internal sealed record FusionCacheFactoryPolicy
+{
+    public required string CacheName { get; init; }
+
+    /// <summary>FusionCache FactoryHardTimeout: how long cache callers without fail-safe data wait.</summary>
+    public required TimeSpan HardTimeout { get; init; }
+
+    /// <summary>When the runner requests cooperative cancellation of the factory.</summary>
+    public required TimeSpan CancellationAfter { get; init; }
+
+    /// <summary>
+    /// The wall-clock ceiling: when the runner abandons a factory that has not completed, releasing the
+    /// FusionCache per-key lock while the orphaned execution keeps its permit until it actually finishes.
+    /// </summary>
+    public required TimeSpan AbandonAfter { get; init; }
+
+    /// <summary>
+    /// Pre-execution permit count: the maximum executions (and thereby DI scopes) that can be live at once
+    /// for this cache, orphans included. Bounds the resources abandoned factories can hold; also caps healthy
+    /// concurrency, so single-key caches use 1 (FusionCache's per-key lock serializes them anyway) and
+    /// high-cardinality caches need headroom for concurrent refreshes of distinct keys.
+    /// </summary>
+    public required int MaxConcurrentExecutions { get; init; }
+
+    // One small-table EF query; CancellationAfter = 30s Npgsql CommandTimeout + acquisition/mapping headroom.
+    public static readonly FusionCacheFactoryPolicy MinimumAuthenticationLevels = new()
+    {
+        CacheName = ResourcePolicyInformationRepository.MinimumAuthenticationLevelsCacheName,
+        HardTimeout = TimeSpan.FromSeconds(5),
+        CancellationAfter = TimeSpan.FromSeconds(45),
+        AbandonAfter = TimeSpan.FromSeconds(55),
+        MaxConcurrentExecutions = 1
+    };
+
+    // Single raw SQL query; CancellationAfter = the 60s hard timeout + margin.
+    public static readonly FusionCacheFactoryPolicy SubjectResourceReferencedPartyResources = new()
+    {
+        CacheName = SubjectResourceRepository.ReferencedPartyResourcesCacheName,
+        HardTimeout = TimeSpan.FromSeconds(60),
+        CancellationAfter = TimeSpan.FromSeconds(90),
+        AbandonAfter = TimeSpan.FromSeconds(100),
+        MaxConcurrentExecutions = 1
+    };
+
+    // Single Dapper query on the singleton NpgsqlDataSource; same shape as the subject-resource query.
+    public static readonly FusionCacheFactoryPolicy PartyResourceReferencedResources = new()
+    {
+        CacheName = PartyResourceRepository.ReferencedResourcesCacheName,
+        HardTimeout = TimeSpan.FromSeconds(60),
+        CancellationAfter = TimeSpan.FromSeconds(90),
+        AbandonAfter = TimeSpan.FromSeconds(100),
+        MaxConcurrentExecutions = 1
+    };
+
+    // Full SubjectResources table EF read, one command; CancellationAfter = CommandTimeout + headroom.
+    public static readonly FusionCacheFactoryPolicy SubjectResources = new()
+    {
+        CacheName = nameof(SubjectResource),
+        HardTimeout = TimeSpan.FromSeconds(5),
+        CancellationAfter = TimeSpan.FromSeconds(45),
+        AbandonAfter = TimeSpan.FromSeconds(55),
+        MaxConcurrentExecutions = 1
+    };
+
+    // Multi-step sequential rebuild whose stages can invoke HTTP factories with their own retry budgets, so a
+    // theoretical worst case exceeds any sane ceiling. Chosen operational ceiling based on observed rebuild
+    // latency; the rebuild must normally finish well within the 120s hard timeout.
+    public static readonly FusionCacheFactoryPolicy ServiceResourceMetadataCatalogue = new()
+    {
+        CacheName = ServiceResourceMetadata.ServiceResourceMetadataCatalogue.CacheName,
+        HardTimeout = TimeSpan.FromSeconds(120),
+        CancellationAfter = TimeSpan.FromSeconds(150),
+        AbandonAfter = TimeSpan.FromSeconds(160),
+        MaxConcurrentExecutions = 1
+    };
+
+    // Awaits inner authorization caches with 25s hard timeouts, plus union/post-processing margin.
+    // High cardinality (one key per caller/filter): permits must cover healthy concurrent refreshes of
+    // distinct keys. 16 is an initial, unmeasured limit; capacity rejections (see runner events) are the
+    // signal that it is sized wrong.
+    public static readonly FusionCacheFactoryPolicy AuthorizedServiceResources = new()
+    {
+        CacheName = AuthorizedServiceResourcesProvider.CacheName,
+        HardTimeout = TimeSpan.FromSeconds(25),
+        CancellationAfter = TimeSpan.FromSeconds(40),
+        AbandonAfter = TimeSpan.FromSeconds(50),
+        MaxConcurrentExecutions = 16
+    };
+
+    /// <summary>Every policy in use; the intentional inventory for validation and telemetry.</summary>
+    public static readonly IReadOnlyList<FusionCacheFactoryPolicy> All =
+    [
+        MinimumAuthenticationLevels,
+        SubjectResourceReferencedPartyResources,
+        PartyResourceReferencedResources,
+        SubjectResources,
+        ServiceResourceMetadataCatalogue,
+        AuthorizedServiceResources
+    ];
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRejectedException.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRejectedException.cs
@@ -5,17 +5,7 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 /// cache's execution permits are exhausted (its factories are stuck or abandoned up to the configured
 /// concurrency bound). Cache callers with fail-safe data are served stale; cold misses observe this exception.
 /// </summary>
-public sealed class FusionCacheFactoryRejectedException : Exception
+internal sealed class FusionCacheFactoryRejectedException : Exception
 {
-    public FusionCacheFactoryRejectedException()
-    {
-    }
-
-    public FusionCacheFactoryRejectedException(string message) : base(message)
-    {
-    }
-
-    public FusionCacheFactoryRejectedException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
+    public FusionCacheFactoryRejectedException(string message) : base(message) { }
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRejectedException.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRejectedException.cs
@@ -5,7 +5,7 @@ namespace Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 /// cache's execution permits are exhausted (its factories are stuck or abandoned up to the configured
 /// concurrency bound). Cache callers with fail-safe data are served stale; cold misses observe this exception.
 /// </summary>
-internal sealed class FusionCacheFactoryRejectedException : Exception
+public sealed class FusionCacheFactoryRejectedException : Exception
 {
     public FusionCacheFactoryRejectedException(string message) : base(message) { }
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRejectedException.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRejectedException.cs
@@ -1,0 +1,21 @@
+namespace Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
+
+/// <summary>
+/// Thrown by <see cref="FusionCacheFactoryRunner"/> when a cache factory invocation is rejected because the
+/// cache's execution permits are exhausted (its factories are stuck or abandoned up to the configured
+/// concurrency bound). Cache callers with fail-safe data are served stale; cold misses observe this exception.
+/// </summary>
+public sealed class FusionCacheFactoryRejectedException : Exception
+{
+    public FusionCacheFactoryRejectedException()
+    {
+    }
+
+    public FusionCacheFactoryRejectedException(string message) : base(message)
+    {
+    }
+
+    public FusionCacheFactoryRejectedException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
@@ -1,0 +1,328 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
+
+/// <summary>
+/// Runs FusionCache factories with their own dependency lifetime, work ceiling, and resource bound.
+///
+/// FusionCache detaches factories from the triggering request: a factory that exceeds FactorySoftTimeout keeps
+/// running as a background completion, and eager refresh starts factories on a request context that is about to
+/// unwind. FactoryHardTimeout only releases waiters; it never cancels the factory, and the per-key memory lock
+/// is released only when the factory task completes. A factory must therefore:
+/// own its dependencies for its full lifetime (a dedicated DI scope instead of captured request-scoped
+/// services), enforce its own work ceiling (cooperative cancellation at CancellationAfter, hard abandonment at
+/// AbandonAfter so a stuck factory cannot hold the per-key lock), and be bounded in how many executions can be
+/// live at once (a pre-execution permit per cache) so abandonment cannot convert a per-key lock wedge into
+/// connection-pool exhaustion.
+/// </summary>
+internal sealed partial class FusionCacheFactoryRunner
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FusionCacheFactoryRunner> _logger;
+    private readonly ConcurrentDictionary<string, BulkheadState> _bulkheads = new(StringComparer.Ordinal);
+
+    public FusionCacheFactoryRunner(IServiceScopeFactory scopeFactory, ILogger<FusionCacheFactoryRunner> logger)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(logger);
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+
+        // Touch every policy's instruments so each cache has a zero-valued series from startup instead of
+        // appearing only on first activity.
+        foreach (var policy in FusionCacheFactoryPolicy.All)
+        {
+            FusionCacheFactoryTelemetry.ActiveExecutions.Add(0, CacheTag(policy));
+            FusionCacheFactoryTelemetry.ActiveOrphans.Add(0, CacheTag(policy));
+        }
+    }
+
+    /// <summary>
+    /// Runs a factory that needs scoped services (DbContext, IOptionsSnapshot, ...) in a dedicated DI scope
+    /// that lives exactly as long as the factory execution, detached or not.
+    /// </summary>
+    public Task<TValue> RunInScope<TValue>(
+        FusionCacheFactoryPolicy policy,
+        Func<IServiceProvider, CancellationToken, Task<TValue>> factory,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(factory);
+        return RunShared(policy, async ct =>
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            return await factory(scope.ServiceProvider, ct);
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs a factory on singleton dependencies (no DI scope) with the same permits and deadlines.
+    /// </summary>
+    public Task<TValue> Run<TValue>(
+        FusionCacheFactoryPolicy policy,
+        Func<CancellationToken, Task<TValue>> factory,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(factory);
+        return RunShared(policy, factory, cancellationToken);
+    }
+
+    private async Task<TValue> RunShared<TValue>(
+        FusionCacheFactoryPolicy policy,
+        Func<CancellationToken, Task<TValue>> factory,
+        CancellationToken cancellationToken)
+    {
+        // A pre-cancelled call reports cancellation, not capacity rejection.
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var lease = AcquireLease(policy);
+        var start = Stopwatch.GetTimestamp();
+        CancellationTokenSource? cancellationSource = null;
+        Task<TValue> factoryTask;
+        try
+        {
+            cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cancellationSource.CancelAfter(policy.CancellationAfter);
+            // Ownership of the lease and the cancellation source transfers to the factory task, whose
+            // finally releases them when the execution ACTUALLY completes - even long after abandonment.
+            factoryTask = RunCore(policy, factory, lease, cancellationSource, cancellationToken);
+        }
+        catch
+        {
+            cancellationSource?.Dispose();
+            lease.Dispose();
+            throw;
+        }
+
+        try
+        {
+            // Both timers were scheduled before any user code ran; pass the REMAINING abandonment budget so
+            // cooperative cancellation and abandonment share one start point.
+            var remaining = policy.AbandonAfter - Stopwatch.GetElapsedTime(start);
+            return await factoryTask.WaitAsync(remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero, cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            if (factoryTask.IsCompleted)
+            {
+                // The factory completed concurrently with the timer; propagate its actual outcome.
+                return await factoryTask;
+            }
+
+            RegisterOrphan(policy, factoryTask, start, deadlineAbandoned: true);
+            var abandonment = new OperationCanceledException(
+                $"The '{policy.CacheName}' cache factory did not complete within its {policy.AbandonAfter} abandonment ceiling.");
+            LogFactoryAbandoned(policy.CacheName, policy.CancellationAfter, policy.AbandonAfter, abandonment);
+            // FusionCache observes a cancelled factory and releases the per-key lock; waiters were already
+            // released (or served stale) at FactoryHardTimeout.
+            throw abandonment;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            if (!factoryTask.IsCompleted)
+            {
+                // Caller cancellation is not a failure, but the still-running execution must be tracked like
+                // any other orphan: it keeps its permit and scope until it actually completes.
+                RegisterOrphan(policy, factoryTask, start, deadlineAbandoned: false);
+            }
+
+            throw;
+        }
+    }
+
+    private static async Task<TValue> RunCore<TValue>(
+        FusionCacheFactoryPolicy policy,
+        Func<CancellationToken, Task<TValue>> factory,
+        ExecutionLease lease,
+        CancellationTokenSource cancellationSource,
+        CancellationToken outerToken)
+    {
+        try
+        {
+            // Return to the wrapper before any user code runs, so a factory that blocks synchronously before
+            // its first await can still be abandoned by the wall-clock ceiling.
+            await Task.Yield();
+            // Skip the work (and the scope) entirely if cancellation or abandonment won while this
+            // continuation was queued.
+            cancellationSource.Token.ThrowIfCancellationRequested();
+            return await factory(cancellationSource.Token);
+        }
+        catch (OperationCanceledException) when (outerToken.IsCancellationRequested)
+        {
+            // Caller/shutdown cancellation is not a factory failure.
+            throw;
+        }
+        catch (OperationCanceledException ex) when (cancellationSource.IsCancellationRequested)
+        {
+            lease.LogFactoryDeadlineCancelled(policy.CancellationAfter, ex);
+            throw;
+        }
+        catch (FusionCacheFactoryRejectedException)
+        {
+            // A nested factory's capacity rejection is already logged as a circuit transition by its own
+            // runner invocation; logging it per-occurrence here would recreate the log storm.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Includes OperationCanceledException that neither the caller nor this runner requested: such
+            // cancellation is an unexpected factory failure and must stay attributable.
+            lease.LogFactoryFailed(ex);
+            throw;
+        }
+        finally
+        {
+            cancellationSource.Dispose();
+            lease.Dispose();
+        }
+    }
+
+    private ExecutionLease AcquireLease(FusionCacheFactoryPolicy policy)
+    {
+        var bulkhead = _bulkheads.GetOrAdd(
+            policy.CacheName,
+            static (_, maxConcurrentExecutions) => new BulkheadState(maxConcurrentExecutions),
+            policy.MaxConcurrentExecutions);
+
+        if (!bulkhead.Permits.Wait(0))
+        {
+            // Log the transition into the exhausted interval exactly once (on the first rejection), never
+            // per rejection.
+            if (Interlocked.CompareExchange(ref bulkhead.ExhaustionLogged, 1, 0) == 0)
+            {
+                LogCapacityExhausted(policy.CacheName, policy.MaxConcurrentExecutions);
+            }
+
+            throw new FusionCacheFactoryRejectedException(
+                $"The '{policy.CacheName}' cache factory was rejected: all {policy.MaxConcurrentExecutions} " +
+                "execution permits are in use by running or abandoned factories.");
+        }
+
+        FusionCacheFactoryTelemetry.ActiveExecutions.Add(1, CacheTag(policy));
+        return new ExecutionLease(this, policy, bulkhead);
+    }
+
+    private void RegisterOrphan<TValue>(FusionCacheFactoryPolicy policy, Task<TValue> factoryTask, long start, bool deadlineAbandoned)
+    {
+        FusionCacheFactoryTelemetry.ActiveOrphans.Add(1, CacheTag(policy));
+        _ = ObserveOrphanAsync(policy, factoryTask, start, deadlineAbandoned);
+    }
+
+    private async Task ObserveOrphanAsync<TValue>(FusionCacheFactoryPolicy policy, Task<TValue> factoryTask, long start, bool deadlineAbandoned)
+    {
+        Exception? failure = null;
+        try
+        {
+            // SuppressThrowing is only valid on the non-generic Task.
+            await ((Task)factoryTask).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            if (factoryTask.Exception is not null)
+            {
+                failure = factoryTask.Exception.GetBaseException();
+            }
+        }
+        finally
+        {
+            FusionCacheFactoryTelemetry.ActiveOrphans.Add(-1, CacheTag(policy));
+        }
+
+        var elapsed = Stopwatch.GetElapsedTime(start);
+        if (deadlineAbandoned)
+        {
+            LogOrphanCompleted(policy.CacheName, elapsed, failure);
+        }
+        else
+        {
+            LogCancelledOrphanCompleted(policy.CacheName, elapsed);
+        }
+    }
+
+    private static KeyValuePair<string, object?> CacheTag(FusionCacheFactoryPolicy policy) =>
+        new(FusionCacheFactoryTelemetry.CacheNameTag, policy.CacheName);
+
+    [LoggerMessage(EventId = 1, EventName = "FusionCacheFactoryFailed", Level = LogLevel.Error,
+        Message = "The {CacheName} cache factory failed.")]
+    private partial void LogFactoryFailed(string cacheName, Exception exception);
+
+    [LoggerMessage(EventId = 2, EventName = "FusionCacheFactoryDeadlineCancelled", Level = LogLevel.Error,
+        Message = "The {CacheName} cache factory was cancelled at its {CancellationAfter} cancellation deadline.")]
+    private partial void LogFactoryDeadlineCancelled(string cacheName, TimeSpan cancellationAfter, Exception exception);
+
+    [LoggerMessage(EventId = 3, EventName = "FusionCacheFactoryAbandoned", Level = LogLevel.Error,
+        Message = "The {CacheName} cache factory ignored cancellation at {CancellationAfter} and was abandoned at its {AbandonAfter} ceiling; it keeps its execution permit until it completes.")]
+    private partial void LogFactoryAbandoned(string cacheName, TimeSpan cancellationAfter, TimeSpan abandonAfter, Exception exception);
+
+    [LoggerMessage(EventId = 4, EventName = "FusionCacheFactoryOrphanCompleted", Level = LogLevel.Warning,
+        Message = "An abandoned {CacheName} cache factory completed after {Elapsed}.")]
+    private partial void LogOrphanCompleted(string cacheName, TimeSpan elapsed, Exception? exception);
+
+    [LoggerMessage(EventId = 5, EventName = "FusionCacheFactoryCapacityExhausted", Level = LogLevel.Error,
+        Message = "All {MaxConcurrentExecutions} execution permits for the {CacheName} cache factory are in use; new factory invocations are rejected until one completes.")]
+    private partial void LogCapacityExhausted(string cacheName, int maxConcurrentExecutions);
+
+    [LoggerMessage(EventId = 6, EventName = "FusionCacheFactoryCapacityRestored", Level = LogLevel.Information,
+        Message = "Execution permits for the {CacheName} cache factory are available again.")]
+    private partial void LogCapacityRestored(string cacheName);
+
+    [LoggerMessage(EventId = 7, EventName = "FusionCacheFactoryCancelledOrphanCompleted", Level = LogLevel.Debug,
+        Message = "A caller-cancelled {CacheName} cache factory completed after {Elapsed}.")]
+    private partial void LogCancelledOrphanCompleted(string cacheName, TimeSpan elapsed);
+
+    private sealed class BulkheadState
+    {
+        public BulkheadState(int maxConcurrentExecutions)
+        {
+            Permits = new SemaphoreSlim(maxConcurrentExecutions, maxConcurrentExecutions);
+        }
+
+        public SemaphoreSlim Permits { get; }
+
+        // 1 while an exhausted interval has been logged (EventId 5); reset (with EventId 6) when a permit frees.
+        public int ExhaustionLogged;
+    }
+
+    /// <summary>
+    /// Owns one execution permit and the matching counter decrement. Idempotent: whichever of the wrapper's
+    /// failure path or the factory task's finally runs last cannot double-release.
+    /// </summary>
+    private sealed class ExecutionLease : IDisposable
+    {
+        private readonly FusionCacheFactoryRunner _runner;
+        private readonly FusionCacheFactoryPolicy _policy;
+        private readonly BulkheadState _bulkhead;
+        private int _disposed;
+
+        public ExecutionLease(FusionCacheFactoryRunner runner, FusionCacheFactoryPolicy policy, BulkheadState bulkhead)
+        {
+            _runner = runner;
+            _policy = policy;
+            _bulkhead = bulkhead;
+        }
+
+        public void LogFactoryFailed(Exception exception) =>
+            _runner.LogFactoryFailed(_policy.CacheName, exception);
+
+        public void LogFactoryDeadlineCancelled(TimeSpan cancellationAfter, Exception exception) =>
+            _runner.LogFactoryDeadlineCancelled(_policy.CacheName, cancellationAfter, exception);
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
+            {
+                return;
+            }
+
+            _bulkhead.Permits.Release();
+            FusionCacheFactoryTelemetry.ActiveExecutions.Add(-1, CacheTag(_policy));
+
+            // Close the exhausted interval (EventId 6) only if EventId 5 opened it.
+            if (Interlocked.CompareExchange(ref _bulkhead.ExhaustionLogged, 0, 1) == 1)
+            {
+                _runner.LogCapacityRestored(_policy.CacheName);
+            }
+        }
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
@@ -22,6 +22,8 @@ internal sealed partial class FusionCacheFactoryRunner
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<FusionCacheFactoryRunner> _logger;
+    // One entry per policy: policies are static per cache, never per key, so this dictionary is bounded by
+    // FusionCacheFactoryPolicy.All and is deliberately never pruned. A per-key policy would leak here.
     private readonly ConcurrentDictionary<string, BulkheadState> _bulkheads = new(StringComparer.Ordinal);
 
     public FusionCacheFactoryRunner(IServiceScopeFactory scopeFactory, ILogger<FusionCacheFactoryRunner> logger)
@@ -194,24 +196,41 @@ internal sealed partial class FusionCacheFactoryRunner
             static (_, maxConcurrentExecutions) => new BulkheadState(maxConcurrentExecutions),
             policy.MaxConcurrentExecutions);
 
+        var rejected = false;
+        var logExhaustion = false;
         lock (bulkhead.Gate)
         {
             if (bulkhead.AvailablePermits == 0)
             {
-                // Log the transition into the exhausted interval exactly once (on the first rejection),
+                rejected = true;
+                // Mark the transition into the exhausted interval exactly once (on the first rejection),
                 // never per rejection.
                 if (!bulkhead.ExhaustionLogged)
                 {
                     bulkhead.ExhaustionLogged = true;
-                    LogCapacityExhausted(policy.CacheName, policy.MaxConcurrentExecutions);
+                    logExhaustion = true;
                 }
+            }
+            else
+            {
+                bulkhead.AvailablePermits--;
+            }
+        }
 
-                throw new FusionCacheFactoryRejectedException(
-                    $"The '{policy.CacheName}' cache factory was rejected: all {policy.MaxConcurrentExecutions} " +
-                    "execution permits are in use by running or abandoned factories.");
+        if (rejected)
+        {
+            // Logged outside the gate: logging providers are third-party code that must not run under the
+            // permit lock (same rule as the metric callbacks below). The transition decision is made under
+            // the gate, so each exhausted interval still logs exactly once; only the emission order against
+            // a concurrent restore can wobble.
+            if (logExhaustion)
+            {
+                LogCapacityExhausted(policy.CacheName, policy.MaxConcurrentExecutions);
             }
 
-            bulkhead.AvailablePermits--;
+            throw new FusionCacheFactoryRejectedException(
+                $"The '{policy.CacheName}' cache factory was rejected: all {policy.MaxConcurrentExecutions} " +
+                "execution permits are in use by running or abandoned factories.");
         }
 
         FusionCacheFactoryTelemetry.ActiveExecutions.Add(1, CacheTag(policy));
@@ -330,6 +349,7 @@ internal sealed partial class FusionCacheFactoryRunner
                 return;
             }
 
+            var logRestored = false;
             lock (_bulkhead.Gate)
             {
                 _bulkhead.AvailablePermits++;
@@ -340,8 +360,15 @@ internal sealed partial class FusionCacheFactoryRunner
                 if (_bulkhead.ExhaustionLogged)
                 {
                     _bulkhead.ExhaustionLogged = false;
-                    _runner.LogCapacityRestored(_policy.CacheName);
+                    logRestored = true;
                 }
+            }
+
+            // Logged outside the gate: a blocked logging provider must not stall permit release, least of
+            // all while the bulkhead is describing its own exhaustion.
+            if (logRestored)
+            {
+                _runner.LogCapacityRestored(_policy.CacheName);
             }
 
             // Deliberately outside the gate: measurement callbacks (MeterListener) run inline on Add and must

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
@@ -156,8 +156,14 @@ internal sealed partial class FusionCacheFactoryRunner
             // Caller/shutdown cancellation is not a factory failure.
             throw;
         }
-        catch (OperationCanceledException ex) when (cancellationSource.IsCancellationRequested)
+        catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationSource.Token)
         {
+            // Matched by token identity, not source state: this event measures whether cooperative
+            // cancellation works, so a cancellation the factory produced independently after the deadline
+            // elapsed must not masquerade as a deadline cancellation. (The caller-cancellation clause above
+            // deliberately stays state-based: once the caller is gone, all cancellation fallout is noise.)
+            // Token-less cancellations that were in fact responses to our token fall through to the failure
+            // log below, which errs toward attribution.
             lease.LogFactoryDeadlineCancelled(policy.CancellationAfter, ex);
             throw;
         }
@@ -169,7 +175,7 @@ internal sealed partial class FusionCacheFactoryRunner
         }
         catch (Exception ex)
         {
-            // Includes OperationCanceledException that neither the caller nor this runner requested: such
+            // Includes OperationCanceledException carrying neither the caller's nor this runner's token: such
             // cancellation is an unexpected factory failure and must stay attributable.
             lease.LogFactoryFailed(ex);
             throw;

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
@@ -118,7 +118,7 @@ internal sealed partial class FusionCacheFactoryRunner
             RegisterOrphan(policy, factoryTask, start, deadlineAbandoned: true);
             var abandonment = new OperationCanceledException(
                 $"The '{policy.CacheName}' cache factory did not complete within its {policy.AbandonAfter} abandonment ceiling.");
-            LogFactoryAbandoned(policy.CacheName, policy.CancellationAfter, policy.AbandonAfter, abandonment);
+            LogFactoryAbandoned(_logger, policy.CacheName, policy.CancellationAfter, policy.AbandonAfter, abandonment);
             // FusionCache observes a cancelled factory and releases the per-key lock; waiters were already
             // released (or served stale) at FactoryHardTimeout.
             throw abandonment;
@@ -225,7 +225,7 @@ internal sealed partial class FusionCacheFactoryRunner
             // a concurrent restore can wobble.
             if (logExhaustion)
             {
-                LogCapacityExhausted(policy.CacheName, policy.MaxConcurrentExecutions);
+                LogCapacityExhausted(_logger, policy.CacheName, policy.MaxConcurrentExecutions);
             }
 
             throw new FusionCacheFactoryRejectedException(
@@ -263,11 +263,11 @@ internal sealed partial class FusionCacheFactoryRunner
         var elapsed = Stopwatch.GetElapsedTime(start);
         if (deadlineAbandoned)
         {
-            LogOrphanCompleted(policy.CacheName, elapsed, failure);
+            LogOrphanCompleted(_logger, policy.CacheName, elapsed, failure);
         }
         else
         {
-            LogCancelledOrphanCompleted(policy.CacheName, elapsed);
+            LogCancelledOrphanCompleted(_logger, policy.CacheName, elapsed);
         }
     }
 
@@ -276,31 +276,31 @@ internal sealed partial class FusionCacheFactoryRunner
 
     [LoggerMessage(EventId = 1, EventName = "FusionCacheFactoryFailed", Level = LogLevel.Error,
         Message = "The {CacheName} cache factory failed.")]
-    private partial void LogFactoryFailed(string cacheName, Exception exception);
+    private static partial void LogFactoryFailed(ILogger logger, string cacheName, Exception exception);
 
     [LoggerMessage(EventId = 2, EventName = "FusionCacheFactoryDeadlineCancelled", Level = LogLevel.Error,
         Message = "The {CacheName} cache factory was cancelled at its {CancellationAfter} cancellation deadline.")]
-    private partial void LogFactoryDeadlineCancelled(string cacheName, TimeSpan cancellationAfter, Exception exception);
+    private static partial void LogFactoryDeadlineCancelled(ILogger logger, string cacheName, TimeSpan cancellationAfter, Exception exception);
 
     [LoggerMessage(EventId = 3, EventName = "FusionCacheFactoryAbandoned", Level = LogLevel.Error,
         Message = "The {CacheName} cache factory ignored cancellation at {CancellationAfter} and was abandoned at its {AbandonAfter} ceiling; it keeps its execution permit until it completes.")]
-    private partial void LogFactoryAbandoned(string cacheName, TimeSpan cancellationAfter, TimeSpan abandonAfter, Exception exception);
+    private static partial void LogFactoryAbandoned(ILogger logger, string cacheName, TimeSpan cancellationAfter, TimeSpan abandonAfter, Exception exception);
 
     [LoggerMessage(EventId = 4, EventName = "FusionCacheFactoryOrphanCompleted", Level = LogLevel.Warning,
         Message = "An abandoned {CacheName} cache factory completed after {Elapsed}.")]
-    private partial void LogOrphanCompleted(string cacheName, TimeSpan elapsed, Exception? exception);
+    private static partial void LogOrphanCompleted(ILogger logger, string cacheName, TimeSpan elapsed, Exception? exception);
 
     [LoggerMessage(EventId = 5, EventName = "FusionCacheFactoryCapacityExhausted", Level = LogLevel.Error,
         Message = "All {MaxConcurrentExecutions} execution permits for the {CacheName} cache factory are in use; new factory invocations are rejected until one completes.")]
-    private partial void LogCapacityExhausted(string cacheName, int maxConcurrentExecutions);
+    private static partial void LogCapacityExhausted(ILogger logger, string cacheName, int maxConcurrentExecutions);
 
     [LoggerMessage(EventId = 6, EventName = "FusionCacheFactoryCapacityRestored", Level = LogLevel.Information,
         Message = "Execution permits for the {CacheName} cache factory are available again.")]
-    private partial void LogCapacityRestored(string cacheName);
+    private static partial void LogCapacityRestored(ILogger logger, string cacheName);
 
     [LoggerMessage(EventId = 7, EventName = "FusionCacheFactoryCancelledOrphanCompleted", Level = LogLevel.Debug,
         Message = "A caller-cancelled {CacheName} cache factory completed after {Elapsed}.")]
-    private partial void LogCancelledOrphanCompleted(string cacheName, TimeSpan elapsed);
+    private static partial void LogCancelledOrphanCompleted(ILogger logger, string cacheName, TimeSpan elapsed);
 
     private sealed class BulkheadState
     {
@@ -337,10 +337,10 @@ internal sealed partial class FusionCacheFactoryRunner
         }
 
         public void LogFactoryFailed(Exception exception) =>
-            _runner.LogFactoryFailed(_policy.CacheName, exception);
+            FusionCacheFactoryRunner.LogFactoryFailed(_runner._logger, _policy.CacheName, exception);
 
         public void LogFactoryDeadlineCancelled(TimeSpan cancellationAfter, Exception exception) =>
-            _runner.LogFactoryDeadlineCancelled(_policy.CacheName, cancellationAfter, exception);
+            FusionCacheFactoryRunner.LogFactoryDeadlineCancelled(_runner._logger, _policy.CacheName, cancellationAfter, exception);
 
         public void Dispose()
         {
@@ -368,7 +368,7 @@ internal sealed partial class FusionCacheFactoryRunner
             // all while the bulkhead is describing its own exhaustion.
             if (logRestored)
             {
-                _runner.LogCapacityRestored(_policy.CacheName);
+                LogCapacityRestored(_runner._logger, _policy.CacheName);
             }
 
             // Deliberately outside the gate: measurement callbacks (MeterListener) run inline on Add and must

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
@@ -188,18 +188,24 @@ internal sealed partial class FusionCacheFactoryRunner
             static (_, maxConcurrentExecutions) => new BulkheadState(maxConcurrentExecutions),
             policy.MaxConcurrentExecutions);
 
-        if (!bulkhead.Permits.Wait(0))
+        lock (bulkhead.Gate)
         {
-            // Log the transition into the exhausted interval exactly once (on the first rejection), never
-            // per rejection.
-            if (Interlocked.CompareExchange(ref bulkhead.ExhaustionLogged, 1, 0) == 0)
+            if (bulkhead.AvailablePermits == 0)
             {
-                LogCapacityExhausted(policy.CacheName, policy.MaxConcurrentExecutions);
+                // Log the transition into the exhausted interval exactly once (on the first rejection),
+                // never per rejection.
+                if (!bulkhead.ExhaustionLogged)
+                {
+                    bulkhead.ExhaustionLogged = true;
+                    LogCapacityExhausted(policy.CacheName, policy.MaxConcurrentExecutions);
+                }
+
+                throw new FusionCacheFactoryRejectedException(
+                    $"The '{policy.CacheName}' cache factory was rejected: all {policy.MaxConcurrentExecutions} " +
+                    "execution permits are in use by running or abandoned factories.");
             }
 
-            throw new FusionCacheFactoryRejectedException(
-                $"The '{policy.CacheName}' cache factory was rejected: all {policy.MaxConcurrentExecutions} " +
-                "execution permits are in use by running or abandoned factories.");
+            bulkhead.AvailablePermits--;
         }
 
         FusionCacheFactoryTelemetry.ActiveExecutions.Add(1, CacheTag(policy));
@@ -275,13 +281,16 @@ internal sealed partial class FusionCacheFactoryRunner
     {
         public BulkheadState(int maxConcurrentExecutions)
         {
-            Permits = new SemaphoreSlim(maxConcurrentExecutions, maxConcurrentExecutions);
+            AvailablePermits = maxConcurrentExecutions;
         }
 
-        public SemaphoreSlim Permits { get; }
-
-        // 1 while an exhausted interval has been logged (EventId 5); reset (with EventId 6) when a permit frees.
-        public int ExhaustionLogged;
+        // Permit accounting and the exhausted-interval flag (EventId 5 logged / awaiting EventId 6) must
+        // transition together under the gate: releasing a permit before resetting the flag would let a
+        // re-acquire-then-reject interleaving observe a stale interval and swallow its EventId 5 while the
+        // original release still emits EventId 6.
+        public Lock Gate { get; } = new();
+        public int AvailablePermits;
+        public bool ExhaustionLogged;
     }
 
     /// <summary>
@@ -315,14 +324,21 @@ internal sealed partial class FusionCacheFactoryRunner
                 return;
             }
 
-            _bulkhead.Permits.Release();
-            FusionCacheFactoryTelemetry.ActiveExecutions.Add(-1, CacheTag(_policy));
-
-            // Close the exhausted interval (EventId 6) only if EventId 5 opened it.
-            if (Interlocked.CompareExchange(ref _bulkhead.ExhaustionLogged, 0, 1) == 1)
+            lock (_bulkhead.Gate)
             {
-                _runner.LogCapacityRestored(_policy.CacheName);
+                _bulkhead.AvailablePermits++;
+
+                // Close the exhausted interval (EventId 6) only if EventId 5 opened it, atomically with the
+                // permit release so the permit cannot be re-acquired and re-exhausted before the interval
+                // closes.
+                if (_bulkhead.ExhaustionLogged)
+                {
+                    _bulkhead.ExhaustionLogged = false;
+                    _runner.LogCapacityRestored(_policy.CacheName);
+                }
             }
+
+            FusionCacheFactoryTelemetry.ActiveExecutions.Add(-1, CacheTag(_policy));
         }
     }
 }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
@@ -166,7 +166,7 @@ internal sealed partial class FusionCacheFactoryRunner
             // deliberately stays state-based: once the caller is gone, all cancellation fallout is noise.)
             // Token-less cancellations that were in fact responses to our token fall through to the failure
             // log below, which errs toward attribution.
-            lease.LogFactoryDeadlineCancelled(policy.CancellationAfter, ex);
+            lease.ReportFactoryDeadlineCancelled(policy.CancellationAfter, ex);
             throw;
         }
         catch (FusionCacheFactoryRejectedException)
@@ -179,7 +179,7 @@ internal sealed partial class FusionCacheFactoryRunner
         {
             // Includes OperationCanceledException carrying neither the caller's nor this runner's token: such
             // cancellation is an unexpected factory failure and must stay attributable.
-            lease.LogFactoryFailed(ex);
+            lease.ReportFactoryFailed(ex);
             throw;
         }
         finally
@@ -336,11 +336,11 @@ internal sealed partial class FusionCacheFactoryRunner
             _bulkhead = bulkhead;
         }
 
-        public void LogFactoryFailed(Exception exception) =>
-            FusionCacheFactoryRunner.LogFactoryFailed(_runner._logger, _policy.CacheName, exception);
+        public void ReportFactoryFailed(Exception exception) =>
+            LogFactoryFailed(_runner._logger, _policy.CacheName, exception);
 
-        public void LogFactoryDeadlineCancelled(TimeSpan cancellationAfter, Exception exception) =>
-            FusionCacheFactoryRunner.LogFactoryDeadlineCancelled(_runner._logger, _policy.CacheName, cancellationAfter, exception);
+        public void ReportFactoryDeadlineCancelled(TimeSpan cancellationAfter, Exception exception) =>
+            LogFactoryDeadlineCancelled(_runner._logger, _policy.CacheName, cancellationAfter, exception);
 
         public void Dispose()
         {

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryRunner.cs
@@ -338,6 +338,9 @@ internal sealed partial class FusionCacheFactoryRunner
                 }
             }
 
+            // Deliberately outside the gate: measurement callbacks (MeterListener) run inline on Add and must
+            // not execute under the permit lock. The counter can transiently overshoot when a release and a
+            // re-acquire interleave; it is a running sum read at export resolution, so the skew self-corrects.
             FusionCacheFactoryTelemetry.ActiveExecutions.Add(-1, CacheTag(_policy));
         }
     }

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryTelemetry.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Common/Caching/FusionCacheFactoryTelemetry.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.Metrics;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
+
+/// <summary>
+/// Telemetry surface for <see cref="FusionCacheFactoryRunner"/>. Public so hosts can subscribe the meter
+/// (OpenTelemetry only exports meters that are explicitly added via AddMeter).
+/// </summary>
+public static class FusionCacheFactoryTelemetry
+{
+    public const string MeterName = "Digdir.Domain.Dialogporten.FusionCacheFactories";
+
+    internal const string CacheNameTag = "cache.name";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    // UpDownCounters rather than observable gauges: no observation callbacks that could retain runner
+    // instances or emit duplicate series when multiple runners exist (tests construct their own).
+    internal static readonly UpDownCounter<long> ActiveExecutions = Meter.CreateUpDownCounter<long>(
+        "dialogporten.fusioncache.factory_executions_active",
+        description: "Cache factory executions currently holding an execution permit, including abandoned ones.");
+
+    internal static readonly UpDownCounter<long> ActiveOrphans = Meter.CreateUpDownCounter<long>(
+        "dialogporten.fusioncache.factory_orphans_active",
+        description: "Cache factory executions abandoned by the runner that have not yet completed.");
+}

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -17,6 +17,7 @@ using Digdir.Domain.Dialogporten.Infrastructure.Altinn.NameRegistry;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.OrganizationRegistry;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.ResourceRegistry;
 using Digdir.Domain.Dialogporten.Infrastructure.Common;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Digdir.Domain.Dialogporten.Infrastructure.Common.Configurations.Dapper;
 using Digdir.Domain.Dialogporten.Infrastructure.GraphQL;
 using Digdir.Domain.Dialogporten.Infrastructure.HealthChecks;
@@ -158,6 +159,7 @@ public static class InfrastructureExtensions
 
             // Singleton
             .AddSingleton<INotificationProcessingContextFactory, NotificationProcessingContextFactory>()
+            .AddSingleton<FusionCacheFactoryRunner>()
 
             // HttpClient
             .AddHttpClients(infrastructureSettings)

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/InfrastructureExtensions.cs
@@ -240,9 +240,12 @@ public static class InfrastructureExtensions
             FactoryHardTimeout = TimeSpan.FromSeconds(25)
         })
         // Subject -> resource (role / access-package) mappings used by dialog-search authorization.
+        // The factory work ceiling lives in FusionCacheFactoryPolicy.SubjectResources; the same policy
+        // supplies this waiter-facing hard timeout so the two cannot drift apart.
         .ConfigureFusionCache(nameof(SubjectResource), new()
         {
-            Duration = TimeSpan.FromMinutes(20)
+            Duration = TimeSpan.FromMinutes(20),
+            FactoryHardTimeout = FusionCacheFactoryPolicy.SubjectResources.HardTimeout
         })
         // dialog id -> service-resource lookup for feature-metric tagging; short-lived, no fail-safe.
         .ConfigureFusionCache(nameof(IFeatureMetricServiceResourceCache), new()
@@ -275,8 +278,8 @@ public static class InfrastructureExtensions
             // Substantial headroom over the factory's DB work (30s Npgsql CommandTimeout, plus connection
             // acquisition and result mapping, which the command timeout does not cover). A tight budget
             // cancels slow-but-succeeding rebuilds, so refreshes never complete and fail-safe silently
-            // becomes the only data source.
-            FactoryHardTimeout = TimeSpan.FromSeconds(60),
+            // becomes the only data source. The factory's own work ceiling lives in the same policy.
+            FactoryHardTimeout = FusionCacheFactoryPolicy.PartyResourceReferencedResources.HardTimeout,
             SkipDistributedCache = true
         })
         // Subjects (roles/access packages) per referenced party-resource; used by the metadata item builder.
@@ -286,14 +289,17 @@ public static class InfrastructureExtensions
             Duration = TimeSpan.FromMinutes(20),
             // See ReferencedResourcesCacheName above for the rationale behind both values.
             FailSafeMaxDuration = TimeSpan.FromHours(24),
-            FactoryHardTimeout = TimeSpan.FromSeconds(60)
+            FactoryHardTimeout = FusionCacheFactoryPolicy.SubjectResourceReferencedPartyResources.HardTimeout
         })
         .ConfigureFusionCache(ResourcePolicyInformationRepository.MinimumAuthenticationLevelsCacheName, new()
         {
             Duration = TimeSpan.FromHours(6),
             // Min auth level is on the authorization hot path; keep stale-but-known data usable well past
             // Duration so the cache can still serve if ResourcePolicyInformation queries start failing.
-            FailSafeMaxDuration = TimeSpan.FromHours(24)
+            FailSafeMaxDuration = TimeSpan.FromHours(24),
+            // The factory work ceiling lives in FusionCacheFactoryPolicy.MinimumAuthenticationLevels; the
+            // same policy supplies this waiter-facing hard timeout so the two cannot drift apart.
+            FactoryHardTimeout = FusionCacheFactoryPolicy.MinimumAuthenticationLevels.HardTimeout
         })
         .ConfigureFusionCache(AccessManagementMetadataClient.CacheName, new()
         {
@@ -327,8 +333,8 @@ public static class InfrastructureExtensions
             // cached lookups, each DB-bound step capped by the 30s CommandTimeout); sized operationally, not a
             // guaranteed worst-case bound. Rebuilds that cannot finish within this budget never succeed, and
             // fail-safe silently becomes the only data source. On a cold miss this hard timeout is the
-            // caller-facing wait ceiling.
-            FactoryHardTimeout = TimeSpan.FromSeconds(120),
+            // caller-facing wait ceiling. The factory's own work ceiling lives in the same policy.
+            FactoryHardTimeout = FusionCacheFactoryPolicy.ServiceResourceMetadataCatalogue.HardTimeout,
             SkipDistributedCache = true
         })
         .ConfigureFusionCache(AuthorizedServiceResourcesProvider.CacheName, new()
@@ -350,8 +356,8 @@ public static class InfrastructureExtensions
             // Must be >= the hard timeouts of the caches this factory transitively awaits (AuthorizedPartiesResult
             // and Altinn.Authorization, both 25s). A smaller value would make this outer factory time out (and, on
             // a cold entry with no fail-safe data, throw) while the inner authorization call is still legitimately
-            // running within its own larger budget.
-            FactoryHardTimeout = TimeSpan.FromSeconds(25),
+            // running within its own larger budget. The factory's own work ceiling lives in the same policy.
+            FactoryHardTimeout = FusionCacheFactoryPolicy.AuthorizedServiceResources.HardTimeout,
             Duration = TimeSpan.FromMinutes(15),
             FailSafeMaxDuration = TimeSpan.FromMinutes(30)
         });

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/PartyResourceRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/PartyResourceRepository.cs
@@ -6,6 +6,7 @@ using Dapper;
 using Digdir.Domain.Dialogporten.Application;
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Microsoft.Extensions.Options;
 using Npgsql;
 using ZiggyCreatures.Caching.Fusion;
@@ -36,15 +37,18 @@ internal sealed class PartyResourceRepository : IPartyResourceReferenceRepositor
     private readonly IOptionsSnapshot<ApplicationSettings> _applicationSettings;
     private readonly IFusionCache _cache;
     private readonly IFusionCache _referencedResourcesCache;
+    private readonly FusionCacheFactoryRunner _factoryRunner;
 
     public PartyResourceRepository(
         NpgsqlDataSource dataSource,
         IOptionsSnapshot<ApplicationSettings> applicationSettings,
-        IFusionCacheProvider cacheProvider)
+        IFusionCacheProvider cacheProvider,
+        FusionCacheFactoryRunner factoryRunner)
     {
         ArgumentNullException.ThrowIfNull(dataSource);
         ArgumentNullException.ThrowIfNull(applicationSettings);
         ArgumentNullException.ThrowIfNull(cacheProvider);
+        ArgumentNullException.ThrowIfNull(factoryRunner);
 
         var cache = cacheProvider.GetCache(nameof(IPartyResourceReferenceRepository));
         ArgumentNullException.ThrowIfNull(cache);
@@ -55,12 +59,18 @@ internal sealed class PartyResourceRepository : IPartyResourceReferenceRepositor
         _applicationSettings = applicationSettings;
         _cache = cache;
         _referencedResourcesCache = referencedResourcesCache;
+        _factoryRunner = factoryRunner;
     }
 
     public async Task<IReadOnlyCollection<string>> GetReferencedResources(CancellationToken cancellationToken) =>
         await _referencedResourcesCache.GetOrSetAsync<List<string>>(
             ReferencedResourcesCacheKey,
-            FetchReferencedResources,
+            // Run (not RunInScope): the factory only touches the singleton NpgsqlDataSource, so it needs the
+            // deadline and permit but no dedicated DI scope.
+            token => _factoryRunner.Run(
+                FusionCacheFactoryPolicy.PartyResourceReferencedResources,
+                FetchReferencedResources,
+                token),
             token: cancellationToken);
 
     private async Task<List<string>> FetchReferencedResources(CancellationToken cancellationToken)

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/ResourcePolicyInformationRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/ResourcePolicyInformationRepository.cs
@@ -1,6 +1,8 @@
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Domain.ResourcePolicyInformation;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -14,29 +16,40 @@ internal sealed class ResourcePolicyInformationRepository : IResourcePolicyInfor
 
     private readonly DialogDbContext _dbContext;
     private readonly IFusionCache _minimumAuthenticationLevelsCache;
+    private readonly FusionCacheFactoryRunner _factoryRunner;
 
     public ResourcePolicyInformationRepository(
         DialogDbContext dbContext,
-        IFusionCacheProvider cacheProvider)
+        IFusionCacheProvider cacheProvider,
+        FusionCacheFactoryRunner factoryRunner)
     {
         ArgumentNullException.ThrowIfNull(dbContext);
         ArgumentNullException.ThrowIfNull(cacheProvider);
+        ArgumentNullException.ThrowIfNull(factoryRunner);
 
         var minimumAuthenticationLevelsCache = cacheProvider.GetCache(MinimumAuthenticationLevelsCacheName);
         ArgumentNullException.ThrowIfNull(minimumAuthenticationLevelsCache);
 
         _dbContext = dbContext;
         _minimumAuthenticationLevelsCache = minimumAuthenticationLevelsCache;
+        _factoryRunner = factoryRunner;
     }
 
     public async Task<IReadOnlyDictionary<string, int>> GetMinimumAuthenticationLevels(CancellationToken cancellationToken) =>
         await _minimumAuthenticationLevelsCache.GetOrSetAsync<Dictionary<string, int>>(
             MinimumAuthenticationLevelsCacheKey,
-            FetchMinimumAuthenticationLevels,
+            token => _factoryRunner.RunInScope(
+                FusionCacheFactoryPolicy.MinimumAuthenticationLevels,
+                FetchMinimumAuthenticationLevels,
+                token),
             token: cancellationToken);
 
-    private async Task<Dictionary<string, int>> FetchMinimumAuthenticationLevels(CancellationToken cancellationToken) =>
-        await _dbContext.ResourcePolicyInformation
+    // Static and resolving its own DbContext: the factory can run detached from the request (see
+    // FusionCacheFactoryRunner), so it must not capture this instance's request-scoped context.
+    private static async Task<Dictionary<string, int>> FetchMinimumAuthenticationLevels(
+        IServiceProvider services,
+        CancellationToken cancellationToken) =>
+        await services.GetRequiredService<DialogDbContext>().ResourcePolicyInformation
             .AsNoTracking()
             .Select(x => new { x.Resource, x.MinimumAuthenticationLevel })
             .ToDictionaryAsync(

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/SubjectResourceRepository.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/Persistence/Repositories/SubjectResourceRepository.cs
@@ -1,6 +1,8 @@
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Domain.SubjectResources;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -14,19 +16,23 @@ internal sealed class SubjectResourceRepository : ISubjectResourceRepository
 
     private readonly DialogDbContext _dbContext;
     private readonly IFusionCache _referencedPartyResourcesCache;
+    private readonly FusionCacheFactoryRunner _factoryRunner;
 
     public SubjectResourceRepository(
         DialogDbContext dbContext,
-        IFusionCacheProvider cacheProvider)
+        IFusionCacheProvider cacheProvider,
+        FusionCacheFactoryRunner factoryRunner)
     {
         ArgumentNullException.ThrowIfNull(dbContext);
         ArgumentNullException.ThrowIfNull(cacheProvider);
+        ArgumentNullException.ThrowIfNull(factoryRunner);
 
         var referencedPartyResourcesCache = cacheProvider.GetCache(ReferencedPartyResourcesCacheName);
         ArgumentNullException.ThrowIfNull(referencedPartyResourcesCache);
 
         _dbContext = dbContext;
         _referencedPartyResourcesCache = referencedPartyResourcesCache;
+        _factoryRunner = factoryRunner;
     }
 
     public async Task<Dictionary<string, List<string>>> GetSubjectsByResource(
@@ -58,11 +64,17 @@ internal sealed class SubjectResourceRepository : ISubjectResourceRepository
         // Callers receive a read-only view, so the cached instance is protected from mutation.
         return await _referencedPartyResourcesCache.GetOrSetAsync<Dictionary<string, IReadOnlyList<string>>>(
             ReferencedPartyResourcesCacheKey,
-            FetchSubjectsForReferencedPartyResources,
+            token => _factoryRunner.RunInScope(
+                FusionCacheFactoryPolicy.SubjectResourceReferencedPartyResources,
+                FetchSubjectsForReferencedPartyResources,
+                token),
             token: cancellationToken);
     }
 
-    private async Task<Dictionary<string, IReadOnlyList<string>>> FetchSubjectsForReferencedPartyResources(
+    // Static and resolving its own DbContext: the factory can run detached from the request (see
+    // FusionCacheFactoryRunner), so it must not capture this instance's request-scoped context.
+    private static async Task<Dictionary<string, IReadOnlyList<string>>> FetchSubjectsForReferencedPartyResources(
+        IServiceProvider services,
         CancellationToken cancellationToken)
     {
         const string sql =
@@ -73,7 +85,7 @@ internal sealed class SubjectResourceRepository : ISubjectResourceRepository
               ON sr."Resource" = 'urn:altinn:resource:' || r."UnprefixedResourceIdentifier"
             """;
 
-        return (await _dbContext.Database
+        return (await services.GetRequiredService<DialogDbContext>().Database
                 .SqlQueryRaw<SubjectResourceRow>(sql)
                 .ToListAsync(cancellationToken))
             .GroupBy(x => x.Resource, StringComparer.OrdinalIgnoreCase)

--- a/src/Digdir.Domain.Dialogporten.Infrastructure/ServiceResourceMetadata/ServiceResourceMetadataCatalogue.cs
+++ b/src/Digdir.Domain.Dialogporten.Infrastructure/ServiceResourceMetadata/ServiceResourceMetadataCatalogue.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.ServiceResourceMetadata;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Microsoft.Extensions.DependencyInjection;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -17,38 +18,40 @@ internal sealed class ServiceResourceMetadataCatalogue : IServiceResourceMetadat
     private const string CacheKey = "all";
 
     private readonly IFusionCache _cache;
-    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly FusionCacheFactoryRunner _factoryRunner;
 
     public ServiceResourceMetadataCatalogue(
         IFusionCacheProvider cacheProvider,
-        IServiceScopeFactory scopeFactory)
+        FusionCacheFactoryRunner factoryRunner)
     {
         ArgumentNullException.ThrowIfNull(cacheProvider);
-        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(factoryRunner);
 
         var cache = cacheProvider.GetCache(CacheName);
         ArgumentNullException.ThrowIfNull(cache);
 
         _cache = cache;
-        _scopeFactory = scopeFactory;
+        _factoryRunner = factoryRunner;
     }
 
     public async Task<IReadOnlyList<ServiceResourceMetadataCatalogueEntry>> GetEntries(CancellationToken cancellationToken) =>
         await _cache.GetOrSetAsync<IReadOnlyList<ServiceResourceMetadataCatalogueEntry>>(
             CacheKey,
-            BuildCatalogue,
+            token => _factoryRunner.RunInScope(
+                FusionCacheFactoryPolicy.ServiceResourceMetadataCatalogue,
+                BuildCatalogue,
+                token),
             token: cancellationToken);
 
-    private async Task<IReadOnlyList<ServiceResourceMetadataCatalogueEntry>> BuildCatalogue(CancellationToken cancellationToken)
+    // Runs in the runner's dedicated scope: this cache uses eager refresh, so the build can outlive the
+    // request that triggered it (see FusionCacheFactoryRunner). The inner caches this build resolves create
+    // their own scopes too, so a nested refresh that detaches from THIS build's scope is safe by construction.
+    private static async Task<IReadOnlyList<ServiceResourceMetadataCatalogueEntry>> BuildCatalogue(
+        IServiceProvider services,
+        CancellationToken cancellationToken)
     {
-        // Build in a fresh DI scope rather than via injected (request-scoped) dependencies. This cache uses
-        // eager refresh, so the factory can run on a background task that outlives the request that triggered
-        // it; the item builder transitively resolves the request-scoped DialogDbContext (via
-        // SubjectResourceRepository), which would already be disposed by then -> ObjectDisposedException. A
-        // dedicated scope gives the (possibly background) build its own DbContext for its full lifetime.
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var itemBuilder = scope.ServiceProvider.GetRequiredService<IServiceResourceMetadataItemBuilder>();
-        var partyResourceReferenceRepository = scope.ServiceProvider.GetRequiredService<IPartyResourceReferenceRepository>();
+        var itemBuilder = services.GetRequiredService<IServiceResourceMetadataItemBuilder>();
+        var partyResourceReferenceRepository = services.GetRequiredService<IPartyResourceReferenceRepository>();
 
         var referencedResources = await partyResourceReferenceRepository.GetReferencedResources(cancellationToken);
 

--- a/src/Digdir.Domain.Dialogporten.Janitor/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.Janitor/Program.cs
@@ -7,6 +7,7 @@ using Digdir.Domain.Dialogporten.Application;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Infrastructure;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Digdir.Domain.Dialogporten.Janitor;
 using Digdir.Domain.Dialogporten.Janitor.CostManagementAggregation;
 using Digdir.Domain.Dialogporten.Janitor.CustomMetrics;
@@ -67,7 +68,9 @@ static void BuildAndRun(string[] args)
     builder.Services
         .AddDialogportenTelemetry(builder.Configuration, builder.Environment,
             additionalTracing: x => x.AddFusionCacheInstrumentation(),
-            additionalMetrics: x => x.AddMeter(CustomMetrics.MeterName),
+            additionalMetrics: x => x
+                .AddMeter(CustomMetrics.MeterName)
+                .AddMeter(FusionCacheFactoryTelemetry.MeterName),
             httpUrlTemplates: DependencyTelemetryUrlTemplates.Defaults)
         .AddApplication(builder.Configuration, builder.Environment)
         .AddInfrastructure(builder.Configuration, builder.Environment)

--- a/src/Digdir.Domain.Dialogporten.Service/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.Service/Program.cs
@@ -3,6 +3,7 @@ using Digdir.Domain.Dialogporten.Application;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Infrastructure;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Digdir.Domain.Dialogporten.Service;
 using Digdir.Domain.Dialogporten.Service.Common;
 using Digdir.Library.Utils.AspNet;
@@ -65,7 +66,8 @@ static void BuildAndRun(string[] args)
         .AddDialogportenTelemetry(builder.Configuration, builder.Environment,
             additionalMetrics: x => x
                 .AddAspNetCoreInstrumentation()
-                .AddNpgsqlInstrumentation(),
+                .AddNpgsqlInstrumentation()
+                .AddMeter(FusionCacheFactoryTelemetry.MeterName),
             additionalTracing: x =>
             {
                 x.AddAspNetCoreInstrumentationExcludingHealthPaths();

--- a/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
+++ b/src/Digdir.Domain.Dialogporten.WebApi/Program.cs
@@ -6,6 +6,7 @@ using Digdir.Domain.Dialogporten.Application.Common.Extensions;
 using Digdir.Domain.Dialogporten.Application.Common.Extensions.OptionExtensions;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Infrastructure;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Digdir.Domain.Dialogporten.WebApi;
 using Digdir.Domain.Dialogporten.WebApi.Common;
 using Digdir.Domain.Dialogporten.WebApi.Common.Authentication;
@@ -92,7 +93,8 @@ static void BuildAndRun(string[] args)
         .AddDialogportenTelemetry(builder.Configuration, builder.Environment,
             additionalMetrics: x => x
                 .AddAspNetCoreInstrumentation()
-                .AddNpgsqlInstrumentation(),
+                .AddNpgsqlInstrumentation()
+                .AddMeter(FusionCacheFactoryTelemetry.MeterName),
             additionalTracing: x => x
                 .AddFusionCacheInstrumentation()
                 .AddAspNetCoreInstrumentationExcludingHealthPaths(),

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/DialogApplication.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Common/DialogApplication.cs
@@ -14,6 +14,7 @@ using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Infrastructure;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.ServiceResourceMetadata;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.Authorization;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Digdir.Domain.Dialogporten.Infrastructure.ServiceResourceMetadata;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.ResourceRegistry;
 using Digdir.Domain.Dialogporten.Infrastructure.Common.Configurations.Dapper;
@@ -151,6 +152,7 @@ public class DialogApplication : IAsyncLifetime
             .AddScoped<IOptionsSnapshot<ApplicationSettings>>(x => x.GetRequiredService<TestApplicationSettings>())
             .AddScoped<IOptions<ApplicationSettings>>(x => x.GetRequiredService<TestApplicationSettings>())
             .AddSingleton<IFusionCacheProvider>(_ => CreateNullFusionCacheProvider())
+            .AddSingleton<FusionCacheFactoryRunner>()
             .AddScoped<ITopicEventSender>(_ => Substitute.For<ITopicEventSender>())
             .AddScoped<IPublishEndpoint>(_ => publishEndpointSubstitute)
             .AddScoped<Lazy<ITopicEventSender>>(sp => new Lazy<ITopicEventSender>(() => sp.GetRequiredService<ITopicEventSender>()))

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Authorization/AltinnAuthorizationClientTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Authorization/AltinnAuthorizationClientTests.cs
@@ -264,6 +264,8 @@ public class AltinnAuthorizationClientTests(DialogApplication application) : App
     }
 
     // The runner's dedicated scope must resolve the same DbContext instance the test seeded, when one exists.
+    // Consequence: unlike production, every scope here yields the same context, so these tests exercise the
+    // call-site wiring but NOT scope isolation; that property is pinned by FusionCacheFactoryRunnerTests.
     private static FusionCacheFactoryRunner CreateFactoryRunner(DialogDbContext? db = null)
     {
         var services = new ServiceCollection();

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Authorization/AltinnAuthorizationClientTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/Common/Authorization/AltinnAuthorizationClientTests.cs
@@ -9,6 +9,7 @@ using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
 using Digdir.Domain.Dialogporten.Domain.Parties;
 using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.Authorization;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Digdir.Domain.Dialogporten.Infrastructure.Persistence.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -220,10 +221,10 @@ public class AltinnAuthorizationClientTests(DialogApplication application) : App
             user,
             db,
             new ServiceResourceMinimumAuthenticationLevelResolver(
-                new ResourcePolicyInformationRepository(db, cacheProvider)),
+                new ResourcePolicyInformationRepository(db, cacheProvider, CreateFactoryRunner(db))),
             Substitute.For<IPartyResourceReferenceRepository>(),
             Substitute.For<ILogger<AltinnAuthorizationClient>>(),
-            Substitute.For<IServiceScopeFactory>(),
+            CreateFactoryRunner(db),
             Substitute.For<IOptionsMonitor<ApplicationSettings>>(),
             Substitute.For<IPartyNameRegistry>()
         );
@@ -256,10 +257,25 @@ public class AltinnAuthorizationClientTests(DialogApplication application) : App
             Substitute.For<IServiceResourceMinimumAuthenticationLevelResolver>(),
             Substitute.For<IPartyResourceReferenceRepository>(),
             Substitute.For<ILogger<AltinnAuthorizationClient>>(),
-            Substitute.For<IServiceScopeFactory>(),
+            CreateFactoryRunner(),
             applicationSettings,
             Substitute.For<IPartyNameRegistry>()
         );
+    }
+
+    // The runner's dedicated scope must resolve the same DbContext instance the test seeded, when one exists.
+    private static FusionCacheFactoryRunner CreateFactoryRunner(DialogDbContext? db = null)
+    {
+        var services = new ServiceCollection();
+        if (db is not null)
+        {
+            services.AddSingleton(db);
+        }
+
+        var serviceProvider = services.BuildServiceProvider();
+        return new FusionCacheFactoryRunner(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            Substitute.For<ILogger<FusionCacheFactoryRunner>>());
     }
 
     // A non-empty response is required for email users without party filters; an empty

--- a/tests/Digdir.Domain.Dialogporten.Architecture.Tests/InfrastructureArchitectureTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Architecture.Tests/InfrastructureArchitectureTests.cs
@@ -18,8 +18,6 @@ public class InfrastructureArchitectureTests
             nameof(InfrastructureExtensions),
             // Hosts must reference the meter name to subscribe it in their OpenTelemetry setup.
             nameof(FusionCacheFactoryTelemetry),
-            // Escapes through cache calls to any caller when a factory is rejected at its concurrency bound.
-            nameof(FusionCacheFactoryRejectedException),
 
             // These classes are currently public but should be internal, moved to another assembly, or deleted
             nameof(IUpstreamServiceError)

--- a/tests/Digdir.Domain.Dialogporten.Architecture.Tests/InfrastructureArchitectureTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Architecture.Tests/InfrastructureArchitectureTests.cs
@@ -1,4 +1,5 @@
 using Digdir.Domain.Dialogporten.Infrastructure;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Digdir.Domain.Dialogporten.Infrastructure.Common.Exceptions;
 using AwesomeAssertions;
 using FluentValidation;
@@ -15,6 +16,10 @@ public class InfrastructureArchitectureTests
         {
             nameof(InfrastructureAssemblyMarker),
             nameof(InfrastructureExtensions),
+            // Hosts must reference the meter name to subscribe it in their OpenTelemetry setup.
+            nameof(FusionCacheFactoryTelemetry),
+            // Escapes through cache calls to any caller when a factory is rejected at its concurrency bound.
+            nameof(FusionCacheFactoryRejectedException),
 
             // These classes are currently public but should be internal, moved to another assembly, or deleted
             nameof(IUpstreamServiceError)

--- a/tests/Digdir.Domain.Dialogporten.Architecture.Tests/InfrastructureArchitectureTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Architecture.Tests/InfrastructureArchitectureTests.cs
@@ -18,6 +18,9 @@ public class InfrastructureArchitectureTests
             nameof(InfrastructureExtensions),
             // Hosts must reference the meter name to subscribe it in their OpenTelemetry setup.
             nameof(FusionCacheFactoryTelemetry),
+            // Escapes assembly boundaries via cache calls on cold-miss rejections; public so callers can
+            // catch it by type (Sonar S3871).
+            nameof(FusionCacheFactoryRejectedException),
 
             // These classes are currently public but should be internal, moved to another assembly, or deleted
             nameof(IUpstreamServiceError)

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/AuthorizedServiceResourcesProviderTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/AuthorizedServiceResourcesProviderTests.cs
@@ -9,6 +9,9 @@ using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Parties.Abstractions;
 using Digdir.Domain.Dialogporten.Infrastructure.Altinn.Authorization;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -31,7 +34,7 @@ public class AuthorizedServiceResourcesProviderTests
         {
             ResourcesByParties = new Dictionary<string, IReadOnlySet<string>> { [PartyA] = new HashSet<string> { ReferencedResource } }
         });
-        var provider = new AuthorizedServiceResourcesProvider(
+        var provider = CreateProvider(
             authorization, CreateUserWithPid(Pid), CreateUserParties(partyCount: 1), CreateSettings(), CreateCacheProvider());
 
         var result = await provider.GetAuthorizedServiceResources(partyFilter: null, TestContext.Current.CancellationToken);
@@ -47,7 +50,7 @@ public class AuthorizedServiceResourcesProviderTests
     public async Task Returns_Full_Catalogue_Signal_When_Party_Count_Exceeds_Limit_On_Unfiltered_Request()
     {
         var authorization = new CountingAltinnAuthorization(new DialogSearchAuthorizationResult());
-        var provider = new AuthorizedServiceResourcesProvider(
+        var provider = CreateProvider(
             authorization, CreateUserWithPid(Pid), CreateUserParties(partyCount: 3),
             CreateSettings(maxAuthorizedParties: 2), CreateCacheProvider());
 
@@ -67,7 +70,7 @@ public class AuthorizedServiceResourcesProviderTests
         {
             ResourcesByParties = new Dictionary<string, IReadOnlySet<string>> { [PartyA] = new HashSet<string> { ReferencedResource } }
         });
-        var provider = new AuthorizedServiceResourcesProvider(
+        var provider = CreateProvider(
             authorization, CreateUserWithPid(Pid), CreateUserParties(partyCount: 1), CreateSettings(), CreateCacheProvider());
 
         var result = await provider.GetAuthorizedServiceResources([PartyA], TestContext.Current.CancellationToken);
@@ -86,7 +89,7 @@ public class AuthorizedServiceResourcesProviderTests
         {
             ResourcesByParties = new Dictionary<string, IReadOnlySet<string>> { [PartyA] = new HashSet<string> { ReferencedResource } }
         });
-        var provider = new AuthorizedServiceResourcesProvider(
+        var provider = CreateProvider(
             authorization, CreateUserWithPid(Pid), CreateUserParties(partyCount: 1), CreateSettings(), CreateCacheProvider());
 
         await provider.GetAuthorizedServiceResources(partyFilter: null, TestContext.Current.CancellationToken);
@@ -108,7 +111,7 @@ public class AuthorizedServiceResourcesProviderTests
         {
             ResourcesByParties = new Dictionary<string, IReadOnlySet<string>> { [PartyA] = new HashSet<string> { ReferencedResource } }
         });
-        var provider = new AuthorizedServiceResourcesProvider(
+        var provider = CreateProvider(
             authorization, new StubUser(principal), CreateUserParties(partyCount: 1), CreateSettings(), CreateCacheProvider());
 
         await provider.GetAuthorizedServiceResources(partyFilter: null, TestContext.Current.CancellationToken);
@@ -130,7 +133,7 @@ public class AuthorizedServiceResourcesProviderTests
 
         AuthorizedServiceResourcesProvider ProviderFor(string pid)
         {
-            return new AuthorizedServiceResourcesProvider(
+            return CreateProvider(
                 authorization, CreateUserWithPid(pid), CreateUserParties(partyCount: 1), CreateSettings(), cacheProvider);
         }
 
@@ -155,7 +158,7 @@ public class AuthorizedServiceResourcesProviderTests
     public async Task Throws_For_Principal_Without_End_User_Party_Identifier()
     {
         var authorization = new CountingAltinnAuthorization(new DialogSearchAuthorizationResult());
-        var provider = new AuthorizedServiceResourcesProvider(
+        var provider = CreateProvider(
             authorization,
             new StubUser(new ClaimsPrincipal(new ClaimsIdentity())),
             CreateUserParties(partyCount: 0),
@@ -167,6 +170,73 @@ public class AuthorizedServiceResourcesProviderTests
         await act.Should().ThrowAsync<UnreachableException>();
         // The throw happens before any cache access or upstream call.
         authorization.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Concurrent_Factories_Each_Observe_Their_Own_Caller_Principal()
+    {
+        // Two callers' factories run concurrently through the SAME runner. Each must observe its own
+        // ambient principal: AsyncLocal flows per call path and must not leak between detached factories.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var principalA = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimsPrincipalExtensions.PidClaim, Pid)]));
+        var principalB = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimsPrincipalExtensions.PidClaim, OtherPid)]));
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var authorization = new BlockingAmbientRecordingAuthorization(gate, expectedCalls: 2, new DialogSearchAuthorizationResult
+        {
+            ResourcesByParties = new Dictionary<string, IReadOnlySet<string>> { [PartyA] = new HashSet<string> { ReferencedResource } }
+        });
+
+        var services = new ServiceCollection()
+            .AddSingleton<IAltinnAuthorization>(authorization)
+            .AddSingleton<IUserParties>(CreateUserParties(partyCount: 1))
+            .AddSingleton<IOptionsSnapshot<ApplicationSettings>>(CreateSettings())
+            .BuildServiceProvider();
+        var runner = new FusionCacheFactoryRunner(
+            services.GetRequiredService<IServiceScopeFactory>(),
+            new CollectingLogger<FusionCacheFactoryRunner>());
+        var cacheProvider = CreateCacheProvider();
+        var providerA = new AuthorizedServiceResourcesProvider(new StubUser(principalA), cacheProvider, runner);
+        var providerB = new AuthorizedServiceResourcesProvider(new StubUser(principalB), cacheProvider, runner);
+
+        try
+        {
+            var taskA = providerA.GetAuthorizedServiceResources(partyFilter: null, cancellationToken);
+            var taskB = providerB.GetAuthorizedServiceResources(partyFilter: null, cancellationToken);
+
+            // Both factories are in-flight simultaneously before either is released.
+            await authorization.AllCallsEntered.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            gate.TrySetResult();
+
+            await taskA.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            await taskB.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        }
+        finally
+        {
+            gate.TrySetResult();
+        }
+
+        // Exactly the two distinct principals were observed; a leak would make both factories see the same one.
+        authorization.ObservedPrincipals.Should().BeEquivalentTo([principalA, principalB]);
+    }
+
+    private static AuthorizedServiceResourcesProvider CreateProvider(
+        IAltinnAuthorization authorization,
+        IUser user,
+        IUserParties userParties,
+        IOptionsSnapshot<ApplicationSettings> applicationSettings,
+        IFusionCacheProvider cacheProvider)
+    {
+        // The provider's factory resolves its dependencies from the runner's dedicated scope, so the stubs
+        // live in a real service collection rather than in the provider's constructor.
+        var services = new ServiceCollection()
+            .AddSingleton(authorization)
+            .AddSingleton(userParties)
+            .AddSingleton(applicationSettings)
+            .BuildServiceProvider();
+        var runner = new FusionCacheFactoryRunner(
+            services.GetRequiredService<IServiceScopeFactory>(),
+            new CollectingLogger<FusionCacheFactoryRunner>());
+        return new AuthorizedServiceResourcesProvider(user, cacheProvider, runner);
     }
 
     private static IFusionCacheProvider CreateCacheProvider() =>
@@ -217,6 +287,53 @@ public class AuthorizedServiceResourcesProviderTests
                     AuthorizedInstances = []
                 }).ToList()
             });
+    }
+
+    private sealed class BlockingAmbientRecordingAuthorization(
+        TaskCompletionSource gate,
+        int expectedCalls,
+        DialogSearchAuthorizationResult result) : IAltinnAuthorization
+    {
+        private readonly System.Collections.Concurrent.ConcurrentBag<ClaimsPrincipal?> _observedPrincipals = [];
+        private readonly TaskCompletionSource _allCallsEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _entered;
+
+        public IReadOnlyCollection<ClaimsPrincipal?> ObservedPrincipals => _observedPrincipals;
+        public Task AllCallsEntered => _allCallsEntered.Task;
+
+        public async Task<DialogSearchAuthorizationResult> GetAuthorizedResourcesForSearch(
+            List<string> constraintParties,
+            List<string> constraintServiceResources,
+            bool includeDialogIds = true,
+            int? minResourcesPruningThreshold = null,
+            CancellationToken cancellationToken = default)
+        {
+            _observedPrincipals.Add(AmbientUserPrincipal.Current);
+            if (Interlocked.Increment(ref _entered) == expectedCalls)
+            {
+                _allCallsEntered.TrySetResult();
+            }
+
+            await gate.Task.WaitAsync(cancellationToken);
+            return result;
+        }
+
+        public Task<DialogDetailsAuthorizationResult> GetDialogDetailsAuthorization(
+            DialogEntity dialogEntity, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<AuthorizedPartiesResult> GetAuthorizedParties(
+            IPartyIdentifier authenticatedParty, bool flatten = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<AuthorizedPartiesResult> GetAuthorizedPartiesForLookup(
+            IPartyIdentifier authenticatedParty, List<string> constraintParties, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<bool> HasListAuthorizationForDialog(
+            DialogEntity dialog, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        public bool UserHasRequiredAuthLevel(int minimumAuthenticationLevel) => throw new NotSupportedException();
+
+        public Task<bool> UserHasRequiredAuthLevel(
+            string serviceResource, CancellationToken cancellationToken) => throw new NotSupportedException();
     }
 
     private sealed class CountingAltinnAuthorization(DialogSearchAuthorizationResult result) : IAltinnAuthorization

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/AuthorizedServiceResourcesProviderTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/AuthorizedServiceResourcesProviderTests.cs
@@ -219,6 +219,45 @@ public class AuthorizedServiceResourcesProviderTests
         authorization.ObservedPrincipals.Should().BeEquivalentTo([principalA, principalB]);
     }
 
+    [Fact]
+    public async Task Establishes_The_Ambient_Principal_Before_Resolving_Scoped_Services()
+    {
+        // Pins the ordering inside the factory delegate: the ambient principal must be established BEFORE
+        // scoped services are resolved from the runner's scope. No current service captures the principal
+        // at construction, so this guards against a future one that does; on this path the blast radius of
+        // an ordering regression is cross-user authorization data.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimsPrincipalExtensions.PidClaim, Pid)]));
+        var authorization = new CountingAltinnAuthorization(new DialogSearchAuthorizationResult
+        {
+            ResourcesByParties = new Dictionary<string, IReadOnlySet<string>> { [PartyA] = new HashSet<string> { ReferencedResource } }
+        });
+
+        ClaimsPrincipal? principalAtResolution = null;
+        var resolutions = 0;
+        var services = new ServiceCollection()
+            .AddScoped<IAltinnAuthorization>(_ =>
+            {
+                // Simulates a service that reads the ambient principal at construction time.
+                principalAtResolution = AmbientUserPrincipal.Current;
+                resolutions++;
+                return authorization;
+            })
+            .AddSingleton<IUserParties>(CreateUserParties(partyCount: 1))
+            .AddSingleton<IOptionsSnapshot<ApplicationSettings>>(CreateSettings())
+            .BuildServiceProvider();
+        var runner = new FusionCacheFactoryRunner(
+            services.GetRequiredService<IServiceScopeFactory>(),
+            new CollectingLogger<FusionCacheFactoryRunner>());
+        var provider = new AuthorizedServiceResourcesProvider(new StubUser(principal), CreateCacheProvider(), runner);
+
+        await provider.GetAuthorizedServiceResources(partyFilter: null, cancellationToken);
+
+        resolutions.Should().Be(1);
+        principalAtResolution.Should().BeSameAs(principal,
+            "the factory must establish the ambient principal before resolving scoped services");
+    }
+
     private static AuthorizedServiceResourcesProvider CreateProvider(
         IAltinnAuthorization authorization,
         IUser user,

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/FusionCacheFactoryRunnerTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/FusionCacheFactoryRunnerTests.cs
@@ -562,7 +562,6 @@ public class FusionCacheFactoryRunnerTests
     private sealed class ScopedDependency : IDisposable
     {
         public bool Disposed { get; private set; }
-        public bool DisposedDuringUse => Disposed;
         public void Dispose() => Disposed = true;
     }
 

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/FusionCacheFactoryRunnerTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/FusionCacheFactoryRunnerTests.cs
@@ -1,0 +1,551 @@
+using System.Diagnostics.Metrics;
+using AwesomeAssertions;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests;
+
+// Verifies the three guarantees FusionCacheFactoryRunner exists to provide: a factory owns its dependencies
+// via a dedicated DI scope (so detached executions never observe a disposed request scope), a factory has a
+// wall-clock ceiling (cooperative cancellation, then hard abandonment that lets FusionCache release its
+// per-key lock), and executions are bounded per cache (abandoned work cannot exhaust shared resources).
+//
+// Timing style: TaskCompletionSource gates + WaitUntil polling with generous deadlock-guard timeouts; no
+// elapsed-time assertions (timing bounds flake on loaded CI runners).
+public class FusionCacheFactoryRunnerTests
+{
+    private static readonly TimeSpan GuardTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task RunInScope_Gives_The_Factory_Its_Own_Scope_That_Survives_Caller_Scope_Disposal()
+    {
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        var policy = RunnerFixture.CreatePolicy();
+
+        ScopedDependency callerInstance;
+        using (var callerScope = fixture.Services.CreateScope())
+        {
+            callerInstance = callerScope.ServiceProvider.GetRequiredService<ScopedDependency>();
+        }
+
+        callerInstance.Disposed.Should().BeTrue();
+
+        var (factoryInstance, disposedWhileFactoryRan) = await fixture.Runner.RunInScope(
+            policy,
+            (services, _) =>
+            {
+                var instance = services.GetRequiredService<ScopedDependency>();
+                return Task.FromResult((instance, instance.Disposed));
+            },
+            testToken);
+
+        factoryInstance.Should().NotBeSameAs(callerInstance);
+        disposedWhileFactoryRan.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RunInScope_Disposes_The_Factory_Scope_After_Completion_And_After_A_Throwing_Run()
+    {
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        var policy = RunnerFixture.CreatePolicy();
+
+        var completedInstance = await fixture.Runner.RunInScope(
+            policy,
+            (services, _) => Task.FromResult(services.GetRequiredService<ScopedDependency>()),
+            testToken);
+        completedInstance.Disposed.Should().BeTrue();
+
+        ScopedDependency? throwingInstance = null;
+        var act = async () => await fixture.Runner.RunInScope<int>(
+            policy,
+            (services, _) =>
+            {
+                throwingInstance = services.GetRequiredService<ScopedDependency>();
+                throw new InvalidOperationException("factory failed");
+            },
+            testToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        throwingInstance.Should().NotBeNull();
+        throwingInstance.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Cooperative_Deadline_Cancels_A_Token_Honoring_Factory()
+    {
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        var policy = RunnerFixture.CreatePolicy(cancellationAfter: TimeSpan.FromMilliseconds(50), abandonAfter: TimeSpan.FromSeconds(8));
+        var neverReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var act = async () => await fixture.Runner.RunInScope<int>(
+            policy,
+            async (_, ct) =>
+            {
+                await neverReleased.Task.WaitAsync(ct);
+                return 1;
+            },
+            testToken);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        var entry = fixture.Logger.Entries.Should()
+            .ContainSingle(x => x.EventId.Id == 2, "the cooperative deadline fired while the outer token did not")
+            .Which;
+        entry.Exception.Should().BeAssignableTo<OperationCanceledException>();
+        testToken.IsCancellationRequested.Should().BeFalse();
+        fixture.Logger.Entries.Should().NotContain(x => x.EventId.Id == 3);
+    }
+
+    [Fact]
+    public async Task Token_Ignoring_Factory_Is_Abandoned_And_Its_Orphan_Cleans_Up_On_Completion()
+    {
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        using var probe = new CounterProbe();
+        var policy = RunnerFixture.CreatePolicy(cancellationAfter: TimeSpan.FromMilliseconds(50), abandonAfter: TimeSpan.FromMilliseconds(200));
+        var ignoredGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ScopedDependency? factoryInstance = null;
+
+        try
+        {
+            var act = async () => await fixture.Runner.RunInScope<int>(
+                policy,
+                async (services, _) =>
+                {
+                    factoryInstance = services.GetRequiredService<ScopedDependency>();
+                    await ignoredGate.Task; // deliberately ignores the cancellation token
+                    return 1;
+                },
+                testToken);
+
+            await act.Should().ThrowAsync<OperationCanceledException>();
+
+            var abandoned = fixture.Logger.Entries.Should().ContainSingle(x => x.EventId.Id == 3).Which;
+            abandoned.Exception.Should().BeOfType<OperationCanceledException>();
+            probe.Sum(policy.CacheName, CounterProbe.Orphans).Should().Be(1);
+        }
+        finally
+        {
+            ignoredGate.TrySetResult();
+        }
+
+        await WaitUntil(() => fixture.Logger.Entries.Any(x => x.EventId.Id == 4), testToken);
+        factoryInstance.Should().NotBeNull();
+        await WaitUntil(() => factoryInstance.Disposed, testToken);
+        await WaitUntil(() => probe.Sum(policy.CacheName, CounterProbe.Executions) == 0, testToken);
+        probe.Sum(policy.CacheName, CounterProbe.Orphans).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Outer_Cancellation_Is_Rethrown_Without_Error_Logging_And_The_Orphan_Still_Cleans_Up()
+    {
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        using var probe = new CounterProbe();
+        var policy = RunnerFixture.CreatePolicy(cancellationAfter: TimeSpan.FromSeconds(8), abandonAfter: TimeSpan.FromSeconds(9));
+        using var outerSource = CancellationTokenSource.CreateLinkedTokenSource(testToken);
+        var factoryEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var ignoredGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ScopedDependency? factoryInstance = null;
+
+        try
+        {
+            var invocation = fixture.Runner.RunInScope<int>(
+                policy,
+                async (services, _) =>
+                {
+                    factoryInstance = services.GetRequiredService<ScopedDependency>();
+                    factoryEntered.TrySetResult();
+                    await ignoredGate.Task; // deliberately ignores the cancellation token
+                    return 1;
+                },
+                outerSource.Token);
+
+            await factoryEntered.Task.WaitAsync(GuardTimeout, testToken);
+            await outerSource.CancelAsync();
+
+            var act = async () => await invocation;
+            await act.Should().ThrowAsync<OperationCanceledException>();
+            fixture.Logger.Entries.Should().NotContain(x => x.Level == Microsoft.Extensions.Logging.LogLevel.Error);
+        }
+        finally
+        {
+            ignoredGate.TrySetResult();
+        }
+
+        await WaitUntil(() => fixture.Logger.Entries.Any(x => x.EventId.Id == 7), testToken);
+        factoryInstance.Should().NotBeNull();
+        await WaitUntil(() => factoryInstance.Disposed, testToken);
+        await WaitUntil(() => probe.Sum(policy.CacheName, CounterProbe.Executions) == 0, testToken);
+
+        // The permit was released by the orphan's completion; a new invocation can enter.
+        var result = await fixture.Runner.RunInScope(policy, (_, _) => Task.FromResult(42), testToken);
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task Factory_Exception_Is_Logged_With_The_Exception_And_Rethrown()
+    {
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        var policy = RunnerFixture.CreatePolicy();
+        var failure = new InvalidOperationException("factory failed");
+
+        var act = async () => await fixture.Runner.RunInScope<int>(policy, (_, _) => throw failure, testToken);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Should().BeSameAs(failure);
+        fixture.Logger.Entries.Should()
+            .ContainSingle(x => x.EventId.Id == 1)
+            .Which.Exception.Should().BeSameAs(failure);
+    }
+
+    [Fact]
+    public async Task Concurrent_Executions_Are_Bounded_Before_Any_Scope_Opens_And_Recover_After_Release()
+    {
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        using var probe = new CounterProbe();
+        var policy = RunnerFixture.CreatePolicy(
+            cancellationAfter: TimeSpan.FromMilliseconds(50),
+            abandonAfter: TimeSpan.FromMilliseconds(200),
+            maxConcurrentExecutions: 2);
+        var ignoredGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var enteredCount = 0;
+
+        try
+        {
+            // Permit acquisition happens synchronously during invocation, so invoking sequentially makes
+            // admission deterministic: the first two acquire, the rest must be rejected without entering.
+            var invocations = Enumerable.Range(0, 5)
+                .Select(_ => fixture.Runner.RunInScope<int>(
+                    policy,
+                    async (services, _) =>
+                    {
+                        services.GetRequiredService<ScopedDependency>();
+                        Interlocked.Increment(ref enteredCount);
+                        await ignoredGate.Task; // deliberately ignores the cancellation token
+                        return 1;
+                    },
+                    testToken))
+                .ToList();
+
+            var rejections = 0;
+            var abandonments = 0;
+            foreach (var invocation in invocations)
+            {
+                try
+                {
+                    await invocation.WaitAsync(GuardTimeout, testToken);
+                }
+                catch (FusionCacheFactoryRejectedException)
+                {
+                    rejections++;
+                }
+                catch (OperationCanceledException)
+                {
+                    abandonments++;
+                }
+            }
+
+            rejections.Should().Be(3);
+            abandonments.Should().Be(2);
+            enteredCount.Should().Be(2);
+            probe.Sum(policy.CacheName, CounterProbe.Executions).Should().Be(2, "abandoned executions keep their permits");
+            probe.Sum(policy.CacheName, CounterProbe.Orphans).Should().Be(2);
+            fixture.Logger.Entries.Count(x => x.EventId.Id == 5).Should().Be(1, "the exhausted interval is logged once, not per rejection");
+            fixture.Logger.Entries.Should().NotContain(x => x.EventId.Id == 1, "rejections must not be logged as factory failures");
+        }
+        finally
+        {
+            ignoredGate.TrySetResult();
+        }
+
+        await WaitUntil(() => fixture.Logger.Entries.Count(x => x.EventId.Id == 4) == 2, testToken);
+        await WaitUntil(() => probe.Sum(policy.CacheName, CounterProbe.Executions) == 0, testToken);
+        probe.Sum(policy.CacheName, CounterProbe.Orphans).Should().Be(0);
+        fixture.Logger.Entries.Count(x => x.EventId.Id == 6).Should().Be(1);
+
+        var result = await fixture.Runner.RunInScope(policy, (_, _) => Task.FromResult(42), testToken);
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task Abandonment_Releases_The_FusionCache_Key_Lock_And_A_Replacement_Factory_Can_Run()
+    {
+        const string key = "key";
+        const string staleValue = "stale-value";
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        var policy = RunnerFixture.CreatePolicy(
+            cancellationAfter: TimeSpan.FromMilliseconds(50),
+            abandonAfter: TimeSpan.FromMilliseconds(250));
+
+        using var cache = new FusionCache(Options.Create(new FusionCacheOptions { CacheName = policy.CacheName }));
+        var options = new FusionCacheEntryOptions
+        {
+            Duration = TimeSpan.FromMilliseconds(1),
+            IsFailSafeEnabled = true,
+            FailSafeMaxDuration = TimeSpan.FromMinutes(5),
+            // Without this, fail-safe activation in phase a throttles phases b and c into serving stale
+            // WITHOUT invoking the factory at all (default throttle is 30s).
+            FailSafeThrottleDuration = TimeSpan.FromMilliseconds(1),
+            FactorySoftTimeout = TimeSpan.FromMilliseconds(100),
+            // Generous headroom: tolerates the interval between EventId 3 and FusionCache's own lock release.
+            FactoryHardTimeout = TimeSpan.FromSeconds(8)
+        };
+
+        var ignoredGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scopesOpened = 0;
+        var replacementRan = 0;
+
+        // Seed fail-safe stock and let the 1ms Duration expire so every later GetOrSet triggers a refresh.
+        await cache.SetAsync(key, staleValue, options, token: testToken);
+        await Task.Delay(TimeSpan.FromMilliseconds(50), testToken);
+
+        try
+        {
+            // Phase a: the first factory ignores cancellation; the caller is served stale at the soft
+            // timeout while the detached completion runs on until the runner abandons it.
+            var stalePhaseResult = await cache.GetOrSetAsync<string>(
+                key,
+                (_, ct) => fixture.Runner.RunInScope<string>(policy, async (services, _) =>
+                {
+                    services.GetRequiredService<ScopedDependency>();
+                    Interlocked.Increment(ref scopesOpened);
+                    await ignoredGate.Task; // deliberately ignores the cancellation token
+                    return "never-produced";
+                }, ct),
+                options: options,
+                token: testToken).AsTask().WaitAsync(GuardTimeout, testToken);
+            stalePhaseResult.Should().Be(staleValue);
+
+            // EventId 3 is a safe synchronization point: orphan registration precedes it.
+            await WaitUntil(() => fixture.Logger.Entries.Any(x => x.EventId.Id == 3), testToken);
+
+            // Phase b: the abandoned orphan still holds the single execution permit, so a refresh attempt
+            // is rejected without opening a scope; the caller gets stale data instead of queueing behind
+            // the (now released) per-key lock.
+            var rejectedPhaseResult = await cache.GetOrSetAsync<string>(
+                key,
+                (_, ct) => fixture.Runner.RunInScope<string>(policy, (services, _) =>
+                {
+                    services.GetRequiredService<ScopedDependency>();
+                    Interlocked.Increment(ref scopesOpened);
+                    return Task.FromResult("never-produced-either");
+                }, ct),
+                options: options,
+                token: testToken).AsTask().WaitAsync(GuardTimeout, testToken);
+            rejectedPhaseResult.Should().Be(staleValue);
+            scopesOpened.Should().Be(1, "a rejected invocation must not open a scope");
+        }
+        finally
+        {
+            ignoredGate.TrySetResult();
+        }
+
+        // Phase c: once the orphan completes and the permit returns, a replacement factory must be able to
+        // acquire the same key and actually run.
+        await WaitUntil(() => fixture.Logger.Entries.Any(x => x.EventId.Id == 6), testToken);
+
+        var freshResult = await cache.GetOrSetAsync<string>(
+            key,
+            (_, ct) => fixture.Runner.RunInScope<string>(policy, (_, _) =>
+            {
+                Interlocked.Increment(ref replacementRan);
+                return Task.FromResult("fresh-value");
+            }, ct),
+            options: options,
+            token: testToken).AsTask().WaitAsync(GuardTimeout, testToken);
+
+        replacementRan.Should().Be(1, "the replacement factory must actually run, not merely serve stale data");
+        freshResult.Should().Be("fresh-value");
+    }
+
+    [Fact]
+    public async Task A_Factory_That_Blocks_Before_Its_First_Await_Is_Still_Abandoned()
+    {
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        var policy = RunnerFixture.CreatePolicy(cancellationAfter: TimeSpan.FromMilliseconds(50), abandonAfter: TimeSpan.FromMilliseconds(200));
+        using var blocker = new ManualResetEventSlim(initialState: false);
+
+        try
+        {
+            var act = async () => await fixture.Runner.Run(
+                policy,
+                _ =>
+                {
+                    blocker.Wait(GuardTimeout, CancellationToken.None); // blocks synchronously; never reaches an await
+                    return Task.FromResult(1);
+                },
+                testToken);
+
+            await act.Should().ThrowAsync<OperationCanceledException>();
+            fixture.Logger.Entries.Should().Contain(x => x.EventId.Id == 3);
+        }
+        finally
+        {
+            blocker.Set();
+        }
+    }
+
+    [Fact]
+    public void Every_Policy_Orders_Its_Deadlines_And_Has_Valid_Capacity_And_Name()
+    {
+        var policies = FusionCacheFactoryPolicy.All;
+
+        policies.Should().NotBeEmpty();
+        policies.Select(x => x.CacheName).Should().OnlyHaveUniqueItems();
+        foreach (var policy in policies)
+        {
+            policy.CacheName.Should().NotBeNullOrWhiteSpace();
+            policy.MaxConcurrentExecutions.Should().BePositive();
+            policy.HardTimeout.Should().BePositive();
+            policy.HardTimeout.Should().BeLessThan(policy.CancellationAfter,
+                "waiters must be released (or served stale) before cooperative cancellation starts");
+            policy.CancellationAfter.Should().BeLessThan(policy.AbandonAfter,
+                "cooperative cancellation must get a chance before hard abandonment");
+        }
+    }
+
+    [Fact]
+    public async Task A_Throwing_Scope_Disposal_Still_Releases_The_Execution_Permit()
+    {
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        using var probe = new CounterProbe();
+        var policy = RunnerFixture.CreatePolicy();
+
+        var act = async () => await fixture.Runner.RunInScope(
+            policy,
+            (services, _) =>
+            {
+                services.GetRequiredService<ThrowingAsyncDisposable>();
+                return Task.FromResult(1);
+            },
+            testToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        fixture.Logger.Entries.Should().ContainSingle(x => x.EventId.Id == 1);
+        probe.Sum(policy.CacheName, CounterProbe.Executions).Should().Be(0);
+
+        var result = await fixture.Runner.RunInScope(policy, (_, _) => Task.FromResult(42), testToken);
+        result.Should().Be(42);
+    }
+
+    private static async Task WaitUntil(Func<bool> condition, CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(GuardTimeout);
+        while (!condition())
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(10), timeout.Token);
+        }
+    }
+
+    private sealed class RunnerFixture : IDisposable
+    {
+        private readonly ServiceProvider _serviceProvider;
+
+        public RunnerFixture()
+        {
+            _serviceProvider = new ServiceCollection()
+                .AddScoped<ScopedDependency>()
+                .AddScoped<ThrowingAsyncDisposable>()
+                .BuildServiceProvider();
+            Logger = new CollectingLogger<FusionCacheFactoryRunner>();
+            Runner = new FusionCacheFactoryRunner(_serviceProvider.GetRequiredService<IServiceScopeFactory>(), Logger);
+        }
+
+        public IServiceProvider Services => _serviceProvider;
+        public CollectingLogger<FusionCacheFactoryRunner> Logger { get; }
+        public FusionCacheFactoryRunner Runner { get; }
+
+        public static FusionCacheFactoryPolicy CreatePolicy(
+            TimeSpan? cancellationAfter = null,
+            TimeSpan? abandonAfter = null,
+            int maxConcurrentExecutions = 1) => new()
+            {
+                // Unique per test: the metric instruments are process-global, so isolation comes from the tag.
+                CacheName = $"test-{Guid.NewGuid():N}",
+                HardTimeout = TimeSpan.FromMilliseconds(10),
+                CancellationAfter = cancellationAfter ?? TimeSpan.FromSeconds(8),
+                AbandonAfter = abandonAfter ?? TimeSpan.FromSeconds(9),
+                MaxConcurrentExecutions = maxConcurrentExecutions
+            };
+
+        public void Dispose() => _serviceProvider.Dispose();
+    }
+
+    private sealed class ScopedDependency : IDisposable
+    {
+        public bool Disposed { get; private set; }
+        public bool DisposedDuringUse => Disposed;
+        public void Dispose() => Disposed = true;
+    }
+
+    private sealed class ThrowingAsyncDisposable : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => throw new InvalidOperationException("scope disposal failed");
+    }
+
+    /// <summary>
+    /// Sums the process-global runner counters per cache-name tag. Tests must filter by their own unique
+    /// cache name and never assert global totals (parallel tests share the instruments).
+    /// </summary>
+    private sealed class CounterProbe : IDisposable
+    {
+        public const string Executions = "dialogporten.fusioncache.factory_executions_active";
+        public const string Orphans = "dialogporten.fusioncache.factory_orphans_active";
+
+        private readonly MeterListener _listener = new();
+        private readonly Lock _lock = new();
+        private readonly Dictionary<(string CacheName, string Instrument), long> _sums = [];
+
+        public CounterProbe()
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == FusionCacheFactoryTelemetry.MeterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+            {
+                foreach (var tag in tags)
+                {
+                    if (tag.Key != "cache.name" || tag.Value is not string cacheName)
+                    {
+                        continue;
+                    }
+
+                    lock (_lock)
+                    {
+                        var key = (cacheName, instrument.Name);
+                        _sums[key] = _sums.GetValueOrDefault(key) + measurement;
+                    }
+
+                    return;
+                }
+            });
+            _listener.Start();
+        }
+
+        public long Sum(string cacheName, string instrument)
+        {
+            lock (_lock)
+            {
+                return _sums.GetValueOrDefault((cacheName, instrument));
+            }
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+}

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/FusionCacheFactoryRunnerTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/FusionCacheFactoryRunnerTests.cs
@@ -330,19 +330,43 @@ public class FusionCacheFactoryRunnerTests
 
             // Phase b: the abandoned orphan still holds the single execution permit, so a refresh attempt
             // is rejected without opening a scope; the caller gets stale data instead of queueing behind
-            // the (now released) per-key lock.
-            var rejectedPhaseResult = await cache.GetOrSetAsync<string>(
-                key,
-                (_, ct) => fixture.Runner.RunInScope<string>(policy, (services, _) =>
+            // the (now released) per-key lock. EventId 3 is logged just before the abandonment exception
+            // reaches FusionCache, so FusionCache's own lock release races this phase - and stale data with
+            // an untouched scope count is also what a still-held key lock would produce. Retry until
+            // FusionCache actually invokes the refresh delegate, which proves the key lock was acquired.
+            var refreshDelegateEntered = 0;
+            string? rejectedPhaseResult = null;
+            using (var retryTimeout = CancellationTokenSource.CreateLinkedTokenSource(testToken))
+            {
+                retryTimeout.CancelAfter(GuardTimeout);
+                while (Volatile.Read(ref refreshDelegateEntered) == 0)
                 {
-                    services.GetRequiredService<ScopedDependency>();
-                    Interlocked.Increment(ref scopesOpened);
-                    return Task.FromResult("never-produced-either");
-                }, ct),
-                options: options,
-                token: testToken).AsTask().WaitAsync(GuardTimeout, testToken);
+                    rejectedPhaseResult = await cache.GetOrSetAsync<string>(
+                        key,
+                        (_, ct) =>
+                        {
+                            Interlocked.Increment(ref refreshDelegateEntered);
+                            return fixture.Runner.RunInScope<string>(policy, (services, _) =>
+                            {
+                                services.GetRequiredService<ScopedDependency>();
+                                Interlocked.Increment(ref scopesOpened);
+                                return Task.FromResult("never-produced-either");
+                            }, ct);
+                        },
+                        options: options,
+                        token: testToken).AsTask().WaitAsync(GuardTimeout, testToken);
+
+                    if (Volatile.Read(ref refreshDelegateEntered) == 0)
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(10), retryTimeout.Token);
+                    }
+                }
+            }
+
             rejectedPhaseResult.Should().Be(staleValue);
             scopesOpened.Should().Be(1, "a rejected invocation must not open a scope");
+            fixture.Logger.Entries.Should().Contain(x => x.EventId.Id == 5,
+                "the refresh attempt must be a real capacity rejection, not stale data served behind a still-held key lock");
         }
         finally
         {

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/FusionCacheFactoryRunnerTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/FusionCacheFactoryRunnerTests.cs
@@ -190,6 +190,38 @@ public class FusionCacheFactoryRunnerTests
     }
 
     [Fact]
+    public async Task An_Unrelated_Cancellation_After_The_Deadline_Is_A_Failure_Not_A_Deadline_Cancellation()
+    {
+        var testToken = TestContext.Current.CancellationToken;
+        using var fixture = new RunnerFixture();
+        var policy = RunnerFixture.CreatePolicy(cancellationAfter: TimeSpan.FromMilliseconds(50), abandonAfter: TimeSpan.FromSeconds(8));
+        using var foreignSource = new CancellationTokenSource();
+        await foreignSource.CancelAsync();
+
+        var act = async () => await fixture.Runner.RunInScope<int>(
+            policy,
+            async (_, ct) =>
+            {
+                // Outlive the deadline while ignoring the token, then fail with a cancellation that has
+                // nothing to do with the runner (an inner client's own timeout, for example). The deadline
+                // source being cancelled at catch time must not turn this into a deadline cancellation.
+                while (!ct.IsCancellationRequested)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(5), CancellationToken.None);
+                }
+
+                throw new OperationCanceledException("inner client timeout", foreignSource.Token);
+            },
+            testToken);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        fixture.Logger.Entries.Should().ContainSingle(x => x.EventId.Id == 1,
+            "a cancellation carrying a foreign token is an unexpected factory failure");
+        fixture.Logger.Entries.Should().NotContain(x => x.EventId.Id == 2,
+            "only cancellations carrying the runner's own token are deadline cancellations");
+    }
+
+    [Fact]
     public async Task Factory_Exception_Is_Logged_With_The_Exception_And_Rethrown()
     {
         var testToken = TestContext.Current.CancellationToken;

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/FusionCacheFactoryRunnerTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/FusionCacheFactoryRunnerTests.cs
@@ -439,6 +439,26 @@ public class FusionCacheFactoryRunnerTests
     }
 
     [Fact]
+    public void Every_Declared_Policy_Is_Included_In_All()
+    {
+        // All is the hand-maintained inventory that drives both the invariant test above and the runner's
+        // startup metric registration; a policy declared on the type but missing from All silently escapes both.
+        var declared = typeof(FusionCacheFactoryPolicy)
+            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .Where(x => x.FieldType == typeof(FusionCacheFactoryPolicy))
+            .ToList();
+
+        declared.Should().NotBeEmpty();
+        foreach (var field in declared)
+        {
+            var policy = (FusionCacheFactoryPolicy)field.GetValue(null)!;
+            FusionCacheFactoryPolicy.All.Should().Contain(policy, $"the declared policy '{field.Name}' must be part of the inventory");
+        }
+
+        FusionCacheFactoryPolicy.All.Should().HaveCount(declared.Count);
+    }
+
+    [Fact]
     public async Task A_Throwing_Scope_Disposal_Still_Releases_The_Execution_Permit()
     {
         var testToken = TestContext.Current.CancellationToken;

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/ServiceResourceMetadataCatalogueTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/ServiceResourceMetadataCatalogueTests.cs
@@ -4,6 +4,7 @@ using Digdir.Domain.Dialogporten.Application.Externals;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.Localizations;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common.ServiceResourceMetadata;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common;
+using Digdir.Domain.Dialogporten.Infrastructure.Common.Caching;
 using Digdir.Domain.Dialogporten.Infrastructure.ServiceResourceMetadata;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -20,14 +21,16 @@ public class ServiceResourceMetadataCatalogueTests
     {
         var builder = new CountingItemBuilder();
         // The catalogue resolves its build dependencies from a fresh DI scope (so a background/eager refresh does
-        // not reuse a disposed request-scoped DbContext), so register the stubs in a real provider and hand it the
-        // scope factory.
+        // not reuse a disposed request-scoped DbContext), so register the stubs in a real provider and hand its
+        // scope factory to the runner.
         var serviceProvider = new ServiceCollection()
             .AddSingleton<IServiceResourceMetadataItemBuilder>(builder)
             .AddSingleton<IPartyResourceReferenceRepository>(new StubReferencedResourcesRepository([ResourceUrn]))
             .BuildServiceProvider();
-        var catalogue = new ServiceResourceMetadataCatalogue(
-            CreateCacheProvider(), serviceProvider.GetRequiredService<IServiceScopeFactory>());
+        var factoryRunner = new FusionCacheFactoryRunner(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            new CollectingLogger<FusionCacheFactoryRunner>());
+        var catalogue = new ServiceResourceMetadataCatalogue(CreateCacheProvider(), factoryRunner);
 
         var first = await catalogue.GetEntries(TestContext.Current.CancellationToken);
         var second = await catalogue.GetEntries(TestContext.Current.CancellationToken);

--- a/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/TestDoubles.cs
+++ b/tests/Digdir.Domain.Dialogporten.Infrastructure.Unit.Tests/TestDoubles.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.Security.Claims;
 using Digdir.Domain.Dialogporten.Application.Externals.Presentation;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -40,3 +42,23 @@ internal sealed class StubOptionsSnapshot<T>(T value) : IOptionsSnapshot<T> wher
     public T Value => value;
     public T Get(string? name) => value;
 }
+
+/// <summary>
+/// Captures log entries for assertions. Thread-safe: cache factories detached by the runner log concurrently
+/// with the test's own thread.
+/// </summary>
+internal sealed class CollectingLogger<T> : ILogger<T>
+{
+    private readonly ConcurrentQueue<CollectedLogEntry> _entries = new();
+
+    public IReadOnlyCollection<CollectedLogEntry> Entries => _entries;
+
+    IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+        _entries.Enqueue(new CollectedLogEntry(logLevel, eventId, exception, formatter(state, exception)));
+}
+
+internal sealed record CollectedLogEntry(LogLevel Level, EventId EventId, Exception? Exception, string Message);


### PR DESCRIPTION
Related to #4252.

## Mechanism

FusionCache detaches factories from the triggering request: a factory exceeding `FactorySoftTimeout` (default 1s) keeps running as a background completion, and eager refresh (default threshold 0.8) starts factories on request contexts that are about to unwind. Factories that captured the request-scoped `DialogDbContext` then run against a disposed DI scope, poisoning connections. A subsequently hung read holds the FusionCache per-key memory lock indefinitely, because `FactoryHardTimeout` only releases waiters; it never cancels the factory, and the lock is released only when the factory task completes (verified against FusionCache 2.6.0). Result: a replica that hangs every request needing that cache key while health probes stay green. Six production incidents since July, latest 2026-08-16. #4230 (24h fail-safe) is containment only; the 2026-08-16 incident happened with it active.

## Execution model

Every DB-touching cache factory now runs through a new `FusionCacheFactoryRunner`:

1. **Pre-execution bulkhead**: a permit per cache (`MaxConcurrentExecutions`) is reserved before any scope opens and released only when the execution actually completes, abandoned or not. No permit: fail fast without opening a scope (callers with fail-safe stock get stale data; cold misses get `FusionCacheFactoryRejectedException`). This bounds the resources stuck factories can hold, so abandonment cannot convert a lock wedge into pool exhaustion.
2. **Dedicated DI scope** (`RunInScope`): the factory resolves fresh dependencies from its own async scope, which lives exactly as long as the execution.
3. **Cooperative cancellation** at `CancellationAfter` (linked CTS): expected to terminate stuck DB work (Npgsql honors tokens; its cancellation timeout bounds the wait for the cancel response), though not yet demonstrated against the exact production failure mode.
4. **Hard abandonment** at `AbandonAfter`: the runner stops awaiting the factory and throws; FusionCache observes a cancelled factory and **releases the per-key lock**, so later calls can attempt a replacement. Foreground callers were already released or served stale at `FactoryHardTimeout`. The orphaned task keeps its permit and scope until it actually completes, is tracked (exception observed, completion logged with elapsed time), and counts against the bulkhead.

Per-cache policies (`FusionCacheFactoryPolicy.All`) carry `HardTimeout` (consumed by the cache registration so the two cannot drift), `CancellationAfter`, `AbandonAfter`, and `MaxConcurrentExecutions`; the ordering invariants are pinned by a unit test. The high-cardinality `AuthorizedServiceResources` gets 16 permits, an unmeasured initial limit; single-key caches get 1.

## Observability

Factory failures were previously unattributable (FusionCache logs a bare Warning; `Microsoft.EntityFrameworkCore` is suppressed at Fatal). The runner logs seven structured events with `CacheName`/`EventName` fields and the exception attached where one exists: factory failed (1), deadline-cancelled (2), abandoned (3), and capacity exhausted (5) at Error; orphan completed (4) at Warning; capacity restored (6) at Information; caller-cancelled orphan completed (7) at Debug. Capacity events fire once per transition, never per rejection. One meter with two `UpDownCounter` instruments (`factory_executions_active`, `factory_orphans_active`, tagged by cache name) is subscribed in all four hosts.

## Changes

- `Infrastructure/Common/Caching/` (new): `FusionCacheFactoryRunner`, `FusionCacheFactoryPolicy`, `FusionCacheFactoryTelemetry`, `FusionCacheFactoryRejectedException`.
- `ResourcePolicyInformationRepository` (the recurring production hang site), `SubjectResourceRepository`: factories become static, resolve a fresh `DialogDbContext` from the runner's scope.
- `AltinnAuthorizationClient.GetAllSubjectResources`: existing sync `CreateScope()` replaced by the runner. Gains the deadline and fixes the synchronous `Dispose()` of a `DialogDbContext` that owns async resources; the runner's scope is disposed with `await using`.
- `AuthorizedServiceResourcesProvider`: factory dependencies (`IOptionsSnapshot`, `IUserParties`, `IAltinnAuthorization`) resolved from the runner's scope instead of captured. The `IOptionsSnapshot` capture had the same lifetime defect as the DbContext captures: a scoped-by-design snapshot read from an already-ended request scope. The ambient caller principal is established inside the delegate before any scoped resolution; tests pin cross-caller isolation and the establish-before-resolve ordering.
- `PartyResourceRepository.GetReferencedResources`: deadline + permit only (`Run`), no scope needed (singleton `NpgsqlDataSource`).
- `ServiceResourceMetadataCatalogue`: hand-rolled scope moves into the runner; gains the missing deadline. Nested factories now scope themselves, so detached nested refreshes are safe by construction.
- Cache registrations consume policy `HardTimeout`s; the previously untuned min-auth and SubjectResource caches state their 5s defaults explicitly.
- Tests: 11-test runner suite including a FusionCache lock-release regression test (an abandoned token-ignoring factory must not prevent a later factory from acquiring the same key) and a concurrent bulkhead-bound test; two-principal concurrency test for the provider; existing tests updated.

**Exception-attribution scope**: limited to the six wrapped factories. HTTP-only factories (name/resource/access-management registries, PDP/parties) keep FusionCache's bare Warning; wrapping them is a follow-up.

## Architecture notes

- The branch touches no Application or Domain source files; everything new lives in Infrastructure, and the architecture tests pass. Two new public Infrastructure types, both allowlisted with reasons: `FusionCacheFactoryTelemetry` (hosts must reference the meter name to subscribe it) and `FusionCacheFactoryRejectedException` (escapes assembly boundaries via cache calls on cold-miss rejections, so callers must be able to catch it by type).
- The factories resolve dependencies via an `IServiceProvider` parameter by necessity: constructor injection is the defect being fixed (the injected scoped dependencies are what get disposed under a detached factory), so the object graph must be composed later, from a scope with the right lifetime. The provider is an explicit delegate parameter, not an ambient locator, and composes only what would otherwise be constructor-injected; the codebase already uses the same lifetime-driven shape in `WarmupService`, `NotificationProcessingContext`, the hosted services, and the two call sites this PR refactors.

## Residual risk

An abandoned factory that also ignores cooperative cancellation keeps one scope/connection until it dies naturally. The bulkhead bounds this (1 per single-key cache, 16 for AuthorizedServiceResources), and while an orphan holds a single-key cache's permit, refreshes are rejected and callers ride fail-safe until it completes. That trade (bounded stale-serving vs replica-wide hang) is the point of the change.

## Verification

- `dotnet build` Release clean; full non-E2E suite green locally (1196 tests, including 846 application integration tests).
- Post-deploy (AT23/staging first): the runner's log events and meters make rebuild failures attributable within the hour on staging, which currently reproduces factory failures every ~25-30 min. Watch capacity rejections (EventId 5) and cold-miss failures as the signal that the 16-permit limit is mis-sized. The nine per-replica Grafana alerts are the regression net.
- Metric note: all four hosts subscribe the meter and emit zero-valued series per policy from startup, but no Janitor path invokes a wrapped factory (its sync commands use only the uncached repository methods), so its series stay permanently at zero; activity-style queries must filter by role.

## Follow-ups (out of scope)

- Npgsql TCP keepalives on the data source
- EF Core retry/execution strategy
- Revisit AllowTimedOutFactoryBackgroundCompletion / EagerRefreshThreshold defaults
- Wrap the HTTP-only factories for exception attribution. This also closes a drift edge the policy type does not cover yet: `AuthorizedServiceResources.HardTimeout` (25s) must stay >= the hard timeouts of the `Altinn.Authorization` and `AuthorizedPartiesResult` caches its factory awaits (both 25s, still inline literals guarded only by a comment). Giving those caches policies makes the constraint testable.
- Query optimization for slow rebuild inputs
- Remove the #4252-motivated alert accommodations after validation
