### PR TITLE
fix(ci): retry Azure OIDC login on transient token endpoint failures

### DIFF
--- a/.github/actions/azure-login/action.yml
+++ b/.github/actions/azure-login/action.yml
@@ -21,8 +21,44 @@ env:
 
 runs:
   using: "composite"
+  # The Entra token endpoint intermittently returns an empty body to a single runner,
+  # which surfaces as "JSON is invalid: Expecting value: line 1 column 1 (char 0)".
+  # Peer logins in the same run keep succeeding, so retrying on a fresh connection
+  # clears it. The final attempt is not marked continue-on-error and fails the job.
   steps:
     - name: OIDC Login to Azure Public Cloud
+      id: login-attempt-1
+      continue-on-error: true
+      uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        subscription-id: ${{ inputs.allow-no-subscriptions == 'true' && '' || inputs.subscription-id }}
+        allow-no-subscriptions: ${{ inputs.allow-no-subscriptions }}
+
+    - name: Back off before login attempt 2
+      if: steps.login-attempt-1.outcome == 'failure'
+      shell: bash
+      run: sleep 5
+
+    - name: OIDC Login to Azure Public Cloud (attempt 2)
+      id: login-attempt-2
+      if: steps.login-attempt-1.outcome == 'failure'
+      continue-on-error: true
+      uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        subscription-id: ${{ inputs.allow-no-subscriptions == 'true' && '' || inputs.subscription-id }}
+        allow-no-subscriptions: ${{ inputs.allow-no-subscriptions }}
+
+    - name: Back off before login attempt 3
+      if: steps.login-attempt-1.outcome == 'failure' && steps.login-attempt-2.outcome == 'failure'
+      shell: bash
+      run: sleep 15
+
+    - name: OIDC Login to Azure Public Cloud (attempt 3)
+      if: steps.login-attempt-1.outcome == 'failure' && steps.login-attempt-2.outcome == 'failure'
       uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
       with:
         client-id: ${{ inputs.client-id }}


### PR DESCRIPTION
Azure Login intermittently fails on a single runner with:

```
##[error]JSON is invalid: Expecting value: line 1 column 1 (char 0)
##[error]Login failed with Error: The process '/usr/bin/az' failed with exit code 1.
```

This is the Entra token endpoint returning an empty body. The OIDC handshake with
GitHub is fine: the action logs valid federated token details with the correct
subject claim before `az login` fails.

It is per-runner and transient, not a credential or federation problem. In 8 of the
9 affected runs since March, exactly one login failed while 3 to 9 peer logins in
the same run succeeded. On 18 May, `graphql` logged in successfully at 14:39:56
while `service` was failing on another runner from 14:39:51 to 14:39:57.

Frequency is 12 failed login steps across 9 runs in six months, roughly one incident
per month. Three of them broke a deploy on main, each leaving at23 with the
migration applied but apps not deployed until someone re-ran the workflow by hand.

## Change

`azure-login` now makes up to three attempts, with 5s and 15s backoff between them.
The first two are `continue-on-error`, the third is not, so a real auth failure
still fails the job on the same error it does today. Worst case this adds about 20s
before a job gives up.

The pinned `azure/login` SHA is unchanged and all three attempts pass identical
inputs. (`continue-on-error` is supported on composite action steps: the runner
schema allows it and `CompositeActionHandler` honours it via the same code path as
job-level steps.)
