### PR TITLE
chore(ci): authenticate the schema publish with Trusted Publishing

### DIFF
--- a/.github/workflows/ci-cd-publish-schema.yml
+++ b/.github/workflows/ci-cd-publish-schema.yml
@@ -296,12 +296,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
+          # Trusted Publishing needs node >= 22.14.0 / npm >= 11.5.1.
           node-version: '24'
-          # Writes the .npmrc auth line that NODE_AUTH_TOKEN fills in. This and the
-          # token below must be removed together when switching to Trusted
-          # Publishing: an auth line with no token 401s and pre-empts the OIDC
-          # exchange. See .github/actions/build-schema.
-          registry-url: 'https://registry.npmjs.org/'
+          # No registry-url on purpose: setup-node would write an .npmrc auth line,
+          # and with no token in the environment npm sends the literal placeholder,
+          # which 401s and pre-empts the OIDC exchange (actions/setup-node#1551).
 
       - name: Check if version exists on NPM
         id: check-version
@@ -346,15 +345,13 @@ jobs:
           jq --arg version "$VERSION" '.version = $version' package.json > temp.json
           mv temp.json package.json
 
-      # Token auth, not Trusted Publishing: no Trusted Publisher record exists for
-      # this package on npmjs.com yet. --provenance still signs the tarball, which
-      # uses OIDC for attestation only and is unrelated to authentication.
-      - name: Publish package
+      # No NODE_AUTH_TOKEN: npm authenticates over OIDC via the Trusted Publisher
+      # record for this package, which is bound to this workflow's filename.
+      - name: Publish package (Trusted Publishing via OIDC)
         if: steps.check-version.outputs.version-exists == 'false'
         run: npm publish --provenance --access public --tag "$DIST_TAG"
         env:
           DIST_TAG: ${{ needs.resolve-context.outputs.dist_tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ${{ env.WORKING_DIRECTORY }}
 
   notify-failure:

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -74,14 +74,14 @@ four parallel workflows consume:
    - Runs in parallel with the staging deployment, not after it
 
 > **Note:** `ci-cd-publish-schema.yml` is the sole publisher of the npm schema
-> package. It authenticates with `NPM_TOKEN`; no Trusted Publisher record exists
-> for this package on npmjs.com yet.
+> package and authenticates via npm Trusted Publishing over OIDC, so no npm token
+> is involved.
 >
-> Keep the publish step inline in this file. npm binds a Trusted Publisher record
-> to the exact workflow **filename**, and when `npm publish` runs inside a called
-> workflow npm validates the *calling* workflow's name instead, so moving the step
-> into a reusable `workflow-*.yml` or renaming this file would block adopting
-> Trusted Publishing later.
+> Keep the publish step inline in this file. npm binds the Trusted Publisher
+> record to the exact workflow **filename**, and when `npm publish` runs inside a
+> called workflow npm validates the *calling* workflow's name instead, so moving
+> the step into a reusable `workflow-*.yml` or renaming this file would break
+> publishing.
 
 #### Production Deployment
 - **Manual Trigger Required** (`ci-cd-prod.yml`)


### PR DESCRIPTION
The Trusted Publisher record for `@digdir/dialogporten-schema` is now configured
on npmjs.com (confirmed by @arealmaas), so this drops the `NPM_TOKEN` fallback
added in #4317 while the record was missing.

## Changes

- `NODE_AUTH_TOKEN` removed from the publish step
- `registry-url` removed from the publish job's setup-node

Both have to go together. `setup-node` writes an `.npmrc` auth line when
`registry-url` is set, and with no token in the environment npm sends the literal
placeholder, which 401s and pre-empts the OIDC exchange
(actions/setup-node#1551).

`id-token: write` and `--provenance` are unchanged, and the `prerelease`/`latest`
dist-tag logic from #4316 is untouched.

Also removes a bus-factor risk: the token authenticated as the individual user
`arealmaas`, so publishing depended on one person's personal npm credentials.

## Merging this will NOT test it

Worth being explicit, because this is the third time a latent failure in this
workflow only surfaced on first execution.

The push trigger is path-filtered, and change detection bases its diff on the
last published version. The newest published version is `1.119.0-991407c`, built
from commit `991407c`, which is current `main`. Merging a workflow-and-docs change
produces a diff window containing no `docs/schema/**` files, so
`hasSchemaPackageChanges` is false and the publish job is skipped.

To actually exercise Trusted Publishing after merging, run
**CI/CD Publish Schema NPM** via `workflow_dispatch` from `main` with both inputs
empty. That path sets `force_publish=true`, which bypasses change detection and
performs a real publish.

Retrying is safe while it keeps failing: the dispatched version is
`version.txt` + `main`'s short sha, so a failed attempt leaves nothing published
and a re-dispatch resolves the same version and tries again. Once it succeeds, a
re-dispatch of the same commit resolves an already-published version and skips, so
iterating with @arealmaas on the npm-side config costs nothing.

## If it fails

Two things to check first, in order:

1. **Environment field.** The publish job declares no `environment:`. If the
   Trusted Publisher record has an environment name set, the OIDC claim will not
   match. It needs to be blank.
2. **Workflow filename.** The record must name `ci-cd-publish-schema.yml` exactly.

If it fails with a 401 or 404 rather than `ENEEDAUTH`, the next thing to try is
npm's own documented shape: set `registry-url` *and* `NODE_AUTH_TOKEN: ''`. npm's
example sets `registry-url`; omitting it (as here) is the alternative that avoids
the placeholder-token problem, and it is the one place this config diverges from
the documented example.

Rolling back is a revert of this PR, which restores working token auth.
