### PR TITLE
fix: changed GetLabelAssignmentLogs to return Gone for deleted dialogs

### DIFF
--- a/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/EndUserContext/Queries/SearchLabelAssignmentLog/SearchLabelAssignmentLogQuery.cs
+++ b/src/Digdir.Domain.Dialogporten.Application/Features/V1/EndUser/EndUserContext/Queries/SearchLabelAssignmentLog/SearchLabelAssignmentLogQuery.cs
@@ -44,6 +44,7 @@ internal sealed class SearchLabelAssignmentLogQueryHandler : IRequestHandler<Sea
                         .ThenInclude(x => x.ActorNameEntity)
                     .Include(x => x.ServiceOwnerContext)
                         .ThenInclude(x => x.ServiceOwnerLabels)
+                    .IgnoreQueryFilters()
                     .FirstOrDefaultAsync(x => x.Id == request.DialogId,
                         cancellationToken: ct),
             cancellationToken);

--- a/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/EndUserContext/Queries/SearchLabelAssignmentLog/DeletedDialogTests.cs
+++ b/tests/Digdir.Domain.Dialogporten.Application.Integration.Tests/Features/V1/EndUser/EndUserContext/Queries/SearchLabelAssignmentLog/DeletedDialogTests.cs
@@ -1,0 +1,20 @@
+using Digdir.Domain.Dialogporten.Application.Common.ReturnTypes;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common;
+using Digdir.Domain.Dialogporten.Application.Integration.Tests.Common.ApplicationFlow;
+using Digdir.Domain.Dialogporten.Domain.Dialogs.Entities;
+using AwesomeAssertions;
+
+namespace Digdir.Domain.Dialogporten.Application.Integration.Tests.Features.V1.EndUser.EndUserContext.Queries.SearchLabelAssignmentLog;
+
+[Collection(nameof(DialogCqrsCollectionFixture))]
+public class DeletedDialogTests(DialogApplication application) : ApplicationCollectionFixture(application)
+{
+    [Fact]
+    public Task Fetching_Label_Assignment_Log_For_Deleted_Dialog_Should_Return_Gone() =>
+        FlowBuilder.For(Application)
+            .CreateSimpleDialog()
+            .DeleteDialog()
+            .GetLabelAssignmentLogs()
+            .ExecuteAndAssert<EntityDeleted<DialogEntity>>(entityDeleted =>
+                entityDeleted.Message.Should().Contain("is removed"));
+}


### PR DESCRIPTION
## Description

`SearchLabelAssignmentLogQueryHandler` was missing `.IgnoreQueryFilters()` on its
dialog query. The soft-delete query filter removed soft-deleted dialogs from the
result before the handler's `dialog.Deleted` check ran, making the `EntityDeleted`
branch unreachable. As a result, requesting the label assignment log for a
soft-deleted dialog returned `404 Not Found` instead of the intended `410 Gone`.

This change adds `.IgnoreQueryFilters()` so the deletion check is reachable,
bringing this endpoint in line with the sibling sub-resource queries (seen logs,
activities, transmissions) that already handle this correctly.

Also adds an integration test (`DeletedDialogTests`) that creates a dialog,
soft-deletes it, and asserts that fetching the label assignment log returns
`EntityDeleted` (410 Gone).

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/4361

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added
- [ ] Database changes manually applied to prod/YT01 (if relevant)

## Documentation

- [ ] Documentation is updated (either in `docs`-directory, Altinnpedia or a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs), if applicable)
