### PR TITLE
fix: add dummy data to labelAssignmentLogs where database is missing PerformedBy 

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/EndUserContext/Queries/SearchLabelAssignmentLog/Mapper.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/EndUserContext/Queries/SearchLabelAssignmentLog/Mapper.cs
@@ -1,4 +1,5 @@
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Common.Actors;
+using Digdir.Domain.Dialogporten.Domain.Actors;
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
 
 namespace Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.EndUserContext.Queries.SearchLabelAssignmentLog;
@@ -12,7 +13,17 @@ internal static class LabelAssignmentLogMapExtensions
             CreatedAt = source.CreatedAt,
             Name = source.Name,
             Action = source.Action,
-            PerformedBy = source.PerformedBy.ToDto()
+            /*
+             * PerformedBy should not be null, but for some cases the database do not have this data.
+             * See issue: https://github.com/Altinn/dialogporten/issues/4340
+             * Code should be removed if we add missing data to the database for all environments
+             */
+            PerformedBy = source.PerformedBy?.ToDto() ?? new ActorDto
+            {
+                ActorType = ActorType.Values.PartyRepresentative,
+                ActorId = "",
+                ActorName = ""
+            }
         };
     }
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/SystemLabels/Commands/SetSystemLabelTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/SystemLabels/Commands/SetSystemLabelTests.cs
@@ -12,6 +12,7 @@ using Digdir.Domain.Dialogporten.Domain.Actors;
 using Digdir.Domain.Dialogporten.Domain.DialogEndUserContexts.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
 using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities.Transmissions;
+using Digdir.Domain.Dialogporten.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -225,6 +226,41 @@ public class SetSystemLabelTests(DialogApplication application) : ApplicationCol
         log.PerformedBy.ActorNameEntity.ActorId.Should().Be(TestUsers.DefaultSystemUserUrn);
         log.PerformedBy.ActorNameEntity.Name.Should().Be("Mock system user name");
     }
+
+    [Fact]
+    public Task Search_Handles_Legacy_Log_Entry_Missing_Actor_Row() =>
+        // Finding A in issue #4340: LabelAssignmentLog rows written before the
+        // shared-actor fix in #3553 can lack their Actor row entirely. The search
+        // must tolerate such rows instead of dereferencing the missing PerformedBy.
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog()
+            .SetSystemLabelsEndUser(x => x.AddLabels = [SystemLabel.Values.Bin])
+            .Do(async ctx =>
+            {
+                // Simulate the legacy data state by deleting a single log entry's actor row.
+                using var scope = Application.GetServiceProvider().CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DialogDbContext>();
+                var dialogId = ctx.GetDialogId();
+                var logId = await db.LabelAssignmentLogs
+                    .Where(l => l.Context.DialogId == dialogId)
+                    .Select(l => l.Id)
+                    .FirstAsync(TestContext.Current.CancellationToken);
+                var deleted = await db.Database.ExecuteSqlAsync($"""
+                                                                 DELETE FROM "Actor"
+                                                                 WHERE "LabelAssignmentLogId" = {logId}
+                                                                 """);
+                deleted.Should().Be(1);
+            })
+            .SendCommand(ctx => new SearchLabelAssignmentLogQuery
+            {
+                DialogId = ctx.GetDialogId(),
+            }).ExecuteAndAssert<List<LabelAssignmentLogDto>>(dtoList =>
+            {
+                dtoList.Should().ContainSingle(dto =>
+                    dto.PerformedBy.ActorName == "" &&
+                    dto.PerformedBy.ActorId == "" &&
+                    dto.PerformedBy.ActorType == ActorType.Values.PartyRepresentative);
+            });
 
     private static GetDialogQuery GetDialog(Guid? id) => new() { DialogId = id!.Value };
 }


### PR DESCRIPTION
## Description
Some labelAssignmentLog's are missing it's PerformedBy field in database. 
Add dummy data for these cases.

If missing entries are filled into database for all environments. these check can be removed

## Related Issue(s)
- https://github.com/Altinn/dialogporten/issues/4340

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)
