### PR TITLE
chore(infra): ship Key Vault audit logs to the environment workspace

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -134,6 +134,7 @@ module environmentKeyVault '../modules/keyvault/create.bicep' = {
     location: location
     sku: keyVaultSku
     tags: tags
+    appInsightWorkspaceName: appInsights.outputs.appInsightsWorkspaceName
   }
 }
 

--- a/.azure/modules/keyvault/create.bicep
+++ b/.azure/modules/keyvault/create.bicep
@@ -21,6 +21,10 @@ param appInsightWorkspaceName string
 
 var keyVaultName = take('${namePrefix}-kv-${uniqueString(resourceGroup().id)}', 24)
 
+resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' existing = {
+  name: appInsightWorkspaceName
+}
+
 resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' = {
   name: keyVaultName
   location: location
@@ -35,18 +39,14 @@ resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' = {
   tags: tags
 }
 
-resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' existing = {
-  name: appInsightWorkspaceName
-}
-
 // Audit logging of vault access (SecretGet etc. with caller identity) to our own
 // workspace, resource-specific table AZKVAuditLogs. The security team ships the same
 // category to their Sentinel workspace through a separate diagnostic setting; Azure
 // allows both as long as no two settings send one category to the same destination.
 // Retention is governed by the workspace, not here.
 resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
-  name: 'KeyVaultDiagnosticSetting'
   scope: keyVault
+  name: 'KeyVaultDiagnosticSetting'
   properties: {
     workspaceId: appInsightsWorkspace.id
     logAnalyticsDestinationType: 'Dedicated'

--- a/.azure/modules/keyvault/create.bicep
+++ b/.azure/modules/keyvault/create.bicep
@@ -16,6 +16,9 @@ type Sku = {
 @description('The SKU of the Key Vault')
 param sku Sku
 
+@description('The name of the Application Insights workspace receiving the vault audit log')
+param appInsightWorkspaceName string
+
 var keyVaultName = take('${namePrefix}-kv-${uniqueString(resourceGroup().id)}', 24)
 
 resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' = {
@@ -30,6 +33,30 @@ resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' = {
     enableRbacAuthorization: true
   }
   tags: tags
+}
+
+resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' existing = {
+  name: appInsightWorkspaceName
+}
+
+// Audit logging of vault access (SecretGet etc. with caller identity) to our own
+// workspace, resource-specific table AZKVAuditLogs. The security team ships the same
+// category to their Sentinel workspace through a separate diagnostic setting; Azure
+// allows both as long as no two settings send one category to the same destination.
+// Retention is governed by the workspace, not here.
+resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'KeyVaultDiagnosticSetting'
+  scope: keyVault
+  properties: {
+    workspaceId: appInsightsWorkspace.id
+    logAnalyticsDestinationType: 'Dedicated'
+    logs: [
+      {
+        category: 'AuditEvent'
+        enabled: true
+      }
+    ]
+  }
 }
 
 output name string = keyVault.name


### PR DESCRIPTION
## What

Adds a diagnostic setting to the environment Key Vault, sending the `AuditEvent` category (secret access with caller identity) to the environment's Log Analytics workspace, using the resource-specific table `AZKVAuditLogs`. Same pattern as the PostgreSQL diagnostic setting in the same IaC.

## Why

Gives the team its own queryable and alertable record of who reads which secrets, notably human reads of the shared database admin password. The security team already ships the `audit` category group from these vaults to their Sentinel workspace via a separate setting; both coexist, since Azure only forbids two settings sending the same category to the same destination. Managing ours in Bicep avoids the untracked-portal-setting drift we have been bitten by before.

## Notes

- Deliberately minimal: no `retentionPolicy` blocks (retired storage-era field, inert for workspace destinations; retention is governed by the workspace) and no metrics routing (platform metrics remain available from the Azure Monitor metrics store). This shape is the model for slimming the PostgreSQL diagnostic setting later.
- No application or user-facing changes; pure telemetry configuration.
- Applies to the environment vaults (`dp-be-<env>-kv-*`) on each environment's next infra deploy.
- The source key vaults (`dp-be-src-kv-*`) are referenced but not managed by this IaC and are **not** covered; they get the same setting applied separately.
- No database changes; nothing to apply manually in prod beyond the normal deploy.