### PR TITLE
chore: persist PostgreSQL enhanced metrics server parameters in IaC

### DIFF
--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -82,6 +82,14 @@ param postgresConfiguration = {
       value: '2097151'
     }
     {
+      name: 'metrics.autovacuum_diagnostics'
+      value: 'on'
+    }
+    {
+      name: 'metrics.collector_database_activity'
+      value: 'on'
+    }
+    {
       name: 'track_cost_delay_timing'
       value: 'on'
     }

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -42,6 +42,17 @@ param postgresConfiguration = {
   // Enabling index tuning will practically also enable query performance insight
   enableIndexTuning: true
   enableQueryPerformanceInsight: true
+  // Azure enhanced metrics: per-database activity counters and autovacuum diagnostics
+  additionalServerConfigurations: [
+    {
+      name: 'metrics.autovacuum_diagnostics'
+      value: 'on'
+    }
+    {
+      name: 'metrics.collector_database_activity'
+      value: 'on'
+    }
+  ]
   backupRetentionDays: 7
   availabilityZone: '2'
   enableBackupVault: false

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -42,6 +42,17 @@ param postgresConfiguration = {
   // Enabling index tuning will practically also enable query performance insight
   enableIndexTuning: false
   enableQueryPerformanceInsight: true
+  // Azure enhanced metrics: per-database activity counters and autovacuum diagnostics
+  additionalServerConfigurations: [
+    {
+      name: 'metrics.autovacuum_diagnostics'
+      value: 'on'
+    }
+    {
+      name: 'metrics.collector_database_activity'
+      value: 'on'
+    }
+  ]
   backupRetentionDays: 7
   availabilityZone: '1'
   enableBackupVault: false

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -43,6 +43,17 @@ param postgresConfiguration = {
   }
   enableIndexTuning: true
   enableQueryPerformanceInsight: true
+  // Azure enhanced metrics: per-database activity counters and autovacuum diagnostics
+  additionalServerConfigurations: [
+    {
+      name: 'metrics.autovacuum_diagnostics'
+      value: 'on'
+    }
+    {
+      name: 'metrics.collector_database_activity'
+      value: 'on'
+    }
+  ]
   backupRetentionDays: 7
   availabilityZone: '1'
   enableBackupVault: false


### PR DESCRIPTION
Persists two PostgreSQL enhanced-metrics server parameters in IaC across all four environments:

- `metrics.collector_database_activity` = `on`
- `metrics.autovacuum_diagnostics` = `on`

These were enabled directly on the prod server, so live configuration and Bicep disagree and an infra deploy would silently revert them. The other environments get the same visibility.

Both are dynamic parameters (`isDynamicConfig: true`, verified against the live servers), so no restart is needed. `prod.bicepparam` already had an `additionalServerConfigurations` block; `test`, `staging` and `yt01` did not, so one is introduced in each.

Verified: all four `*.bicepparam` files compile clean with `az bicep build-params`, and both parameters exist and are writable on every server, including the Burstable test SKU.

Post-deploy check:

```
az postgres flexible-server parameter show --name metrics.autovacuum_diagnostics -g dp-be-prod-rg -s dp-be-prod-postgres2-adeqyizi6r4eu
```

Related to #4334
