### PR TITLE
feat(graphql): add labelAssignmentLog query to end-user GraphQL API

### DIFF
--- a/docs/schema/V1/schema.verified.graphql
+++ b/docs/schema/V1/schema.verified.graphql
@@ -8,6 +8,7 @@ type Queries @authorize(policy: "enduser") {
   dialogLookup(instanceRef: String!): DialogLookupPayload!
   dialogById(dialogId: UUID!): DialogByIdPayload!
   searchDialogs(input: SearchDialogInput!): SearchDialogsPayload!
+  labelAssignmentLog(dialogId: UUID!): LabelAssignmentLogPayload!
   limits: Limits!
   parties: [AuthorizedParty!]!
   serviceResources(parties: [String!], includeUnauthorized: Boolean! = false): ServiceResourceMetadata!
@@ -391,6 +392,35 @@ type GuiAction {
   prompt: [Localization!]
 }
 
+type LabelAssignmentLog {
+  "The date and time when the label assignment log entry was created."
+  createdAt: DateTime!
+  "The name of the system label that was changed."
+  name: String!
+  "The action that was performed on the label, e.g. 'set' or 'removed'."
+  action: String!
+  "The actor that performed the label assignment."
+  performedBy: Actor!
+}
+
+type LabelAssignmentLogDeleted implements LabelAssignmentLogError {
+  message: String!
+}
+
+type LabelAssignmentLogForbidden implements LabelAssignmentLogError {
+  message: String!
+}
+
+type LabelAssignmentLogNotFound implements LabelAssignmentLogError {
+  message: String!
+}
+
+type LabelAssignmentLogPayload {
+  "The immutable list of label assignment log entries for the dialog's end-user context."
+  labelAssignmentLog: [LabelAssignmentLog!]!
+  errors: [LabelAssignmentLogError!]!
+}
+
 type Limits {
   endUserSearch: EndUserSearchLimits!
   serviceOwnerSearch: ServiceOwnerSearchLimits!
@@ -668,6 +698,10 @@ interface DialogByIdError {
 }
 
 interface DialogLookupError {
+  message: String!
+}
+
+interface LabelAssignmentLogError {
   message: String!
 }
 

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/LabelAssignmentLog/Mapper.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/LabelAssignmentLog/Mapper.cs
@@ -1,0 +1,29 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.Actors;
+using Digdir.Domain.Dialogporten.GraphQL.EndUser.Common;
+using LabelAssignmentLogDto = Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.EndUserContext.Queries.SearchLabelAssignmentLog.LabelAssignmentLogDto;
+
+namespace Digdir.Domain.Dialogporten.GraphQL.EndUser.LabelAssignmentLog;
+
+internal static class LabelAssignmentLogMapExtensions
+{
+    extension(List<LabelAssignmentLogDto> source)
+    {
+        public List<LabelAssignmentLog> ToLabelAssignmentLogs() =>
+            source.Select(MapLabelAssignmentLog).ToList();
+    }
+
+    private static LabelAssignmentLog MapLabelAssignmentLog(LabelAssignmentLogDto source) => new()
+    {
+        CreatedAt = source.CreatedAt,
+        Name = source.Name,
+        Action = source.Action,
+        PerformedBy = MapActor(source.PerformedBy)
+    };
+
+    private static Actor MapActor(ActorDto source) => new()
+    {
+        ActorType = (ActorType)source.ActorType,
+        ActorId = source.ActorId,
+        ActorName = source.ActorName
+    };
+}

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/LabelAssignmentLog/ObjectTypes.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/LabelAssignmentLog/ObjectTypes.cs
@@ -1,0 +1,46 @@
+using Digdir.Domain.Dialogporten.GraphQL.EndUser.Common;
+
+namespace Digdir.Domain.Dialogporten.GraphQL.EndUser.LabelAssignmentLog;
+
+[InterfaceType("LabelAssignmentLogError")]
+public interface ILabelAssignmentLogError
+{
+    string Message { get; set; }
+}
+
+public sealed class LabelAssignmentLogNotFound : ILabelAssignmentLogError
+{
+    public required string Message { get; set; }
+}
+
+public sealed class LabelAssignmentLogDeleted : ILabelAssignmentLogError
+{
+    public required string Message { get; set; }
+}
+
+public sealed class LabelAssignmentLogForbidden : ILabelAssignmentLogError
+{
+    public string Message { get; set; } = "Forbidden";
+}
+
+public sealed class LabelAssignmentLogPayload
+{
+    [GraphQLDescription("The immutable list of label assignment log entries for the dialog's end-user context.")]
+    public List<LabelAssignmentLog> LabelAssignmentLog { get; set; } = [];
+    public List<ILabelAssignmentLogError> Errors { get; set; } = [];
+}
+
+public sealed class LabelAssignmentLog
+{
+    [GraphQLDescription("The date and time when the label assignment log entry was created.")]
+    public required DateTimeOffset CreatedAt { get; set; }
+
+    [GraphQLDescription("The name of the system label that was changed.")]
+    public required string Name { get; set; }
+
+    [GraphQLDescription("The action that was performed on the label, e.g. 'set' or 'removed'.")]
+    public required string Action { get; set; }
+
+    [GraphQLDescription("The actor that performed the label assignment.")]
+    public required Actor PerformedBy { get; set; }
+}

--- a/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/LabelAssignmentLogQueries.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/EndUser/LabelAssignmentLogQueries.cs
@@ -1,0 +1,38 @@
+using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.EndUserContext.Queries.SearchLabelAssignmentLog;
+using Digdir.Domain.Dialogporten.GraphQL.EndUser.LabelAssignmentLog;
+using MediatR;
+
+namespace Digdir.Domain.Dialogporten.GraphQL.EndUser;
+
+public sealed partial class Queries
+{
+    public async Task<LabelAssignmentLogPayload> GetLabelAssignmentLog(
+        [Service] ISender mediator,
+        [Argument] Guid dialogId,
+        CancellationToken cancellationToken)
+    {
+        var request = new SearchLabelAssignmentLogQuery { DialogId = dialogId };
+
+        var result = await mediator.Send(request, cancellationToken);
+
+        return result.Match(
+            logs => new LabelAssignmentLogPayload
+            {
+                LabelAssignmentLog = logs.ToLabelAssignmentLogs()
+            },
+            notFound => new LabelAssignmentLogPayload
+            {
+                Errors = [new LabelAssignmentLogNotFound { Message = notFound.Message }]
+            },
+            deleted => new LabelAssignmentLogPayload
+            {
+                Errors = [new LabelAssignmentLogDeleted { Message = deleted.Message }]
+            },
+            forbidden => new LabelAssignmentLogPayload
+            {
+                Errors = forbidden.Reasons.Count > 0
+                    ? [.. forbidden.Reasons.Select(x => new LabelAssignmentLogForbidden { Message = x })]
+                    : [new LabelAssignmentLogForbidden()]
+            });
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.GraphQL/IRequestExecutorBuilderExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.GraphQL/IRequestExecutorBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogById;
 using Digdir.Domain.Dialogporten.GraphQL.EndUser.DialogLookup;
+using Digdir.Domain.Dialogporten.GraphQL.EndUser.LabelAssignmentLog;
 using Digdir.Domain.Dialogporten.GraphQL.EndUser.MutationTypes;
 using Digdir.Domain.Dialogporten.GraphQL.EndUser.SearchDialogs;
 using HotChocolate.Execution.Configuration;
@@ -16,7 +17,8 @@ internal static class IRequestExecutorBuilderExtensions
             typeof(ISetSystemLabelError),
             typeof(ISearchDialogError),
             typeof(IDialogByIdError),
-            typeof(IDialogLookupError)
+            typeof(IDialogLookupError),
+            typeof(ILabelAssignmentLogError)
         };
 
         var errorTypes = typeof(ServiceCollectionExtensions).Assembly

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/Features/LabelAssignmentLog/LabelAssignmentLogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/Features/LabelAssignmentLog/LabelAssignmentLogTests.cs
@@ -1,0 +1,62 @@
+using AwesomeAssertions;
+using Digdir.Library.Dialogporten.E2E.Common;
+using Digdir.Library.Dialogporten.E2E.Common.Extensions;
+using StrawberryShake;
+
+namespace Digdir.Domain.Dialogporten.GraphQl.E2E.Tests.Features.LabelAssignmentLog;
+
+[Collection(nameof(GraphQlTestCollectionFixture))]
+public class LabelAssignmentLogTests(GraphQlE2EFixture fixture) : E2ETestBase<GraphQlE2EFixture>(fixture)
+{
+    [E2EFact]
+    public async Task Should_Return_Label_Assignment_Log_After_Setting_Label()
+    {
+        // Arrange
+        var dialogId = await Fixture.ServiceownerApi.CreateSimpleDialogAsync();
+
+        var setLabelResult = await Fixture.GraphQlClient.SetSystemLabel.ExecuteAsync(
+            new SetSystemLabelInput
+            {
+                DialogId = dialogId,
+                AddLabels = [SystemLabel.Bin],
+                RemoveLabels = []
+            },
+            TestContext.Current.CancellationToken);
+
+        setLabelResult.Errors.Should().BeEmpty();
+        setLabelResult.Data.Should().NotBeNull();
+        setLabelResult.Data.SetSystemLabel.Success.Should().BeTrue();
+
+        // Act
+        var result = await GetLabelAssignmentLog(dialogId);
+
+        // Assert
+        result.Data.Should().NotBeNull();
+
+        var payload = result.Data.LabelAssignmentLog;
+        payload.Errors.Should().BeEmpty();
+        payload.LabelAssignmentLog.Should().ContainSingle()
+            .Which.Action.Should().Be("set");
+    }
+
+    [E2EFact]
+    public async Task Should_Return_Typed_NotFound_Error_For_Unknown_DialogId()
+    {
+        // Arrange
+        var dialogId = Guid.NewGuid();
+
+        // Act
+        var result = await GetLabelAssignmentLog(dialogId);
+
+        // Assert
+        result.Data.Should().NotBeNull();
+
+        var error = result.Data.LabelAssignmentLog.Errors.Single();
+
+        error.Should().BeOfType<GetLabelAssignmentLog_LabelAssignmentLog_Errors_LabelAssignmentLogNotFound>();
+        error.Message.Should().Contain(dialogId.ToString());
+    }
+
+    private Task<IOperationResult<IGetLabelAssignmentLogResult>> GetLabelAssignmentLog(Guid dialogId) =>
+        Fixture.GraphQlClient.GetLabelAssignmentLog.ExecuteAsync(dialogId, TestContext.Current.CancellationToken);
+}

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/GetLabelAssignmentLog.graphql
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/GetLabelAssignmentLog.graphql
@@ -1,0 +1,18 @@
+query GetLabelAssignmentLog($dialogId: UUID!) {
+  labelAssignmentLog(dialogId: $dialogId) {
+    labelAssignmentLog {
+      createdAt
+      name
+      action
+      performedBy {
+        actorType
+        actorId
+        actorName
+      }
+    }
+    errors {
+      __typename
+      message
+    }
+  }
+}

--- a/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/SetSystemLabel.graphql
+++ b/tests/Digdir.Domain.Dialogporten.GraphQl.E2E.Tests/SetSystemLabel.graphql
@@ -1,0 +1,9 @@
+mutation SetSystemLabel($input: SetSystemLabelInput!) {
+  setSystemLabel(input: $input) {
+    success
+    errors {
+      __typename
+      message
+    }
+  }
+}


### PR DESCRIPTION
## Description

Exposes the dialog end-user **label assignment log** through the GraphQL API. The log entries (which system label was changed, the action, when, and by whom) were previously only available via the REST endpoint `GET enduser/dialogs/{dialogId}/context/labellog`. This PR adds an equivalent GraphQL query so GraphQL consumers get feature parity.

### API

New end-user query field:

```graphql
labelAssignmentLog(dialogId: UUID!): LabelAssignmentLogPayload!
```

```graphql
type LabelAssignmentLogPayload {
  labelAssignmentLog: [LabelAssignmentLog!]!
  errors: [LabelAssignmentLogError!]!
}

type LabelAssignmentLog {
  createdAt: DateTime!
  name: String!
  action: String!
  performedBy: Actor!
}

interface LabelAssignmentLogError { message: String! }
# LabelAssignmentLogNotFound | LabelAssignmentLogDeleted | LabelAssignmentLogForbidden
```

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/4253

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)


