### PR TITLE
fix(ci): authenticate the schema publish with NPM_TOKEN

### DIFF
--- a/.github/workflows/ci-cd-publish-schema.yml
+++ b/.github/workflows/ci-cd-publish-schema.yml
@@ -296,10 +296,12 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          # Trusted Publishing needs node >= 22.14.0 / npm >= 11.5.1.
           node-version: '24'
-          # No registry-url on purpose: it writes an .npmrc auth line that breaks
-          # the OIDC exchange when no token is set. See .github/actions/build-schema.
+          # Writes the .npmrc auth line that NODE_AUTH_TOKEN fills in. This and the
+          # token below must be removed together when switching to Trusted
+          # Publishing: an auth line with no token 401s and pre-empts the OIDC
+          # exchange. See .github/actions/build-schema.
+          registry-url: 'https://registry.npmjs.org/'
 
       - name: Check if version exists on NPM
         id: check-version
@@ -344,11 +346,15 @@ jobs:
           jq --arg version "$VERSION" '.version = $version' package.json > temp.json
           mv temp.json package.json
 
-      - name: Publish package (Trusted Publishing via OIDC)
+      # Token auth, not Trusted Publishing: no Trusted Publisher record exists for
+      # this package on npmjs.com yet. --provenance still signs the tarball, which
+      # uses OIDC for attestation only and is unrelated to authentication.
+      - name: Publish package
         if: steps.check-version.outputs.version-exists == 'false'
         run: npm publish --provenance --access public --tag "$DIST_TAG"
         env:
           DIST_TAG: ${{ needs.resolve-context.outputs.dist_tag }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ${{ env.WORKING_DIRECTORY }}
 
   notify-failure:

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -74,10 +74,14 @@ four parallel workflows consume:
    - Runs in parallel with the staging deployment, not after it
 
 > **Note:** `ci-cd-publish-schema.yml` is the sole publisher of the npm schema
-> package and is registered as the Trusted Publisher for it on npmjs.com. npm
-> binds that record to the exact workflow **filename**, so the file cannot be
-> renamed, and the publish step cannot be moved into a reusable `workflow-*.yml`,
-> without updating the npmjs.com configuration first.
+> package. It authenticates with `NPM_TOKEN`; no Trusted Publisher record exists
+> for this package on npmjs.com yet.
+>
+> Keep the publish step inline in this file. npm binds a Trusted Publisher record
+> to the exact workflow **filename**, and when `npm publish` runs inside a called
+> workflow npm validates the *calling* workflow's name instead, so moving the step
+> into a reusable `workflow-*.yml` or renaming this file would block adopting
+> Trusted Publishing later.
 
 #### Production Deployment
 - **Manual Trigger Required** (`ci-cd-prod.yml`)


### PR DESCRIPTION
Unblocks schema publishing. `main` is currently red on
`ci-cd-publish-schema.yml` and the package is not being published.

## What is actually broken

Trusted Publishing has never authenticated for this package. The last successful
publish was `1.119.0-d98a3d6` on 2026-08-17 13:40, which predates #4021 merging
at 2026-08-18 14:10, and it used `NPM_TOKEN`.

Every attempt since #4021 merged has failed:

| run | outcome |
|---|---|
| [32240631773](https://github.com/Altinn/dialogporten/actions/runs/32240631773) | missing `--tag` for a prerelease |
| [32241447744](https://github.com/Altinn/dialogporten/actions/runs/32241447744) | same |
| [32246862744](https://github.com/Altinn/dialogporten/actions/runs/32246862744) | `ENEEDAUTH` |

The first two never reached authentication, so the `--tag` bug fixed in #4316 was
masking this one. The third built the tarball correctly and then failed to
authenticate.

The workflow side checks out: `id-token: write` is granted, npm is 11.17.0 (above
the 11.5.1 floor), there is no committed `.npmrc`, and `registry-url` was
correctly omitted. What is missing is the Trusted Publisher record on npmjs.com,
which needs npm org admin on `@digdir`.

## This change

- `registry-url` on the publish job's setup-node, so an `.npmrc` auth line is
  written
- `NODE_AUTH_TOKEN` from the existing `NPM_TOKEN` secret on the publish step

`--provenance` stays. It uses OIDC for attestation only, which is independent of
authentication, and `id-token: write` is still granted.

Also corrects `docs/CI-CD.md`, which stated the workflow "is registered as the
Trusted Publisher for it on npmjs.com". It never was. That claim is why the gap
went unnoticed through review.

## Adopting Trusted Publishing later

`ci/trusted-publishing` holds the Trusted Publishing version. Once an admin
configures the record, it can be verified **before** merging:

1. Run **CI/CD Publish Schema NPM** via `workflow_dispatch`, selecting
   `ci/trusted-publishing` in the ref dropdown, both inputs empty.
2. `workflow_dispatch` runs the workflow file from the selected ref, so the
   Trusted Publishing version executes even while `main` carries the token.
3. `force_publish=true` on that path skips change detection, so it performs a
   real publish and exercises the genuine OIDC handshake.
4. Green means it works. Merge that branch, which removes `registry-url` and
   `NODE_AUTH_TOKEN` together.

Per npm's docs the record matches on organization, repository, workflow filename,
and optionally environment. The ref is not part of the match, which is why
dispatching from a branch is a valid test.

Two things the admin needs to get right:

- Workflow filename is `ci-cd-publish-schema.yml`.
- Leave the **environment** field blank. The publish job declares no
  `environment:`, so filling that field in would stop OIDC matching.

## Note on the token

The failing run logged npm's warning that tokens bypassing 2FA are being
restricted for direct publishing, so this is a temporary measure rather than a
settled state.
