### PR TITLE
fix(ci): tag all PRs in the deployed range for prod, tt02 and yt01

### DIFF
--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -120,11 +120,13 @@ jobs:
 
   tag-issues-with-environment:
     name: Tag deployed PRs and issues for prod
-    needs: [ deploy-apps, deploy-infra ]
+    needs: [ get-versions-from-github, deploy-apps, deploy-infra ]
     if: ${{ always() && !failure() && !cancelled() && (needs.deploy-apps.outputs.deployment_executed == 'true' || needs.deploy-infra.outputs.deployment_executed == 'true') }}
     uses: ./.github/workflows/workflow-tag-issues-with-environment.yml
     with:
       environment-label: prod
+      from-sha: ${{ needs.get-versions-from-github.outputs.apps_version_sha }}
+      to-sha: v${{ inputs.version }}
       version: ${{ inputs.version }}
 
   publish-sdk-to-nuget:

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -101,11 +101,13 @@ jobs:
 
   tag-issues-with-environment:
     name: Tag deployed PRs and issues for staging
-    needs: [ deploy-apps, deploy-infra ]
+    needs: [ get-versions-from-github, deploy-apps, deploy-infra ]
     if: ${{ always() && !failure() && !cancelled() && (needs.deploy-apps.outputs.deployment_executed == 'true' || needs.deploy-infra.outputs.deployment_executed == 'true') }}
     uses: ./.github/workflows/workflow-tag-issues-with-environment.yml
     with:
       environment-label: tt02
+      from-sha: ${{ needs.get-versions-from-github.outputs.apps_version_sha }}
+      to-sha: v${{ github.event.client_payload.version }}
       version: ${{ github.event.client_payload.version }}
 
   publish-sdk-to-nuget:

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -124,11 +124,13 @@ jobs:
 
   tag-issues-with-environment:
     name: Tag deployed PRs and issues for yt01
-    needs: [ deploy-apps, deploy-infra, resolve-version ]
+    needs: [ get-versions-from-github, deploy-apps, deploy-infra, resolve-version ]
     if: ${{ always() && !failure() && !cancelled() && (needs.deploy-apps.outputs.deployment_executed == 'true' || needs.deploy-infra.outputs.deployment_executed == 'true') }}
     uses: ./.github/workflows/workflow-tag-issues-with-environment.yml
     with:
       environment-label: yt01
+      from-sha: ${{ needs.get-versions-from-github.outputs.apps_version_sha }}
+      to-sha: v${{ needs.resolve-version.outputs.version }}
       version: ${{ needs.resolve-version.outputs.version }}
 
   store-apps-version:

--- a/.github/workflows/workflow-tag-issues-with-environment.yml
+++ b/.github/workflows/workflow-tag-issues-with-environment.yml
@@ -51,7 +51,7 @@ jobs:
 
           if [[ -n "$FROM_SHA" && -n "$TO_SHA" ]]; then
             pr_numbers="$(
-              gh api "repos/${REPOSITORY}/compare/${FROM_SHA}...${TO_SHA}" --jq '.commits[].commit.message | split("\n")[0]' | extract_pull_request_numbers
+              gh api --paginate "repos/${REPOSITORY}/compare/${FROM_SHA}...${TO_SHA}" --jq '.commits[].commit.message | split("\n")[0]' | extract_pull_request_numbers
             )"
           elif [[ -n "$VERSION" ]]; then
             pr_numbers="$(

--- a/.github/workflows/workflow-tag-issues-with-environment.yml
+++ b/.github/workflows/workflow-tag-issues-with-environment.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
       version:
-        description: "Release version for release-based pull request discovery"
+        description: "Release version for release-based pull request discovery. Only used when from-sha/to-sha are not both set"
         required: false
         type: string
 
@@ -49,24 +49,17 @@ jobs:
               paste -sd ',' - || true
           }
 
-          if [[ -n "$VERSION" ]]; then
-            if [[ -n "$FROM_SHA" || -n "$TO_SHA" ]]; then
-              echo "::error::Provide either version or from-sha/to-sha, not both."
-              exit 1
-            fi
-
+          if [[ -n "$FROM_SHA" && -n "$TO_SHA" ]]; then
+            pr_numbers="$(
+              gh api "repos/${REPOSITORY}/compare/${FROM_SHA}...${TO_SHA}" --jq '.commits[].commit.message | split("\n")[0]' | extract_pull_request_numbers
+            )"
+          elif [[ -n "$VERSION" ]]; then
             pr_numbers="$(
               gh api "repos/${REPOSITORY}/releases/tags/v${VERSION}" --jq '.body // ""' | extract_pull_request_numbers
             )"
           else
-            if [[ -z "$FROM_SHA" || -z "$TO_SHA" ]]; then
-              echo "::error::Provide both from-sha and to-sha when version is not set."
-              exit 1
-            fi
-
-            pr_numbers="$(
-              gh api "repos/${REPOSITORY}/compare/${FROM_SHA}...${TO_SHA}" --jq '.commits[].commit.message | split("\n")[0]' | extract_pull_request_numbers
-            )"
+            echo "::error::Provide both from-sha and to-sha, or version."
+            exit 1
           fi
 
           echo "pr_numbers=${pr_numbers}" >> "$GITHUB_OUTPUT"
@@ -104,8 +97,8 @@ jobs:
                 /^## / && in_section { exit }
                 in_section { print }
               ' |
-              grep -oE '#[0-9]+' |
-              tr -d '#' |
+              grep -oE "#[0-9]+|github\.com/${REPOSITORY}/issues/[0-9]+" |
+              grep -oE '[0-9]+$' |
               sort -u || true
           }
 


### PR DESCRIPTION
## Description

The environment tagger for prod, tt02 and yt01 read only the release notes of the version being deployed. Those deploys are cumulative, so whenever a version was skipped in an environment, the PRs and issues in that version never received the environment label. Two recent prod examples: 1.118.7 (skipped between 1.118.6 and 1.118.8) and 1.119.1 (run cancelled, then 1.120.0 deployed). None of their PRs carry `prod`.

This ports the fix from Arbeidsflate (Altinn/dialogporten-frontend#4603):

- The shared tagger now prefers the `from-sha`/`to-sha` commit range when both are given, and only falls back to release notes when the range is unavailable (for example when the apps-version variable is empty on a first run).
- prod, tt02 and yt01 pass the range from the last deployed apps version (`apps_version_sha`, already resolved by `get-versions-from-github`) to the new tag.

Related issues are now also recognised when written as a full URL to this repository (`https://github.com/Altinn/dialogporten/issues/1234`), not only as `#1234`. About half of recent PRs use the URL form and those issues never received any environment label.

Side effect worth knowing: the range also picks up PRs whose commit types release-please hides from release notes (docs, refactor, the release PRs themselves). That matches what the at23 path already does.

The store-apps-version job intentionally stays independent of the tagger, unlike at23, because that variable also drives change detection for the deploy itself.

The already-missed PRs in the v1.118.6...v1.120.0 range, plus issues #3239 and #3537 referenced by URL from PRs in that range, have been backfilled with `prod` manually.

## Related Issue(s)

- N/A

## Verification

- [x] **Your** code builds clean without any errors or warnings (workflow YAML validated locally)
- [x] Manual testing done (required): the range query was run by hand against v1.119.0...v1.120.0 and returns the PRs from both 1.119.1 and 1.120.0; the issue extraction was run against PRs #4265 (URL form), #4206 (`#` form) and a cross-repo URL (correctly ignored)
- [ ] Relevant automated test added (not applicable, workflow only)
- [ ] Database changes manually applied to prod/YT01 (not applicable)

## Documentation

- [ ] Documentation is updated (not applicable)
