### PR TITLE
fix(ci): publish schema prereleases under their own dist-tag

### DIFF
--- a/.github/workflows/ci-cd-publish-schema.yml
+++ b/.github/workflows/ci-cd-publish-schema.yml
@@ -249,7 +249,7 @@ jobs:
           # is what a bare `npm install` resolves to. Keyed on the version shape,
           # not the trigger: workflow_dispatch can supply either kind.
           case "${version%%+*}" in
-            *-*) dist_tag=dev ;;
+            *-*) dist_tag=prerelease ;;
             *)   dist_tag=latest ;;
           esac
           echo "dist_tag=$dist_tag" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-cd-publish-schema.yml
+++ b/.github/workflows/ci-cd-publish-schema.yml
@@ -54,6 +54,7 @@ jobs:
       base_sha: ${{ steps.context.outputs.base_sha }}
       environment: ${{ steps.context.outputs.environment }}
       force_publish: ${{ steps.context.outputs.force_publish }}
+      dist_tag: ${{ steps.context.outputs.dist_tag }}
     steps:
       - uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
@@ -244,6 +245,16 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $version"
 
+          # npm >= 11 refuses a prerelease without an explicit --tag, and "latest"
+          # is what a bare `npm install` resolves to. Keyed on the version shape,
+          # not the trigger: workflow_dispatch can supply either kind.
+          case "${version%%+*}" in
+            *-*) dist_tag=dev ;;
+            *)   dist_tag=latest ;;
+          esac
+          echo "dist_tag=$dist_tag" >> "$GITHUB_OUTPUT"
+          echo "Dist-tag: $dist_tag"
+
   check-for-changes:
     name: Check for schema changes
     needs: [resolve-context]
@@ -335,7 +346,9 @@ jobs:
 
       - name: Publish package (Trusted Publishing via OIDC)
         if: steps.check-version.outputs.version-exists == 'false'
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag "$DIST_TAG"
+        env:
+          DIST_TAG: ${{ needs.resolve-context.outputs.dist_tag }}
         working-directory: ${{ env.WORKING_DIRECTORY }}
 
   notify-failure:

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -38,8 +38,8 @@ third that only starts when the schema package is touched:
    - Only starts when the push touches `docs/schema/V*/**`,
      `.github/actions/build-schema/**`, or the workflow file itself
    - Publishes `@digdir/dialogporten-schema@${version.txt}-${shortSha}` if the
-     schema package changed, under the `dev` dist-tag - prereleases never take
-     `latest`, so a bare `npm install` still resolves to a real release
+     schema package changed, under the `prerelease` dist-tag, so a bare
+     `npm install` still resolves to a real release
    - Runs independently of `ci-cd-main.yml`, so it is **not** gated on a
      successful deployment to Test
 

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -38,7 +38,8 @@ third that only starts when the schema package is touched:
    - Only starts when the push touches `docs/schema/V*/**`,
      `.github/actions/build-schema/**`, or the workflow file itself
    - Publishes `@digdir/dialogporten-schema@${version.txt}-${shortSha}` if the
-     schema package changed
+     schema package changed, under the `dev` dist-tag - prereleases never take
+     `latest`, so a bare `npm install` still resolves to a real release
    - Runs independently of `ci-cd-main.yml`, so it is **not** gated on a
      successful deployment to Test
 
@@ -68,7 +69,8 @@ four parallel workflows consume:
    - Deployment similar to staging, but does not publish the SDK
 
 4. **Publish Schema NPM** (`ci-cd-publish-schema.yml`)
-   - Publishes `@digdir/dialogporten-schema` at the release version
+   - Publishes `@digdir/dialogporten-schema` at the release version, under the
+     `latest` dist-tag
    - Runs in parallel with the staging deployment, not after it
 
 > **Note:** `ci-cd-publish-schema.yml` is the sole publisher of the npm schema


### PR DESCRIPTION
## Tag name

Settled: prereleases publish under the `prerelease` dist-tag. Nothing was ever
published under the earlier `dev` placeholder, so there is no stale dist-tag to
clean up.

## Problem

The first push to main that actually reached `npm publish` after #4021 failed:

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

Runs: [32240631773](https://github.com/Altinn/dialogporten/actions/runs/32240631773)
and [32241447744](https://github.com/Altinn/dialogporten/actions/runs/32241447744),
both the same error.

The push path publishes `${version.txt}-${shortSha}` (e.g. `1.119.0-526c47f`),
which is a semver prerelease. #4021 raised `build-schema`'s default
`node-version` from 20 to 24, which Trusted Publishing requires
(npm >= 11.5.1), and npm 11 refuses to publish a prerelease without an explicit
`--tag`. npm 10.x, bundled with Node 20, allowed it.

Verified locally: npm 10.8.2 and 10.9.4 publish a prerelease with no `--tag`;
11.0.0 and every version above refuse. The check is client-side, it fires under
`--dry-run` in under a second, so Trusted Publishing and OIDC are not involved.

It stayed latent because the only other run of the new workflow skipped the
publish job on change detection, so this was the first run to reach it.

## Fix

`resolve-context` derives a `dist_tag` from the resolved version and the publish
step passes it:

- prerelease (`1.119.0-526c47f`) to `prerelease`
- release (`1.119.0`) to `latest`

Keyed on the version shape rather than the trigger, since `workflow_dispatch`
can supply either kind and the hotfix convention is prerelease-shaped too. Build
metadata is stripped before the check, so `1.2.3+build-1` counts as a release.

The schema changes from the two failed runs are not lost. The registry watermark
introduced in #4021 takes its base from what is actually published, so the first
successful run after this merges will diff from the last published version and
pick up everything that was missed.

## Side effect worth noting

Under npm 10 the push path published every per-commit prerelease straight to
`latest`. `latest` currently points at `1.119.0-d98a3d6`, so the documented
`npm install @digdir/dialogporten-schema` resolves to a per-commit build and the
README badge shows that version.

Prereleases no longer move `latest`, but it stays on `1.119.0-d98a3d6` until the
next release publishes. To correct it sooner:
`npm dist-tag add @digdir/dialogporten-schema@1.119.0 latest`

## Verification

- Extracted the real `resolve-context` script and ran all four paths with stubs:
  push to `prerelease`, release dispatch to `latest`, manual derived to
  `prerelease`, manual explicit `1.120.0` to `latest`.
- All five existing guards still fire (missing version, missing
  previous_release_sha, ref without version, malformed version, unsupported
  event).
- An explicit `--tag` clears the error on npm 11.17.0 and 11.19.0; a release version
  with no tag still passes.
- Docs state which dist-tag each path uses.

Merging this PR touches the workflow file, which is in its own `paths` trigger,
so the merge itself will start a publish run and serve as the end-to-end test.
