### PR TITLE
fix: align dialog sub-resource visibility with getDialogById

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/AltinnAuthorizationExtensions.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Externals/AltinnAuthorization/AltinnAuthorizationExtensions.cs
@@ -1,0 +1,34 @@
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+
+namespace Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
+
+public static class AltinnAuthorizationExtensions
+{
+    /// <summary>
+    /// Resolves the dialog details authorization and determines whether the user may access the dialog at all.
+    /// Access is granted if the user has access to the dialog's main resource, or - if the user for some reason
+    /// does not have access to the main resource, which might be because they are granted XACML-actions besides
+    /// "read" not explicitly defined on the dialog - if the user has access to the dialog via the list authorization.
+    /// </summary>
+    /// <remarks>
+    /// The resolved <see cref="DialogDetailsAuthorizationResult"/> is returned so callers can reuse it for
+    /// per-resource decoration (e.g. flagging unauthorized actions or transmissions) without resolving it again.
+    /// Callers should keep that decoration after this check, since it only answers whether the dialog is visible,
+    /// not which sub-resources are authorized.
+    /// </remarks>
+    public static async Task<(bool HasAccess, DialogDetailsAuthorizationResult Authorization)> GetDialogAccess(
+        this IAltinnAuthorization altinnAuthorization,
+        DialogEntity dialog,
+        CancellationToken cancellationToken)
+    {
+        var authorizationResult = await altinnAuthorization.GetDialogDetailsAuthorization(dialog, cancellationToken);
+
+        if (authorizationResult.HasAccessToMainResource())
+        {
+            return (true, authorizationResult);
+        }
+
+        var hasListAuthorization = await altinnAuthorization.HasListAuthorizationForDialog(dialog, cancellationToken);
+        return (hasListAuthorization, authorizationResult);
+    }
+}

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/Get/GetDialogQuery.cs
@@ -193,25 +193,10 @@ internal sealed class GetDialogQueryHandler : IRequestHandler<GetDialogQuery, Ge
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
-        var authorizationResult = await _altinnAuthorization.GetDialogDetailsAuthorization(
-            dialog,
-            cancellationToken: cancellationToken);
-
-        if (!authorizationResult.HasAccessToMainResource())
+        var (hasAccess, authorizationResult) = await _altinnAuthorization.GetDialogAccess(dialog, cancellationToken);
+        if (!hasAccess)
         {
-            // If the user for some reason does not have access to the main resource, which might be
-            // because they are granted access to XACML-actions besides "read" not explicitly defined in the dialog,
-            // we do a recheck if the user has access to the dialog via the list authorization. If this is the case,
-            // we return the dialog and let DecorateWithAuthorization flag the actions as unauthorized. Note that
-            // there might be transmissions that the user has access to, even though there are no authorized actions.
-            var listAuthorizationResult = await _altinnAuthorization.HasListAuthorizationForDialog(
-                dialog,
-                cancellationToken: cancellationToken);
-
-            if (!listAuthorizationResult)
-            {
-                return new Forbidden("Forbidden");
-            }
+            return new Forbidden("Forbidden");
         }
 
         if (dialog.Deleted)

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetActivity/GetActivityQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetActivity/GetActivityQuery.cs
@@ -62,12 +62,8 @@ internal sealed class GetActivityQueryHandler : IRequestHandler<GetActivityQuery
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
-        var authorizationResult = await _altinnAuthorization.GetDialogDetailsAuthorization(
-            dialog,
-            cancellationToken: cancellationToken);
-
-        // If we cannot access the dialog at all, we don't allow access to any of the activity history
-        if (!authorizationResult.HasAccessToMainResource())
+        var (hasAccess, _) = await _altinnAuthorization.GetDialogAccess(dialog, cancellationToken);
+        if (!hasAccess)
         {
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetSeenLog/GetSeenLogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetSeenLog/GetSeenLogQuery.cs
@@ -61,12 +61,8 @@ internal sealed class GetSeenLogQueryHandler : IRequestHandler<GetSeenLogQuery, 
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
-        var authorizationResult = await _altinnAuthorization.GetDialogDetailsAuthorization(
-            dialog,
-            cancellationToken: cancellationToken);
-
-        // If we cannot access the dialog at all, we don't allow access to the seen log
-        if (!authorizationResult.HasAccessToMainResource())
+        var (hasAccess, _) = await _altinnAuthorization.GetDialogAccess(dialog, cancellationToken);
+        if (!hasAccess)
         {
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetTransmission/GetTransmissionQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/GetTransmission/GetTransmissionQuery.cs
@@ -92,12 +92,8 @@ internal sealed class GetTransmissionQueryHandler : IRequestHandler<GetTransmiss
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
-        var authorizationResult = await _altinnAuthorization.GetDialogDetailsAuthorization(
-            dialog,
-            cancellationToken: cancellationToken);
-
-        // If we cannot access the dialog at all, we don't allow access to any of the dialog transmissions.
-        if (!authorizationResult.HasAccessToMainResource())
+        var (hasAccess, authorizationResult) = await _altinnAuthorization.GetDialogAccess(dialog, cancellationToken);
+        if (!hasAccess)
         {
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchActivities/SearchActivityQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchActivities/SearchActivityQuery.cs
@@ -56,12 +56,8 @@ internal sealed class SearchActivityQueryHandler : IRequestHandler<SearchActivit
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
-        var authorizationResult = await _altinnAuthorization.GetDialogDetailsAuthorization(
-            dialog,
-            cancellationToken: cancellationToken);
-
-        // If we cannot access the dialog at all, we don't allow access to any of the activity history
-        if (!authorizationResult.HasAccessToMainResource())
+        var (hasAccess, _) = await _altinnAuthorization.GetDialogAccess(dialog, cancellationToken);
+        if (!hasAccess)
         {
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchSeenLogs/SearchSeenLogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchSeenLogs/SearchSeenLogQuery.cs
@@ -60,12 +60,8 @@ internal sealed class SearchSeenLogQueryHandler : IRequestHandler<SearchSeenLogQ
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
-        var authorizationResult = await _altinnAuthorization.GetDialogDetailsAuthorization(
-            dialog,
-            cancellationToken: cancellationToken);
-
-        // If we cannot access the dialog at all, we don't allow access to the seen log
-        if (!authorizationResult.HasAccessToMainResource())
+        var (hasAccess, _) = await _altinnAuthorization.GetDialogAccess(dialog, cancellationToken);
+        if (!hasAccess)
         {
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchTransmissions/SearchTransmissionQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/Dialogs/Queries/SearchTransmissions/SearchTransmissionQuery.cs
@@ -85,12 +85,8 @@ internal sealed class SearchTransmissionQueryHandler : IRequestHandler<SearchTra
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
-        var authorizationResult = await _altinnAuthorization.GetDialogDetailsAuthorization(
-            dialog,
-            cancellationToken: cancellationToken);
-
-        // If we cannot access the dialog at all, we don't allow access to any of the activity history
-        if (!authorizationResult.HasAccessToMainResource())
+        var (hasAccess, authorizationResult) = await _altinnAuthorization.GetDialogAccess(dialog, cancellationToken);
+        if (!hasAccess)
         {
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }

--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/EndUserContext/Queries/SearchLabelAssignmentLog/SearchLabelAssignmentLogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/EndUserContext/Queries/SearchLabelAssignmentLog/SearchLabelAssignmentLogQuery.cs
@@ -53,8 +53,8 @@ internal sealed class SearchLabelAssignmentLogQueryHandler : IRequestHandler<Sea
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }
 
-        var authorizationResult = await _altinnAuthorization.GetDialogDetailsAuthorization(dialog, cancellationToken: cancellationToken);
-        if (!authorizationResult.HasAccessToMainResource())
+        var (hasAccess, _) = await _altinnAuthorization.GetDialogAccess(dialog, cancellationToken);
+        if (!hasAccess)
         {
             return new EntityNotFound<DialogEntity>(request.DialogId);
         }

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/SystemLabels/Commands/SetSystemLabelTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/SystemLabels/Commands/SetSystemLabelTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
 using Digdir.Domain.Dialogporten.Application.Externals;
+using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
 using Digdir.Domain.Dialogporten.Application.Features.V1.Common;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.Dialogs.Queries.Get;
 using Digdir.Domain.Dialogporten.Application.Features.V1.EndUser.EndUserContext.Commands.SetSystemLabel;
@@ -261,6 +262,49 @@ public class SetSystemLabelTests(DialogApplication application) : ApplicationCol
                     dto.PerformedBy.ActorId == "" &&
                     dto.PerformedBy.ActorType == ActorType.Values.PartyRepresentative);
             });
+
+    [Fact]
+    public Task Search_Returns_Entries_When_No_Main_Resource_Access_But_List_Authorization() =>
+        //When the user lacks main-resource access but is granted access via the list
+        // authorization, the entries should be returned instead of NotFound.
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog()
+            .SetSystemLabelsEndUser(x => x.AddLabels = [SystemLabel.Values.Bin])
+            .ConfigureAltinnAuthorization(altinnAuthorization =>
+            {
+                // No authorized actions => no access to the main resource
+                altinnAuthorization
+                    .GetDialogDetailsAuthorization(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+                    .Returns(new DialogDetailsAuthorizationResult { AuthorizedChecks = [] });
+                // But access is granted via the list authorization
+                altinnAuthorization
+                    .HasListAuthorizationForDialog(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+                    .Returns(true);
+                altinnAuthorization
+                    .UserHasRequiredAuthLevel(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                    .Returns(true);
+            })
+            .GetLabelAssignmentLogs()
+            .ExecuteAndAssert<List<LabelAssignmentLogDto>>(x => x.Should().ContainSingle());
+
+    [Fact]
+    public Task Search_Returns_NotFound_When_No_Main_Resource_Access_And_No_List_Authorization() =>
+        // When the user has neither main-resource access nor list authorization,
+        // the dialog is not visible and the label log must return NotFound.
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog()
+            .SetSystemLabelsEndUser(x => x.AddLabels = [SystemLabel.Values.Bin])
+            .ConfigureAltinnAuthorization(altinnAuthorization =>
+            {
+                altinnAuthorization
+                    .GetDialogDetailsAuthorization(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+                    .Returns(new DialogDetailsAuthorizationResult { AuthorizedChecks = [] });
+                altinnAuthorization
+                    .HasListAuthorizationForDialog(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+                    .Returns(false);
+            })
+            .GetLabelAssignmentLogs()
+            .ExecuteAndAssert<EntityNotFound<DialogEntity>>();
 
     private static GetDialogQuery GetDialog(Guid? id) => new() { DialogId = id!.Value };
 }

--- a/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Externals/AltinnAuthorization/AltinnAuthorizationExtensionsTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Unit.Tests/Externals/AltinnAuthorization/AltinnAuthorizationExtensionsTests.cs
@@ -1,0 +1,79 @@
+using AwesomeAssertions;
+using Digdir.Domain.Dialogporten.Application.Common.Authorization;
+using Digdir.Domain.Dialogporten.Application.Externals.AltinnAuthorization;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using NSubstitute;
+
+namespace Digdir.Domain.Dialogporten.Application.Unit.Tests.Externals.AltinnAuthorization;
+
+public class AltinnAuthorizationExtensionsTests
+{
+    private readonly IAltinnAuthorization _altinnAuthorization = Substitute.For<IAltinnAuthorization>();
+    private readonly DialogEntity _dialog = new();
+
+    [Fact]
+    public async Task GetDialogAccess_Grants_Access_When_Access_To_Main_Resource_Without_Checking_List_Authorization()
+    {
+        // Arrange
+        var authorizationResult = new DialogDetailsAuthorizationResult
+        {
+            AuthorizedChecks =
+            [
+                AuthorizedCheck.FullyPermitted(new AuthorizationCheck(
+                    Constants.ReadAction, AuthorizationResourceSpec.Main, []))
+            ]
+        };
+        _altinnAuthorization
+            .GetDialogDetailsAuthorization(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+            .Returns(authorizationResult);
+
+        // Act
+        var (hasAccess, authorization) = await _altinnAuthorization.GetDialogAccess(_dialog, TestContext.Current.CancellationToken);
+
+        // Assert
+        hasAccess.Should().BeTrue();
+        authorization.Should().BeSameAs(authorizationResult);
+        await _altinnAuthorization.DidNotReceiveWithAnyArgs()
+            .HasListAuthorizationForDialog(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetDialogAccess_Falls_Back_To_List_Authorization_When_No_Access_To_Main_Resource()
+    {
+        // Arrange
+        var authorizationResult = new DialogDetailsAuthorizationResult { AuthorizedChecks = [] };
+        _altinnAuthorization
+            .GetDialogDetailsAuthorization(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+            .Returns(authorizationResult);
+        _altinnAuthorization
+            .HasListAuthorizationForDialog(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        var (hasAccess, authorization) = await _altinnAuthorization.GetDialogAccess(_dialog, TestContext.Current.CancellationToken);
+
+        // Assert
+        hasAccess.Should().BeTrue();
+        authorization.Should().BeSameAs(authorizationResult);
+    }
+
+    [Fact]
+    public async Task GetDialogAccess_Denies_Access_When_No_Access_To_Main_Resource_And_No_List_Authorization()
+    {
+        // Arrange
+        var authorizationResult = new DialogDetailsAuthorizationResult { AuthorizedChecks = [] };
+        _altinnAuthorization
+            .GetDialogDetailsAuthorization(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+            .Returns(authorizationResult);
+        _altinnAuthorization
+            .HasListAuthorizationForDialog(Arg.Any<DialogEntity>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        // Act
+        var (hasAccess, authorization) = await _altinnAuthorization.GetDialogAccess(_dialog, TestContext.Current.CancellationToken);
+
+        // Assert
+        hasAccess.Should().BeFalse();
+        authorization.Should().BeSameAs(authorizationResult);
+    }
+}


### PR DESCRIPTION
## Description
The EndUser dialog sub-resource queries returned NotFound whenever the PDP denied access to the main resource, even when the user could still see the dialog via list authorization. This diverged from getDialogById, which already falls back to the list authorization, so the same dialog and token could be visible in Arbeidsflate while labelAssignmentLog, seenlog, activities and transmissions returned NotFound.

Extract the main-resource/list-authorization check that previously lived inline in GetDialogQuery into a reusable IAltinnAuthorization.GetDialogAccess extension that resolves the authorization once and returns both the access decision and the DialogDetailsAuthorizationResult, so callers that decorate sub-resources reuse it without an extra PDP call.

Use it in all seven EndUser sub-resource handlers (SearchLabelAssignmentLog, Search/GetSeenLog, Search/GetActivity, Search/GetTransmission), which keep returning NotFound only when the dialog is truly not visible, and refactor GetDialogQuery to use the same helper.


## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/4360

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added 
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
