### PR TITLE
ci: remove unused pull-requests read permission from deploy workflows

### DIFF
--- a/.github/workflows/ci-cd-prod-dry-run.yml
+++ b/.github/workflows/ci-cd-prod-dry-run.yml
@@ -12,7 +12,6 @@ concurrency:
 permissions:
   contents: read
   id-token: write
-  pull-requests: read
 
 jobs:
   get-versions-from-github:

--- a/.github/workflows/ci-cd-pull-request-release-please.yml
+++ b/.github/workflows/ci-cd-pull-request-release-please.yml
@@ -40,7 +40,6 @@ jobs:
     needs: [generate-git-short-sha, get-current-version, check-for-changes]
     permissions:
       contents: read
-      pull-requests: read
       id-token: write
     uses: ./.github/workflows/workflow-deploy-infra.yml
     secrets:
@@ -62,7 +61,6 @@ jobs:
     needs: [generate-git-short-sha, get-current-version, check-for-changes]
     permissions:
       contents: read
-      pull-requests: read
       id-token: write
     uses: ./.github/workflows/workflow-deploy-apps.yml
     secrets:

--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -188,7 +188,6 @@ jobs:
     if: ${{ always() && needs.check-for-changes.outputs.hasInfraChanges == 'true' }}
     permissions:
       contents: read
-      pull-requests: read
       id-token: write
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -217,7 +216,6 @@ jobs:
     if: ${{ always() && !failure() && !cancelled() && (needs.check-for-changes.outputs.hasBackendChanges == 'true' || needs.check-for-changes.outputs.hasMigrationChanges == 'true') }}
     permissions:
       contents: read
-      pull-requests: read
       id-token: write
     uses: ./.github/workflows/workflow-deploy-apps.yml
     secrets:

--- a/.github/workflows/workflow-deploy-infra.yml
+++ b/.github/workflows/workflow-deploy-infra.yml
@@ -57,7 +57,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: read
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:


### PR DESCRIPTION
## Description

`workflow-deploy-infra.yml` requested `pull-requests: read` on its deploy job without any step using the GitHub token. Deployment authenticates through Azure OIDC, and the checkout only needs `contents: read`. The scope came from the blanket explicit-permissions pass in #2647 rather than from an actual consumer.

Because a called workflow cannot request a scope its caller does not grant, that declaration also left `dispatch-infrastructure.yml` unusable. It grants only `contents: read` and `id-token: write`, with no job-level override, so dispatching it fails at startup with:

```
The workflow ... is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.
```

That workflow has no run history, so the breakage went unnoticed since #2647 landed. Removing the declaration fixes it, and makes the matching grants in the callers surplus, so those go as well:

| File | Removed |
| --- | --- |
| `workflow-deploy-infra.yml` | callee declaration on the deploy job |
| `ci-cd-pull-request.yml` | both dry-run deploy jobs |
| `ci-cd-prod-dry-run.yml` | workflow-level grant |
| `ci-cd-pull-request-release-please.yml` | both dry-run deploy jobs |

The `pull-requests: write` grants elsewhere are untouched. Those feed `workflow-tag-issues-with-environment` and the k6 PR comments, which have real consumers.

## Related Issue(s)

None. Spotted while looking into skipped release-please runs.

## Verification

- [x] **Your** code builds clean without any errors or warnings (no compiled code in this change; all four workflow files parse as valid YAML)
- [x] Manual testing done (required) (confirmed no step in `workflow-deploy-infra.yml` or the `azure-login` composite action references `GITHUB_TOKEN`, `GH_TOKEN`, or `gh`. This PR touches `.github/workflows/**`, so its own `dry-run-deploy-infra` job runs the modified reusable workflow and exercises the reduced grant for real. `dispatch-infrastructure.yml` is not dispatched as a test because it performs an actual deployment, with no `dryRun` input.)
- [ ] Relevant automated test added (not applicable)
- [ ] Database changes manually applied to prod/YT01 (not applicable)

## Documentation

- [ ] Documentation is updated (not applicable, no behavioural or interface change)
