### PR TITLE
fix(ci): use a Dialogporten-owned digdir resource as the second org in staging k6 tests

### DIFF
--- a/.github/workflows/dispatch-k6-tests.yml
+++ b/.github/workflows/dispatch-k6-tests.yml
@@ -34,3 +34,6 @@ jobs:
       environment: ${{ inputs.environment }}
       apiVersion: ${{ inputs.apiVersion }}
       testSuitePath: ${{ inputs.testSuitePath }}
+    permissions:
+      checks: write
+      pull-requests: write

--- a/tests/k6/common/config.js
+++ b/tests/k6/common/config.js
@@ -64,8 +64,10 @@ export const otherOrg = (() => {
             };
         case 'staging':
         case 'prod':
-            // Owned by digdir (same org number as ttd), so the test tokens can create dialogs
-            // on it while Dialogporten still records a different org than the default ttd resource.
+            // Owned by digdir, which shares org number 991825827 with ttd. The test tokens can therefore
+            // create dialogs on it, while Dialogporten records a different org code than for the default
+            // ttd resource. Registered in TT02 only: the functional suite never runs against prod, and
+            // the default ttd resource is not registered there either.
             return {
                 orgNo: '991825827',
                 name: 'digdir',

--- a/tests/k6/common/config.js
+++ b/tests/k6/common/config.js
@@ -64,10 +64,12 @@ export const otherOrg = (() => {
             };
         case 'staging':
         case 'prod':
+            // Owned by digdir (same org number as ttd), so the test tokens can create dialogs
+            // on it while Dialogporten still records a different org than the default ttd resource.
             return {
-                orgNo: '889640782',
-                name: 'nav',
-                serviceResource: 'app_nav_barnehagelister'
+                orgNo: '991825827',
+                name: 'digdir',
+                serviceResource: 'digdir-dialogporten-automated-tests'
             };
         default:
             throw new Error(`Invalid API environment: ${__ENV.API_ENVIRONMENT}. Please ensure it's set correctly in your environment variables.`);

--- a/tests/k6/tests/serviceowner/dialogCreateIdempotentKey.js
+++ b/tests/k6/tests/serviceowner/dialogCreateIdempotentKey.js
@@ -25,34 +25,41 @@ export default function () {
         });
     })
 
-    describe('Attempt to create dialog with same idempotentKey different Org', () => {
+    describe('Attempt to create dialog with same idempotentKey for a different org code', () => {
+        // idempotentKey uniqueness is scoped by the org code of the resource owner, so the same key
+        // must be accepted once per org code. otherServiceResource is owned by a different org code
+        // than the default resource.
+        const idempotentKey = uuidv7();
+
         let dialog = dialogToInsert();
-        dialog.idempotentKey = uuidv7();
-        dialog.serviceResource = "urn:altinn:resource:" +otherServiceResource;
+        dialog.idempotentKey = idempotentKey;
+        dialog.serviceResource = "urn:altinn:resource:" + otherServiceResource;
         dialog.activities[2].performedBy.actorId = "urn:altinn:organization:identifier-no:" + otherOrgNo;
 
-        let responseNav = postSO('dialogs', dialog, null, otherOrg);
-        expectStatusFor(responseNav).to.equal(201);
+        let responseOtherOrg = postSO('dialogs', dialog, null, otherOrg);
+        expectStatusFor(responseOtherOrg).to.equal(201);
 
-        expect(responseNav, 'response').to.have.validJsonBody();
-        expect(responseNav.json(), 'response json').to.match(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
+        expect(responseOtherOrg, 'response').to.have.validJsonBody();
+        expect(responseOtherOrg.json(), 'response json').to.match(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
 
+        const otherOrgDialogId = responseOtherOrg.json();
         dialogs.push({
-            id: responseNav.json(),
+            id: otherOrgDialogId,
             org: otherOrg
         })
 
         dialog = dialogToInsert();
-        dialog.idempotentKey = uuidv7();
+        dialog.idempotentKey = idempotentKey;
 
-        let responseDigdir = postSO('dialogs', dialog);
-        expectStatusFor(responseDigdir).to.equal(201);
+        let responseDefaultOrg = postSO('dialogs', dialog);
+        expectStatusFor(responseDefaultOrg).to.equal(201);
 
-        expect(responseDigdir, 'response').to.have.validJsonBody();
-        expect(responseDigdir.json(), 'response json').to.match(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
+        expect(responseDefaultOrg, 'response').to.have.validJsonBody();
+        expect(responseDefaultOrg.json(), 'response json').to.match(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
+        expect(responseDefaultOrg.json(), 'response json').to.not.equal(otherOrgDialogId);
 
         dialogs.push({
-            id: responseDigdir.json(),
+            id: responseDefaultOrg.json(),
             org: null
         });
     })


### PR DESCRIPTION
## Problem

`CI/CD Staging (1.121.0)` failed on one k6 check, "Attempt to create dialog with same idempotentKey different Org" in `tests/k6/tests/serviceowner/dialogCreateIdempotentKey.js`. The test creates a dialog as a second service owner on `urn:altinn:resource:app_nav_barnehagelister`, which no longer exists in the TT02 resource registry. Dialogporten answered 422 as designed. The same check passed on 2026-09-01, so the resource was removed between the 1.120.1 and 1.121.0 staging runs. Run: https://github.com/Altinn/dialogporten/actions/runs/33866811660

The WebAPI and GraphQL E2E jobs depend on the k6 job and were skipped for 1.121.0. Both suites were run locally against TT02 on the tag: WebAPI 424 passed, 2 skipped; GraphQL 12 passed, 1 skipped.

## Why this resource

Dialogporten sets `dialog.Org` from the resource owner's org code, and idempotentKey uniqueness is scoped by that column. Ownership is checked by org number, in Dialogporten and in the resource registry. `ttd` and `digdir` share org number 991825827, so a digdir-owned resource is a different org for the test while the existing test tokens can create dialogs on it. This removes the dependency on a resource another agency can delete.

`digdir-dialogporten-automated-tests` is registered in TT02 as a GenericAccessResource, status Active, `visible: false`, competent authority digdir/991825827, contact `servicedesk@digdir.no`. No policy is attached; the test only needs a service owner create and purge.

## Changes

- `tests/k6/common/config.js`: the staging/prod `otherOrg` entry now points at digdir, org number 991825827 and the new resource. The prod case is kept for the shared switch but is never exercised: the functional suite does not run against prod, and the default ttd test resource is not registered there either.
- `tests/k6/tests/serviceowner/dialogCreateIdempotentKey.js`: the test generated a fresh `idempotentKey` for each create, so it never tested the org-scoped uniqueness it is named for. Both creates now share one key, must return 201, and must produce different dialog ids. The same-org 409 test is unchanged.
- `.github/workflows/dispatch-k6-tests.yml`: the calling job now grants `checks: write` and `pull-requests: write`, which the reusable k6 workflow declares. Every manual dispatch had failed at startup since #2647 for lack of them; the other callers already grant them.

## Verification

Manual dispatch of `tests/k6/suites/all-single-pass.js` against staging from this branch: 191 of 191 checks passed, the rewritten test returned 201 twice with different dialog ids. https://github.com/Altinn/dialogporten/actions/runs/33880730678

## Not covered here

yt01 still borrows `app_skd_formueinntekt-skattemelding-v2` from Skatteetaten. The team's own test resources carry a placeholder contact address. Related to #4370.
