### PR TITLE
fix(ci): base schema prereleases on the next patch version

### DIFF
--- a/.github/workflows/ci-cd-publish-schema.yml
+++ b/.github/workflows/ci-cd-publish-schema.yml
@@ -115,9 +115,19 @@ jobs:
           # Sets a global rather than echoing: set -e does not fire through
           # `v=$(fn)`, so failures here would silently yield "1.2.3-" or "-abc123".
           # Short SHA width must match workflow-generate-git-short-sha.yml so the
-          # npm version lines up with the docker tag - don't hard-code a width.
+          # npm version carries the same commit id as the docker tag for the same
+          # build - don't hard-code a width.
+          #
+          # version.txt holds the version that was last released, so appending a
+          # prerelease suffix to it yields a version semver sorts BELOW that
+          # release: 1.2.3-abc123 < 1.2.3. Consumers cannot then reach it through
+          # any range that also matches the release, and the `^` range npm writes
+          # on install resolves straight back to the release. Bumping the patch
+          # first keeps main builds sorted above the release they follow. The
+          # number only establishes ordering - the eventual release may bump the
+          # minor or major instead, and will still sort above these prereleases.
           resolve_version_from_file() {
-            local version short_sha
+            local version short_sha major minor patch
             version=$(cat version.txt) || {
               echo "::error::Could not read version.txt"; exit 1;
             }
@@ -128,7 +138,12 @@ jobs:
               echo "::error::Empty version ('$version') or short SHA ('$short_sha')"
               exit 1
             fi
-            RESOLVED_VERSION="${version}-${short_sha}"
+            IFS=. read -r major minor patch <<<"$version"
+            if ! printf '%s' "${major}.${minor}.${patch}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "::error::version.txt must hold a plain semver version, got '$version'"
+              exit 1
+            fi
+            RESOLVED_VERSION="${major}.${minor}.$((patch + 1))-${short_sha}"
           }
 
           # npm versions are immutable - reject malformed ones before publishing.


### PR DESCRIPTION
## Problem

Push builds of `@digdir/dialogporten-schema` were published as
`<version.txt>-<short sha>`, and `version.txt` holds the version that was
*last released*. Every main build was therefore a prerelease of a version
that was already published, which semver sorts *below* that release:
`1.119.1-4704900 < 1.119.1`.

Verified consequences against the live registry:

- `^1.119.0`, `^1.119.1` and `1.119.x` never match the prereleases at all
- `npm install @digdir/dialogporten-schema@prerelease` works once, but npm
  writes `^1.119.1-<sha>` to package.json, and that range also matches
  `1.119.1`, so the next `npm install` silently swaps the prerelease back
  out for the older release
- the only spec that survives an install cycle is an exact pin without caret

Reported by the Arbeidsflate team, who could not reach the build containing
#4322 through any normal install flow.

## Fix

Bump the patch segment of `version.txt` before appending the short SHA, so
main builds publish as `1.120.1-<sha>` against a released `1.120.0`.

Verified with semver 7: `1.120.0 < 1.120.1-<sha> < 1.120.1 < 1.121.0 < 2.0.0`,
so ordering is correct whatever bump the next release turns out to be, and
the caret range npm writes no longer matches the older release (no silent
downgrade), while it does match the next release once it exists (a safe
upgrade, since releases are cut from main after the prerelease commit).

Also validates that `version.txt` holds a plain `x.y.z` before doing
arithmetic on it, and rejects the publish otherwise.

## Deliberate limitations

- The number is an ordering anchor, not a prediction: release-please may
  bump minor or major instead of patch. When it does, the `1.120.1-<sha>`
  prereleases remain in the registry as prereleases of a version that never
  shipped. They stay harmless (every range prefers the real release) and the
  stream re-anchors on the new `version.txt` at the first schema change
  after the release. Reading the *actual* next version from release-please
  was considered and rejected: it couples the publish job to the existence
  of an open release PR, with bootstrap and race failure modes, for a purely
  cosmetic gain.
- Pre-existing and unchanged: ordering *between two prereleases* follows
  semver identifier rules, not publish time (an all-digit SHA sorts below an
  alphanumeric one). The `prerelease` dist-tag remains the only reliable
  pointer to the newest main build.
- The npm version no longer equals the docker tag string (`ci-cd-main.yml`
  still tags images `<version.txt>-<sha>`). Correlation is by the embedded
  short SHA, which is unchanged; the comment in the workflow is updated
  accordingly.

## Verification

- Ran the patched `resolve_version_from_file` verbatim against the current
  tree: yields `1.120.1-<sha>`
- Malformed `version.txt` inputs (`1.119.1-rc1`, `1.2`, `abc`, empty) are
  rejected with an error instead of publishing garbage
- `last_published_base_sha` is unaffected: release mode filters on exact
  `x.y.z` and never sees prereleases; any mode extracts the SHA after the
  last dash, and the new format still has exactly one dash
- `assert_semver`, the dist-tag derivation and the version-exists check all
  accept the new shape
